### PR TITLE
Adapt test fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.9
+  python: python3.12
 
 minimum_pre_commit_version: 3.6.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.12
+  python: python3.9
 
 minimum_pre_commit_version: 3.6.0
 

--- a/services/ifrs/tests_ifrs/conftest.py
+++ b/services/ifrs/tests_ifrs/conftest.py
@@ -12,26 +12,47 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Set up session-scope fixtures for tests."""
 
-"""Contains module-scoped fixtures"""
-
+import pytest_asyncio
 from hexkit.providers.akafka.testutils import (
-    get_clean_kafka_fixture,
     kafka_container_fixture,  # noqa: F401
+    kafka_fixture,  # noqa: F401
 )
 from hexkit.providers.mongodb.testutils import (
-    get_clean_mongodb_fixture,
     mongodb_container_fixture,  # noqa: F401
+    mongodb_fixture,  # noqa: F401
 )
 from hexkit.providers.s3.testutils import (  # noqa: F401
-    get_clean_s3_fixture,
+    S3Fixture,
     s3_container_fixture,
+    s3_fixture,
 )
 
-from tests_ifrs.fixtures.joint import JointFixture, get_joint_fixture  # noqa: F401
+from tests_ifrs.fixtures.joint import (  # noqa: F401
+    OUTBOX_BUCKET,
+    PERMANENT_BUCKET,
+    STAGING_BUCKET,
+    JointFixture,
+    joint_fixture,
+)
 
-mongodb = get_clean_mongodb_fixture("session")
-kafka = get_clean_kafka_fixture("session")
-s3 = get_clean_s3_fixture("session")
-second_s3 = get_clean_s3_fixture("session", name="second_s3")
-joint_fixture = get_joint_fixture("session")
+
+async def _populate_s3_buckets(s3: S3Fixture):
+    await s3.populate_buckets(
+        buckets=[
+            OUTBOX_BUCKET,
+            STAGING_BUCKET,
+            PERMANENT_BUCKET,
+        ]
+    )
+
+
+def get_populate_s3_buckets_fixture(name: str = "populate_s3_buckets"):
+    """Populate the S3 instance buckets"""
+    return pytest_asyncio.fixture(
+        _populate_s3_buckets, scope="function", name=name, autouse=True
+    )
+
+
+populate_s3_buckets = get_populate_s3_buckets_fixture()

--- a/services/ifrs/tests_ifrs/fixtures/joint.py
+++ b/services/ifrs/tests_ifrs/fixtures/joint.py
@@ -17,10 +17,11 @@
 
 __all__ = [
     "JointFixture",
-    "get_joint_fixture",
+    "OUTBOX_BUCKET",
+    "PERMANENT_BUCKET",
+    "STAGING_BUCKET",
 ]
 
-import socket
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 
@@ -38,7 +39,6 @@ from ifrs.config import Config
 from ifrs.inject import prepare_core
 from ifrs.ports.inbound.file_registry import FileRegistryPort
 from ifrs.ports.outbound.dao import FileMetadataDaoPort
-from pytest_asyncio.plugin import _ScopeName
 
 from tests_ifrs.fixtures.config import get_config
 
@@ -56,13 +56,6 @@ class EndpointAliases:
     fake: str = f"{STORAGE_ALIASES[0]}_fake"
 
 
-def get_free_port() -> int:
-    """Finds and returns a free port on localhost."""
-    sock = socket.socket()
-    sock.bind(("", 0))
-    return int(sock.getsockname()[1])
-
-
 @dataclass
 class JointFixture:
     """Returned by the `joint_fixture`."""
@@ -70,7 +63,6 @@ class JointFixture:
     config: Config
     mongodb: MongoDbFixture
     s3: S3Fixture
-    second_s3: S3Fixture
     file_metadata_dao: FileMetadataDaoPort
     file_registry: FileRegistryPort
     kafka: KafkaFixture
@@ -78,18 +70,11 @@ class JointFixture:
     staging_bucket: str
     endpoint_aliases: EndpointAliases
 
-    async def reset_state(self):
-        """Completely reset fixture states"""
-        await self.s3.empty_buckets()
-        await self.second_s3.empty_buckets()
-        self.mongodb.empty_collections()
-        await self.kafka.clear_topics()
 
-
-async def joint_fixture_function(
+@pytest_asyncio.fixture(scope="function")
+async def joint_fixture(
     mongodb: MongoDbFixture,
     s3: S3Fixture,
-    second_s3: S3Fixture,
     kafka: KafkaFixture,
 ) -> AsyncGenerator[JointFixture, None]:
     """A fixture that embeds all other fixtures for API-level integration testing"""
@@ -98,16 +83,12 @@ async def joint_fixture_function(
     node_config = S3ObjectStorageNodeConfig(
         bucket=PERMANENT_BUCKET, credentials=s3.config
     )
-    second_node_config = S3ObjectStorageNodeConfig(
-        bucket=PERMANENT_BUCKET, credentials=second_s3.config
-    )
 
     endpoint_aliases = EndpointAliases()
 
     object_storage_config = S3ObjectStoragesConfig(
         object_storages={
             endpoint_aliases.node1: node_config,
-            endpoint_aliases.node2: second_node_config,
         }
     )
     config = get_config(sources=[mongodb.config, object_storage_config, kafka.config])
@@ -116,30 +97,12 @@ async def joint_fixture_function(
         dao_factory=dao_factory
     )
 
-    # create a DI container instance:translators
+    # Prepare the file registry (core)
     async with prepare_core(config=config) as file_registry:
-        # create storage entities:
-
-        await s3.populate_buckets(
-            buckets=[
-                OUTBOX_BUCKET,
-                STAGING_BUCKET,
-                PERMANENT_BUCKET,
-            ]
-        )
-        await second_s3.populate_buckets(
-            buckets=[
-                OUTBOX_BUCKET,
-                STAGING_BUCKET,
-                PERMANENT_BUCKET,
-            ]
-        )
-
         yield JointFixture(
             config=config,
             mongodb=mongodb,
             s3=s3,
-            second_s3=second_s3,
             file_metadata_dao=file_metadata_dao,
             file_registry=file_registry,
             kafka=kafka,
@@ -147,8 +110,3 @@ async def joint_fixture_function(
             staging_bucket=STAGING_BUCKET,
             endpoint_aliases=endpoint_aliases,
         )
-
-
-def get_joint_fixture(scope: _ScopeName = "function"):
-    """Produce a joint fixture with desired scope"""
-    return pytest_asyncio.fixture(joint_fixture_function, scope=scope)

--- a/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
@@ -18,26 +18,21 @@
 import logging
 
 import pytest
-from hexkit.providers.s3.testutils import FileObject, file_fixture  # noqa: F401
+from hexkit.providers.s3.testutils import (  # noqa: F401,
+    FileObject,
+    S3Fixture,
+    file_fixture,
+)
 from ifrs.ports.inbound.file_registry import FileRegistryPort
 
 from tests_ifrs.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
-from tests_ifrs.fixtures.session_scope_fixtures import (  # noqa: F401
-    JointFixture,
-    joint_fixture,
-    kafka,
-    kafka_container_fixture,
-    mongodb,
-    mongodb_container_fixture,
-    s3,
-    s3_container_fixture,
-    second_s3,
-)
+from tests_ifrs.fixtures.joint import JointFixture
+
+pytestmark = pytest.mark.asyncio()
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_register_with_empty_staging(joint_fixture: JointFixture):  # noqa: F811
-    """Test registration of a file when the file content is missing from the staging."""
+async def test_register_with_empty_staging(joint_fixture: JointFixture):
+    """Test registration of a file when the file content is missing from staging."""
     with pytest.raises(FileRegistryPort.FileContentNotInStagingError):
         await joint_fixture.file_registry.register_file(
             file_without_object_id=EXAMPLE_METADATA_BASE,
@@ -46,127 +41,114 @@ async def test_register_with_empty_staging(joint_fixture: JointFixture):  # noqa
         )
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_reregistration(
-    joint_fixture: JointFixture,  # noqa: F811
-    tmp_file: FileObject,
-):
+async def test_reregistration(joint_fixture: JointFixture, tmp_file: FileObject):
     """Test the re-registration of a file with identical metadata (should not result in
     an exception). Test PR/Push workflow message
     """
-    for storage, storage_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+
+    # place example content in the staging bucket:
+    file_object = tmp_file.model_copy(
+        update={
+            "bucket_id": joint_fixture.staging_bucket,
+            "object_id": EXAMPLE_METADATA.object_id,
+        }
+    )
+    await storage.populate_file_objects(file_objects=[file_object])
+
+    # register new file from the staging bucket:
+    # (And check if an event informing about the new registration has been published.)
+    file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
+        update={"storage_alias": storage_alias}
+    )
+
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.file_registered_event_topic
+    ) as recorder:
+        await joint_fixture.file_registry.register_file(
+            file_without_object_id=file_metadata_base,
+            staging_object_id=EXAMPLE_METADATA.object_id,
+            staging_bucket_id=joint_fixture.staging_bucket,
+        )
+
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
+
+    # re-register the same file from the staging bucket:
+    # (A second event is not expected.)
+    async with joint_fixture.kafka.expect_events(
+        events=[],
+        in_topic=joint_fixture.config.file_registered_event_topic,
     ):
-        # place example content in the staging:
-        file_object = tmp_file.model_copy(
-            update={
-                "bucket_id": joint_fixture.staging_bucket,
-                "object_id": EXAMPLE_METADATA.object_id,
-            }
-        )
-        await storage.populate_file_objects(file_objects=[file_object])
-
-        # register new file from the staging:
-        # (And check if an event informing about the new registration has been published.)
-        file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
-            update={"storage_alias": storage_alias}
+        await joint_fixture.file_registry.register_file(
+            file_without_object_id=file_metadata_base,
+            staging_object_id=EXAMPLE_METADATA.object_id,
+            staging_bucket_id=joint_fixture.staging_bucket,
         )
 
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.file_registered_event_topic
-        ) as recorder:
-            await joint_fixture.file_registry.register_file(
-                file_without_object_id=file_metadata_base,
-                staging_object_id=EXAMPLE_METADATA.object_id,
-                staging_bucket_id=joint_fixture.staging_bucket,
-            )
 
-        assert len(recorder.recorded_events) == 1
-        event = recorder.recorded_events[0]
-        assert event.payload["object_id"] != ""
-        assert event.type_ == joint_fixture.config.file_registered_event_type
-
-        # re-register the same file from the staging:
-        # (A second event is not expected.)
-        async with joint_fixture.kafka.expect_events(
-            events=[],
-            in_topic=joint_fixture.config.file_registered_event_topic,
-        ):
-            await joint_fixture.file_registry.register_file(
-                file_without_object_id=file_metadata_base,
-                staging_object_id=EXAMPLE_METADATA.object_id,
-                staging_bucket_id=joint_fixture.staging_bucket,
-            )
-
-        await joint_fixture.reset_state()
-
-
-@pytest.mark.asyncio(scope="session")
 async def test_reregistration_with_updated_metadata(
     caplog,
-    joint_fixture: JointFixture,  # noqa: F811
+    joint_fixture: JointFixture,
     tmp_file: FileObject,
 ):
     """Check that a re-registration of a file with updated metadata fails with the
     expected exception.
     """
-    for storage, storage_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
-    ):
-        # place example content in the staging:
-        file_object = tmp_file.model_copy(
-            update={
-                "bucket_id": joint_fixture.staging_bucket,
-                "object_id": EXAMPLE_METADATA.object_id,
-            }
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+    # place example content in the staging bucket:
+    file_object = tmp_file.model_copy(
+        update={
+            "bucket_id": joint_fixture.staging_bucket,
+            "object_id": EXAMPLE_METADATA.object_id,
+        }
+    )
+    await storage.populate_file_objects(file_objects=[file_object])
+
+    # register new file from the staging bucket:
+    # (And check if an event informing about the new registration has been published.)
+    file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
+        update={"storage_alias": storage_alias}
+    )
+
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.file_registered_event_topic,
+    ) as recorder:
+        await joint_fixture.file_registry.register_file(
+            file_without_object_id=file_metadata_base,
+            staging_object_id=EXAMPLE_METADATA.object_id,
+            staging_bucket_id=joint_fixture.staging_bucket,
         )
-        await storage.populate_file_objects(file_objects=[file_object])
 
-        # register new file from the staging:
-        # (And check if an event informing about the new registration has been published.)
-        file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
-            update={"storage_alias": storage_alias}
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
+
+    # try to re-register the same file with updated metadata:
+    # Check for correct logging
+    file_update = file_metadata_base.model_copy(update={"decrypted_size": 4321})
+
+    caplog.clear()
+
+    with caplog.at_level(level=logging.ERROR, logger="ifrs.core.file_registry"):
+        expected_message = str(
+            FileRegistryPort.FileUpdateError(file_id=file_metadata_base.file_id)
         )
-
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.file_registered_event_topic,
-        ) as recorder:
-            await joint_fixture.file_registry.register_file(
-                file_without_object_id=file_metadata_base,
-                staging_object_id=EXAMPLE_METADATA.object_id,
-                staging_bucket_id=joint_fixture.staging_bucket,
-            )
-
-        assert len(recorder.recorded_events) == 1
-        event = recorder.recorded_events[0]
-        assert event.payload["object_id"] != ""
-        assert event.type_ == joint_fixture.config.file_registered_event_type
-
-        # try to re-register the same file with updated metadata:
-        # Check for correct logging
-        file_update = file_metadata_base.model_copy(update={"decrypted_size": 4321})
-
-        caplog.clear()
-
-        with caplog.at_level(level=logging.ERROR, logger="ifrs.core.file_registry"):
-            expected_message = str(
-                FileRegistryPort.FileUpdateError(file_id=file_metadata_base.file_id)
-            )
-            await joint_fixture.file_registry.register_file(
-                file_without_object_id=file_update,
-                staging_object_id=EXAMPLE_METADATA.object_id,
-                staging_bucket_id=joint_fixture.staging_bucket,
-            )
-            assert len(caplog.messages) == 1
-            assert expected_message in caplog.messages
-
-        await joint_fixture.reset_state()
+        await joint_fixture.file_registry.register_file(
+            file_without_object_id=file_update,
+            staging_object_id=EXAMPLE_METADATA.object_id,
+            staging_bucket_id=joint_fixture.staging_bucket,
+        )
+        assert len(caplog.messages) == 1
+        assert expected_message in caplog.messages
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F811
+async def test_stage_non_existing_file(joint_fixture: JointFixture):
     """Check that requesting to stage a non-registered file fails with the expected
     exception.
     """
@@ -179,10 +161,8 @@ async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F8
         )
 
 
-@pytest.mark.asyncio(scope="session")
 async def test_stage_checksum_mismatch(
-    joint_fixture: JointFixture,  # noqa: F811
-    tmp_file: FileObject,
+    joint_fixture: JointFixture, tmp_file: FileObject
 ):
     """Check that requesting to stage a registered file to the outbox by specifying the
     wrong checksum fails with the expected exception.
@@ -190,36 +170,32 @@ async def test_stage_checksum_mismatch(
     # populate the database with a corresponding file metadata entry:
     await joint_fixture.file_metadata_dao.insert(EXAMPLE_METADATA)
 
-    for storage, storage_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
-    ):
-        bucket_id = joint_fixture.config.object_storages[storage_alias].bucket
-        # place the content for an example file in the permanent storage:
-        file_object = tmp_file.model_copy(
-            update={
-                "bucket_id": bucket_id,
-                "object_id": EXAMPLE_METADATA.object_id,
-            }
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+
+    bucket_id = joint_fixture.config.object_storages[storage_alias].bucket
+    # place the content for an example file in the permanent storage:
+    file_object = tmp_file.model_copy(
+        update={
+            "bucket_id": bucket_id,
+            "object_id": EXAMPLE_METADATA.object_id,
+        }
+    )
+    await storage.populate_file_objects(file_objects=[file_object])
+
+    # request a stage for the registered file to the outbox by specifying a wrong checksum:
+    with pytest.raises(FileRegistryPort.ChecksumMismatchError):
+        await joint_fixture.file_registry.stage_registered_file(
+            file_id=EXAMPLE_METADATA_BASE.file_id,
+            decrypted_sha256=(
+                "e6da6d6d05cc057964877aad8a3e9ad712c8abeae279dfa2f89b07eba7ef8abe"
+            ),
+            outbox_object_id=EXAMPLE_METADATA.object_id,
+            outbox_bucket_id=joint_fixture.outbox_bucket,
         )
-        await storage.populate_file_objects(file_objects=[file_object])
-
-        # request a stage for the registered file to the outbox by specifying a wrong checksum:
-        with pytest.raises(FileRegistryPort.ChecksumMismatchError):
-            await joint_fixture.file_registry.stage_registered_file(
-                file_id=EXAMPLE_METADATA_BASE.file_id,
-                decrypted_sha256=(
-                    "e6da6d6d05cc057964877aad8a3e9ad712c8abeae279dfa2f89b07eba7ef8abe"
-                ),
-                outbox_object_id=EXAMPLE_METADATA.object_id,
-                outbox_bucket_id=joint_fixture.outbox_bucket,
-            )
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_storage_db_inconsistency(
-    joint_fixture: JointFixture,  # noqa: F811
-):
+async def test_storage_db_inconsistency(joint_fixture: JointFixture):
     """Check that an inconsistency between the database and the storage, whereby the
     database contains a file metadata registration but the storage is missing the
     corresponding content, results in the expected exception.

--- a/services/ifrs/tests_ifrs/test_ifrs_typical_journey.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_typical_journey.py
@@ -26,134 +26,119 @@ from hexkit.providers.s3.testutils import (
 )
 
 from tests_ifrs.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
-from tests_ifrs.fixtures.session_scope_fixtures import (  # noqa: F401
-    JointFixture,
-    joint_fixture,
-    kafka,
-    kafka_container_fixture,
-    mongodb,
-    mongodb_container_fixture,
-    s3,
-    s3_container_fixture,
-    second_s3,
-)
+from tests_ifrs.fixtures.joint import JointFixture
+
+pytestmark = pytest.mark.asyncio()
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_happy_journey(
-    joint_fixture: JointFixture,  # noqa: F811
-    tmp_file: FileObject,
-):
+async def test_happy_journey(joint_fixture: JointFixture, tmp_file: FileObject):
     """Simulates a typical, successful journey for upload, download, and deletion"""
-    for storage, storage_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+
+    bucket_id = joint_fixture.config.object_storages[storage_alias].bucket
+    # place example content in the staging:
+    file_object = tmp_file.model_copy(
+        update={
+            "bucket_id": joint_fixture.staging_bucket,
+            "object_id": EXAMPLE_METADATA.object_id,
+        }
+    )
+    await storage.populate_file_objects(file_objects=[file_object])
+
+    # register new file from the staging:
+    # (And check if an event informing about the new registration has been published.)
+    file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
+        update={"storage_alias": storage_alias}, deep=True
+    )
+
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.file_registered_event_topic,
+    ) as recorder:
+        await joint_fixture.file_registry.register_file(
+            file_without_object_id=file_metadata_base,
+            staging_object_id=EXAMPLE_METADATA.object_id,
+            staging_bucket_id=joint_fixture.staging_bucket,
+        )
+
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
+
+    object_id = cast(str, event.payload["object_id"])
+
+    # check that the file content is now in both the staging and the permanent storage:
+    assert await storage.storage.does_object_exist(
+        bucket_id=joint_fixture.staging_bucket,
+        object_id=EXAMPLE_METADATA.object_id,
+    )
+    assert await storage.storage.does_object_exist(
+        bucket_id=bucket_id,
+        object_id=object_id,
+    )
+
+    # request a stage to the outbox:
+    async with joint_fixture.kafka.expect_events(
+        events=[
+            ExpectedEvent(
+                payload={
+                    "file_id": file_metadata_base.file_id,
+                    "decrypted_sha256": file_metadata_base.decrypted_sha256,
+                    "target_object_id": EXAMPLE_METADATA.object_id,
+                    "target_bucket_id": joint_fixture.outbox_bucket,
+                    "s3_endpoint_alias": storage_alias,
+                },
+                type_=joint_fixture.config.file_staged_event_type,
+                key=file_metadata_base.file_id,
+            )
+        ],
+        in_topic=joint_fixture.config.file_staged_event_topic,
     ):
-        bucket_id = joint_fixture.config.object_storages[storage_alias].bucket
-        # place example content in the staging:
-        file_object = tmp_file.model_copy(
-            update={
-                "bucket_id": joint_fixture.staging_bucket,
-                "object_id": EXAMPLE_METADATA.object_id,
-            }
-        )
-        await storage.populate_file_objects(file_objects=[file_object])
-
-        # register new file from the staging:
-        # (And check if an event informing about the new registration has been published.)
-        file_metadata_base = EXAMPLE_METADATA_BASE.model_copy(
-            update={"storage_alias": storage_alias}, deep=True
+        await joint_fixture.file_registry.stage_registered_file(
+            file_id=file_metadata_base.file_id,
+            decrypted_sha256=file_metadata_base.decrypted_sha256,
+            outbox_object_id=EXAMPLE_METADATA.object_id,
+            outbox_bucket_id=joint_fixture.outbox_bucket,
         )
 
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.file_registered_event_topic,
-        ) as recorder:
-            await joint_fixture.file_registry.register_file(
-                file_without_object_id=file_metadata_base,
-                staging_object_id=EXAMPLE_METADATA.object_id,
-                staging_bucket_id=joint_fixture.staging_bucket,
+    # check that the file content is now in all three storage entities:
+    assert await storage.storage.does_object_exist(
+        bucket_id=joint_fixture.staging_bucket,
+        object_id=EXAMPLE_METADATA.object_id,
+    )
+    assert await storage.storage.does_object_exist(
+        bucket_id=bucket_id,
+        object_id=object_id,
+    )
+    assert await storage.storage.does_object_exist(
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
+    )
+
+    # check that the file content in the outbox is identical to the content in the
+    # staging:
+    download_url = await storage.storage.get_object_download_url(
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
+    )
+    response = requests.get(download_url, timeout=60)
+    response.raise_for_status()
+    assert response.content == file_object.content
+
+    # Request file deletion:
+    async with joint_fixture.kafka.expect_events(
+        events=[
+            ExpectedEvent(
+                payload={"file_id": file_metadata_base.file_id},
+                type_=joint_fixture.config.file_deleted_event_type,
             )
-
-        assert len(recorder.recorded_events) == 1
-        event = recorder.recorded_events[0]
-        assert event.payload["object_id"] != ""
-        assert event.type_ == joint_fixture.config.file_registered_event_type
-
-        object_id = cast(str, event.payload["object_id"])
-
-        # check that the file content is now in both the staging and the permanent storage:
-        assert await storage.storage.does_object_exist(
-            bucket_id=joint_fixture.staging_bucket,
-            object_id=EXAMPLE_METADATA.object_id,
-        )
-        assert await storage.storage.does_object_exist(
-            bucket_id=bucket_id,
-            object_id=object_id,
+        ],
+        in_topic=joint_fixture.config.file_deleted_event_topic,
+    ):
+        await joint_fixture.file_registry.delete_file(
+            file_id=file_metadata_base.file_id,
         )
 
-        # request a stage to the outbox:
-        async with joint_fixture.kafka.expect_events(
-            events=[
-                ExpectedEvent(
-                    payload={
-                        "file_id": file_metadata_base.file_id,
-                        "decrypted_sha256": file_metadata_base.decrypted_sha256,
-                        "target_object_id": EXAMPLE_METADATA.object_id,
-                        "target_bucket_id": joint_fixture.outbox_bucket,
-                        "s3_endpoint_alias": storage_alias,
-                    },
-                    type_=joint_fixture.config.file_staged_event_type,
-                    key=file_metadata_base.file_id,
-                )
-            ],
-            in_topic=joint_fixture.config.file_staged_event_topic,
-        ):
-            await joint_fixture.file_registry.stage_registered_file(
-                file_id=file_metadata_base.file_id,
-                decrypted_sha256=file_metadata_base.decrypted_sha256,
-                outbox_object_id=EXAMPLE_METADATA.object_id,
-                outbox_bucket_id=joint_fixture.outbox_bucket,
-            )
-
-        # check that the file content is now in all three storage entities:
-        assert await storage.storage.does_object_exist(
-            bucket_id=joint_fixture.staging_bucket,
-            object_id=EXAMPLE_METADATA.object_id,
-        )
-        assert await storage.storage.does_object_exist(
-            bucket_id=bucket_id,
-            object_id=object_id,
-        )
-        assert await storage.storage.does_object_exist(
-            bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
-        )
-
-        # check that the file content in the outbox is identical to the content in the
-        # staging:
-        download_url = await storage.storage.get_object_download_url(
-            bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
-        )
-        response = requests.get(download_url, timeout=60)
-        response.raise_for_status()
-        assert response.content == file_object.content
-
-        # Request file deletion:
-        async with joint_fixture.kafka.expect_events(
-            events=[
-                ExpectedEvent(
-                    payload={"file_id": file_metadata_base.file_id},
-                    type_=joint_fixture.config.file_deleted_event_type,
-                )
-            ],
-            in_topic=joint_fixture.config.file_deleted_event_topic,
-        ):
-            await joint_fixture.file_registry.delete_file(
-                file_id=file_metadata_base.file_id,
-            )
-
-        assert not await storage.storage.does_object_exist(
-            bucket_id=bucket_id,
-            object_id=object_id,
-        )
-
-        await joint_fixture.reset_state()
+    assert not await storage.storage.does_object_exist(
+        bucket_id=bucket_id,
+        object_id=object_id,
+    )

--- a/services/irs/tests_irs/conftest.py
+++ b/services/irs/tests_irs/conftest.py
@@ -1,0 +1,58 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Set up session-scope fixtures for tests."""
+
+import pytest
+import pytest_asyncio
+from hexkit.providers.akafka.testutils import (  # noqa: F401
+    kafka_container_fixture,
+    kafka_fixture,
+)
+from hexkit.providers.mongodb.testutils import (  # noqa: F401
+    mongodb_container_fixture,
+    mongodb_fixture,
+)
+from hexkit.providers.s3.testutils import (  # noqa: F401
+    S3Fixture,
+    s3_container_fixture,
+    s3_fixture,
+)
+
+from tests_irs.fixtures.joint import (  # noqa: F401
+    INBOX_BUCKET_ID,
+    STAGING_BUCKET_ID,
+    JointFixture,
+    joint_fixture,
+)
+
+
+async def _populate_s3_buckets(s3: S3Fixture):
+    await s3.populate_buckets([INBOX_BUCKET_ID, STAGING_BUCKET_ID])
+
+
+def get_populate_s3_buckets_fixture(name: str = "populate_s3_buckets"):
+    """Populate the S3 instance buckets"""
+    return pytest_asyncio.fixture(
+        _populate_s3_buckets, scope="function", name=name, autouse=True
+    )
+
+
+populate_s3_buckets = get_populate_s3_buckets_fixture()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def regenerate_keypair(joint_fixture: JointFixture):  # noqa: F811
+    """Regenerate the keypair for each test."""
+    joint_fixture.keypair.regenerate()

--- a/services/irs/tests_irs/fixtures/joint.py
+++ b/services/irs/tests_irs/fixtures/joint.py
@@ -16,32 +16,18 @@
 
 """Provides multiple fixtures in one spot"""
 
-import asyncio
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 
-import pytest
 import pytest_asyncio
 from ghga_service_commons.utils.multinode_storage import (
     S3ObjectStorageNodeConfig,
     S3ObjectStoragesConfig,
 )
 from hexkit.providers.akafka import KafkaEventSubscriber
-from hexkit.providers.akafka.testutils import (
-    KafkaFixture,
-    get_clean_kafka_fixture,
-    kafka_container_fixture,  # noqa: F401
-)
-from hexkit.providers.mongodb.testutils import (
-    MongoDbFixture,
-    get_clean_mongodb_fixture,
-    mongodb_container_fixture,  # noqa: F401
-)
-from hexkit.providers.s3.testutils import (
-    S3Fixture,
-    get_clean_s3_fixture,
-    s3_container_fixture,  # noqa: F401
-)
+from hexkit.providers.akafka.testutils import KafkaFixture
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+from hexkit.providers.s3.testutils import S3Fixture
 from irs.config import Config
 from irs.inject import prepare_core, prepare_event_subscriber
 from irs.ports.inbound.interrogator import InterrogatorPort
@@ -55,12 +41,6 @@ from tests_irs.fixtures.keypair_fixtures import (
 FILE_SIZE = 50 * 1024**2
 INBOX_BUCKET_ID = "test-inbox"
 STAGING_BUCKET_ID = "test-staging"
-
-
-kafka_fixture = get_clean_kafka_fixture(scope="session")
-mongodb_fixture = get_clean_mongodb_fixture(scope="session")
-s3_fixture = get_clean_s3_fixture(scope="session")
-second_s3_fixture = get_clean_s3_fixture(scope="session", name="second_s3")
 
 
 @dataclass
@@ -82,32 +62,19 @@ class JointFixture:
     keypair: KeypairFixture
     mongodb: MongoDbFixture
     s3: S3Fixture
-    second_s3: S3Fixture
     endpoint_aliases: EndpointAliases
 
-    async def reset_state(self):
-        """Completely reset fixture states"""
-        await self.s3.empty_buckets()
-        await self.second_s3.empty_buckets()
-        self.mongodb.empty_collections()
-        await self.kafka.clear_topics()
-        self.keypair.regenerate()
 
-
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture(scope="function")
 async def joint_fixture(
     keypair_fixture: KeypairFixture,  # noqa: F811
     kafka: KafkaFixture,
     mongodb: MongoDbFixture,
     s3: S3Fixture,
-    second_s3: S3Fixture,
 ) -> AsyncGenerator[JointFixture, None]:
     """A fixture that embeds all other fixtures for integration testing"""
     node_config = S3ObjectStorageNodeConfig(
         bucket=STAGING_BUCKET_ID, credentials=s3.config
-    )
-    second_node_config = S3ObjectStorageNodeConfig(
-        bucket=STAGING_BUCKET_ID, credentials=second_s3.config
     )
 
     endpoint_aliases = EndpointAliases()
@@ -115,15 +82,11 @@ async def joint_fixture(
     object_storage_config = S3ObjectStoragesConfig(
         object_storages={
             endpoint_aliases.node1: node_config,
-            endpoint_aliases.node2: second_node_config,
         }
     )
     config = get_config(sources=[kafka.config, mongodb.config, object_storage_config])
 
-    await s3.populate_buckets([INBOX_BUCKET_ID, STAGING_BUCKET_ID])
-    await second_s3.populate_buckets([INBOX_BUCKET_ID, STAGING_BUCKET_ID])
-
-    # Create joint_fixure using the injection
+    # Create joint_fixture using the inject module
     async with (
         prepare_core(config=config) as interrogator,
         prepare_event_subscriber(
@@ -138,16 +101,5 @@ async def joint_fixture(
             keypair=keypair_fixture,
             mongodb=mongodb,
             s3=s3,
-            second_s3=second_s3,
             endpoint_aliases=endpoint_aliases,
         )
-
-
-@pytest.fixture(autouse=True, scope="function")
-def reset_state(joint_fixture: JointFixture):
-    """Clear joint_fixture state before tests that use this fixture.
-
-    This is a function-level fixture because it needs to run in each test.
-    """
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(joint_fixture.reset_state())

--- a/services/irs/tests_irs/test_cli.py
+++ b/services/irs/tests_irs/test_cli.py
@@ -26,18 +26,14 @@ from irs.inject import prepare_storage_inspector
 from tests_irs.fixtures.joint import (
     STAGING_BUCKET_ID,
     JointFixture,
-    joint_fixture,  # noqa: F401
-    kafka_fixture,  # noqa: F401
     keypair_fixture,  # noqa: F401
-    mongodb_fixture,  # noqa: F401
-    s3_fixture,  # noqa: F401
-    second_s3_fixture,  # noqa: F401
 )
 from tests_irs.fixtures.test_files import create_test_file
 
+pytestmark = pytest.mark.asyncio()
 
-@pytest.mark.asyncio(scope="session")
-async def test_staging_inspector(caplog, joint_fixture: JointFixture):  # noqa: F811
+
+async def test_staging_inspector(caplog, joint_fixture: JointFixture):
     """Check storage inspector functionality."""
     # prepare storage entries
     file_1 = await create_test_file(
@@ -50,7 +46,7 @@ async def test_staging_inspector(caplog, joint_fixture: JointFixture):  # noqa: 
         bucket_id=STAGING_BUCKET_ID,
         private_key=joint_fixture.keypair.private,
         public_key=joint_fixture.keypair.public,
-        s3=joint_fixture.second_s3,
+        s3=joint_fixture.s3,
     )
     file_3 = await create_test_file(
         bucket_id=STAGING_BUCKET_ID,
@@ -68,7 +64,7 @@ async def test_staging_inspector(caplog, joint_fixture: JointFixture):  # noqa: 
     staging_object_2 = StagingObject(
         file_id=file_2.file_id,
         object_id=file_2.file_object.object_id,
-        storage_alias=joint_fixture.endpoint_aliases.node2,
+        storage_alias=joint_fixture.endpoint_aliases.node1,
     )
 
     # modify second object to be recognized as stale
@@ -94,7 +90,7 @@ async def test_staging_inspector(caplog, joint_fixture: JointFixture):  # noqa: 
 
     assert len(caplog.messages) == 2
     assert (
-        f"Stale object '{file_2.file_object.object_id}' found for file '{file_2.file_id}' in bucket '{STAGING_BUCKET_ID}' of storage '{joint_fixture.endpoint_aliases.node2}'."
+        f"Stale object '{file_2.file_object.object_id}' found for file '{file_2.file_id}' in bucket '{STAGING_BUCKET_ID}' of storage '{joint_fixture.endpoint_aliases.node1}'."
         in caplog.messages
     )
     assert (

--- a/services/irs/tests_irs/test_event_handling.py
+++ b/services/irs/tests_irs/test_event_handling.py
@@ -37,19 +37,13 @@ from tests_irs.fixtures.joint import (  # noqa: F401
     INBOX_BUCKET_ID,
     STAGING_BUCKET_ID,
     JointFixture,
-    joint_fixture,
-    kafka_container_fixture,
-    kafka_fixture,
     keypair_fixture,
-    mongodb_container_fixture,
-    mongodb_fixture,
-    s3_container_fixture,
-    s3_fixture,
-    second_s3_fixture,
 )
 from tests_irs.fixtures.test_files import EncryptedData, create_test_file
 
 EKSS_NEW_SECRET = os.urandom(32)
+
+pytestmark = pytest.mark.asyncio()
 
 
 def _incoming_event_file_registered(
@@ -101,283 +95,264 @@ def _ekss_call(
     )
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_failure_event(
-    monkeypatch,
-    joint_fixture: JointFixture,  # noqa: F811
-):
+async def test_failure_event(monkeypatch, joint_fixture: JointFixture):
     """Test the whole pipeline from receiving an event to notifying about failure"""
-    for s3, endpoint_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
-    ):
-        data = await create_test_file(
-            bucket_id=INBOX_BUCKET_ID,
-            private_key=joint_fixture.keypair.private,
-            public_key=joint_fixture.keypair.public,
-            s3=s3,
-        )
-        ekss_patch = partial(_ekss_call, data=data)
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+    data = await create_test_file(
+        bucket_id=INBOX_BUCKET_ID,
+        private_key=joint_fixture.keypair.private,
+        public_key=joint_fixture.keypair.public,
+        s3=storage,
+    )
+    ekss_patch = partial(_ekss_call, data=data)
 
-        monkeypatch.setattr(
-            "irs.core.interrogator.call_eks_api",
-            ekss_patch,
-        )
+    monkeypatch.setattr(
+        "irs.core.interrogator.call_eks_api",
+        ekss_patch,
+    )
 
-        payload_in = {
-            "s3_endpoint_alias": endpoint_alias,
-            "file_id": data.file_id,
-            "object_id": data.file_object.object_id,
-            "bucket_id": INBOX_BUCKET_ID,
-            "submitter_public_key": base64.b64encode(
-                joint_fixture.keypair.public
-            ).decode("utf-8"),
-            "upload_date": data.upload_date,
-            "expected_decrypted_sha256": data.checksum,
-            "decrypted_size": data.file_size,
-        }
+    payload_in = {
+        "s3_endpoint_alias": storage_alias,
+        "file_id": data.file_id,
+        "object_id": data.file_object.object_id,
+        "bucket_id": INBOX_BUCKET_ID,
+        "submitter_public_key": base64.b64encode(joint_fixture.keypair.public).decode(
+            "utf-8"
+        ),
+        "upload_date": data.upload_date,
+        "expected_decrypted_sha256": data.checksum,
+        "decrypted_size": data.file_size,
+    }
 
-        # introduce invalid checksum
-        payload_in["expected_decrypted_sha256"] = payload_in[
-            "expected_decrypted_sha256"
-        ][1:]
-        event_in = _incoming_event_upload_received(
-            payload=payload_in, config=joint_fixture.config
-        )
+    # introduce invalid checksum
+    payload_in["expected_decrypted_sha256"] = payload_in["expected_decrypted_sha256"][
+        1:
+    ]
+    event_in = _incoming_event_upload_received(
+        payload=payload_in, config=joint_fixture.config
+    )
 
-        payload_out = {
-            "s3_endpoint_alias": endpoint_alias,
-            "file_id": data.file_id,
-            "bucket_id": STAGING_BUCKET_ID,
-            "reason": "Checksum mismatch",
-            "upload_date": data.upload_date,
-        }
-        expected_event_out = ExpectedEvent(
-            payload=payload_out,
-            type_=joint_fixture.config.interrogation_failure_type,
-            key=data.file_id,
-        )
+    payload_out = {
+        "s3_endpoint_alias": storage_alias,
+        "file_id": data.file_id,
+        "bucket_id": STAGING_BUCKET_ID,
+        "reason": "Checksum mismatch",
+        "upload_date": data.upload_date,
+    }
+    expected_event_out = ExpectedEvent(
+        payload=payload_out,
+        type_=joint_fixture.config.interrogation_failure_type,
+        key=data.file_id,
+    )
 
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.interrogation_topic,
-        ) as event_recorder:
-            await joint_fixture.kafka.publish_event(**event_in)
-            await joint_fixture.event_subscriber.run(forever=False)
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.interrogation_topic,
+    ) as event_recorder:
+        await joint_fixture.kafka.publish_event(**event_in)
+        await joint_fixture.event_subscriber.run(forever=False)
 
-        recorded_events = event_recorder.recorded_events
+    recorded_events = event_recorder.recorded_events
 
-        assert len(recorded_events) == 1
-        assert recorded_events[0].payload["object_id"] != ""
-        expected_event_out.payload["object_id"] = recorded_events[0].payload[
-            "object_id"
-        ]
-        assert recorded_events[0].payload == expected_event_out.payload
+    assert len(recorded_events) == 1
+    assert recorded_events[0].payload["object_id"] != ""
+    expected_event_out.payload["object_id"] = recorded_events[0].payload["object_id"]
+    assert recorded_events[0].payload == expected_event_out.payload
 
-        # check staging object dao state
-        staging_object_dao = await StagingObjectDaoConstructor.construct(
-            dao_factory=joint_fixture.mongodb.dao_factory
-        )
-        with pytest.raises(ResourceNotFoundError):
-            await staging_object_dao.get_by_id(id_=data.file_id)
+    # check staging object dao state
+    staging_object_dao = await StagingObjectDaoConstructor.construct(
+        dao_factory=joint_fixture.mongodb.dao_factory
+    )
+    with pytest.raises(ResourceNotFoundError):
+        await staging_object_dao.get_by_id(id_=data.file_id)
 
-        # check fingerprint is created for unsuccessful processing
-        fingerprint_dao = await FingerprintDaoConstructor.construct(
-            dao_factory=joint_fixture.mongodb.dao_factory
-        )
+    # check fingerprint is created for unsuccessful processing
+    fingerprint_dao = await FingerprintDaoConstructor.construct(
+        dao_factory=joint_fixture.mongodb.dao_factory
+    )
 
-        seen_event = _populate_subject(payload_in)
-        fingerprint = UploadReceivedFingerprint.generate(seen_event)
+    seen_event = _populate_subject(payload_in)
+    fingerprint = UploadReceivedFingerprint.generate(seen_event)
 
-        await fingerprint_dao.get_by_id(fingerprint.checksum)
+    await fingerprint_dao.get_by_id(fingerprint.checksum)
 
 
-@pytest.mark.asyncio(scope="session")
-async def test_success_event(
-    monkeypatch,
-    joint_fixture: JointFixture,  # noqa: F811
-):
+async def test_success_event(monkeypatch, joint_fixture: JointFixture):
     """Test the whole pipeline from receiving an event to notifying about success"""
     secret_id = "secret_id"
     encrypted_parts_md5 = ["abc", "def", "ghi"]
     encrypted_parts_sha256 = ["abc", "def", "ghi"]
 
-    for s3, endpoint_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
-    ):
-        data = await create_test_file(
-            bucket_id=INBOX_BUCKET_ID,
-            private_key=joint_fixture.keypair.private,
-            public_key=joint_fixture.keypair.public,
-            s3=s3,
-        )
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+    data = await create_test_file(
+        bucket_id=INBOX_BUCKET_ID,
+        private_key=joint_fixture.keypair.private,
+        public_key=joint_fixture.keypair.public,
+        s3=storage,
+    )
 
-        ekss_patch = partial(_ekss_call, data=data)
+    ekss_patch = partial(_ekss_call, data=data)
 
-        monkeypatch.setattr(
-            "irs.core.interrogator.call_eks_api",
-            ekss_patch,
-        )
+    monkeypatch.setattr(
+        "irs.core.interrogator.call_eks_api",
+        ekss_patch,
+    )
 
-        payload_in = {
-            "s3_endpoint_alias": endpoint_alias,
-            "file_id": data.file_id,
-            "object_id": data.file_object.object_id,
-            "bucket_id": INBOX_BUCKET_ID,
-            "submitter_public_key": base64.b64encode(
-                joint_fixture.keypair.public
-            ).decode("utf-8"),
-            "upload_date": data.upload_date,
-            "expected_decrypted_sha256": data.checksum,
-            "decrypted_size": data.file_size,
-        }
-        event_in = _incoming_event_upload_received(
-            payload=payload_in, config=joint_fixture.config
-        )
+    payload_in = {
+        "s3_endpoint_alias": storage_alias,
+        "file_id": data.file_id,
+        "object_id": data.file_object.object_id,
+        "bucket_id": INBOX_BUCKET_ID,
+        "submitter_public_key": base64.b64encode(joint_fixture.keypair.public).decode(
+            "utf-8"
+        ),
+        "upload_date": data.upload_date,
+        "expected_decrypted_sha256": data.checksum,
+        "decrypted_size": data.file_size,
+    }
+    event_in = _incoming_event_upload_received(
+        payload=payload_in, config=joint_fixture.config
+    )
 
-        part_size = calc_part_size(file_size=data.file_size)
+    part_size = calc_part_size(file_size=data.file_size)
 
-        payload_out = {
-            "s3_endpoint_alias": endpoint_alias,
-            "file_id": data.file_id,
-            "object_id": data.file_object.object_id,
-            "bucket_id": STAGING_BUCKET_ID,
-            "upload_date": data.upload_date,
-            "decryption_secret_id": secret_id,
-            "content_offset": data.offset,
-            "encrypted_part_size": part_size,
-            "decrypted_sha256": data.checksum,
-        }
-        expected_event_out = ExpectedEvent(
-            payload=payload_out,
-            type_=joint_fixture.config.interrogation_success_type,
-            key=data.file_id,
-        )
+    payload_out = {
+        "s3_endpoint_alias": storage_alias,
+        "file_id": data.file_id,
+        "object_id": data.file_object.object_id,
+        "bucket_id": STAGING_BUCKET_ID,
+        "upload_date": data.upload_date,
+        "decryption_secret_id": secret_id,
+        "content_offset": data.offset,
+        "encrypted_part_size": part_size,
+        "decrypted_sha256": data.checksum,
+    }
+    expected_event_out = ExpectedEvent(
+        payload=payload_out,
+        type_=joint_fixture.config.interrogation_success_type,
+        key=data.file_id,
+    )
 
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.interrogation_topic,
-        ) as event_recorder:
-            await joint_fixture.kafka.publish_event(**event_in)
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.interrogation_topic,
+    ) as event_recorder:
+        await joint_fixture.kafka.publish_event(**event_in)
 
-            await joint_fixture.event_subscriber.run(forever=False)
+        await joint_fixture.event_subscriber.run(forever=False)
 
-        recorded_events = event_recorder.recorded_events
+    recorded_events = event_recorder.recorded_events
 
-        assert len(recorded_events) == 1
-        event = recorded_events[0]
+    assert len(recorded_events) == 1
+    event = recorded_events[0]
 
-        expected_event_out.payload["object_id"] = event.payload["object_id"]
-        for key in payload_out:
-            assert event.payload[key] == expected_event_out.payload[key]
+    expected_event_out.payload["object_id"] = event.payload["object_id"]
+    for key in payload_out:
+        assert event.payload[key] == expected_event_out.payload[key]
 
-        # check staging object dao state and ensure, object actually exists in storage
-        staging_object_dao = await StagingObjectDaoConstructor.construct(
-            dao_factory=joint_fixture.mongodb.dao_factory
-        )
-        staging_object = await staging_object_dao.get_by_id(id_=data.file_id)
+    # check staging object dao state and ensure, object actually exists in storage
+    staging_object_dao = await StagingObjectDaoConstructor.construct(
+        dao_factory=joint_fixture.mongodb.dao_factory
+    )
+    staging_object = await staging_object_dao.get_by_id(id_=data.file_id)
 
-        assert await s3.storage.does_object_exist(
-            bucket_id=STAGING_BUCKET_ID, object_id=staging_object.object_id
-        )
+    assert await storage.storage.does_object_exist(
+        bucket_id=STAGING_BUCKET_ID, object_id=staging_object.object_id
+    )
 
-        # check event fingerprint is stored in DB
-        mongo_dao = await FingerprintDaoConstructor.construct(
-            dao_factory=joint_fixture.mongodb.dao_factory
-        )
+    # check event fingerprint is stored in DB
+    mongo_dao = await FingerprintDaoConstructor.construct(
+        dao_factory=joint_fixture.mongodb.dao_factory
+    )
 
-        seen_event = _populate_subject(payload_in)
-        fingerprint = UploadReceivedFingerprint.generate(seen_event)
+    seen_event = _populate_subject(payload_in)
+    fingerprint = UploadReceivedFingerprint.generate(seen_event)
 
-        await mongo_dao.get_by_id(fingerprint.checksum)
+    await mongo_dao.get_by_id(fingerprint.checksum)
 
-        # check removal on successful registration
-        payload_remove_object = {
-            "file_id": data.file_id,
-            "object_id": data.file_object.object_id,
-            "bucket_id": data.file_object.bucket_id,
-            "s3_endpoint_alias": endpoint_alias,
-            "decrypted_size": data.file_size,
-            "decryption_secret_id": secret_id,
-            "content_offset": data.offset,
-            "encrypted_part_size": part_size,
-            "encrypted_parts_md5": encrypted_parts_md5,
-            "encrypted_parts_sha256": encrypted_parts_sha256,
-            "decrypted_sha256": data.checksum,
-            "upload_date": now_as_utc().isoformat(),
-        }
+    # check removal on successful registration
+    payload_remove_object = {
+        "file_id": data.file_id,
+        "object_id": data.file_object.object_id,
+        "bucket_id": data.file_object.bucket_id,
+        "s3_endpoint_alias": storage_alias,
+        "decrypted_size": data.file_size,
+        "decryption_secret_id": secret_id,
+        "content_offset": data.offset,
+        "encrypted_part_size": part_size,
+        "encrypted_parts_md5": encrypted_parts_md5,
+        "encrypted_parts_sha256": encrypted_parts_sha256,
+        "decrypted_sha256": data.checksum,
+        "upload_date": now_as_utc().isoformat(),
+    }
 
-        remove_event = _incoming_event_file_registered(
-            payload=payload_remove_object, config=joint_fixture.config
-        )
+    remove_event = _incoming_event_file_registered(
+        payload=payload_remove_object, config=joint_fixture.config
+    )
 
-        async with joint_fixture.kafka.record_events(
-            in_topic=joint_fixture.config.file_registered_event_topic,
-        ) as event_recorder:
-            await joint_fixture.kafka.publish_event(**remove_event)
-            await joint_fixture.event_subscriber.run(forever=False)
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.file_registered_event_topic,
+    ) as event_recorder:
+        await joint_fixture.kafka.publish_event(**remove_event)
+        await joint_fixture.event_subscriber.run(forever=False)
 
-        assert len(event_recorder.recorded_events) == 1
+    assert len(event_recorder.recorded_events) == 1
 
-        assert not await s3.storage.does_object_exist(
-            bucket_id=STAGING_BUCKET_ID, object_id=staging_object.object_id
-        )
+    assert not await storage.storage.does_object_exist(
+        bucket_id=STAGING_BUCKET_ID, object_id=staging_object.object_id
+    )
 
 
-@pytest.mark.asyncio(scope="session")
 async def test_fingerprint_already_present(
-    caplog,
-    monkeypatch,
-    joint_fixture: JointFixture,  # noqa: F811
+    caplog, monkeypatch, joint_fixture: JointFixture
 ):
     """Test the whole pipeline from receiving an event to notifying about success"""
-    for s3, endpoint_alias in (
-        (joint_fixture.s3, joint_fixture.endpoint_aliases.node1),
-        (joint_fixture.second_s3, joint_fixture.endpoint_aliases.node2),
-    ):
-        data = await create_test_file(
-            bucket_id=INBOX_BUCKET_ID,
-            private_key=joint_fixture.keypair.private,
-            public_key=joint_fixture.keypair.public,
-            s3=s3,
-        )
+    storage = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.node1
+    data = await create_test_file(
+        bucket_id=INBOX_BUCKET_ID,
+        private_key=joint_fixture.keypair.private,
+        public_key=joint_fixture.keypair.public,
+        s3=storage,
+    )
 
-        ekss_patch = partial(_ekss_call, data=data)
+    ekss_patch = partial(_ekss_call, data=data)
 
-        monkeypatch.setattr(
-            "irs.core.interrogator.call_eks_api",
-            ekss_patch,
-        )
+    monkeypatch.setattr(
+        "irs.core.interrogator.call_eks_api",
+        ekss_patch,
+    )
 
-        payload_in = {
-            "s3_endpoint_alias": endpoint_alias,
-            "file_id": data.file_id,
-            "object_id": data.file_object.object_id,
-            "bucket_id": INBOX_BUCKET_ID,
-            "submitter_public_key": base64.b64encode(
-                joint_fixture.keypair.public
-            ).decode("utf-8"),
-            "upload_date": data.upload_date,
-            "expected_decrypted_sha256": data.checksum,
-            "decrypted_size": data.file_size,
-        }
-        event_in = _incoming_event_upload_received(
-            payload=payload_in, config=joint_fixture.config
-        )
+    payload_in = {
+        "s3_endpoint_alias": storage_alias,
+        "file_id": data.file_id,
+        "object_id": data.file_object.object_id,
+        "bucket_id": INBOX_BUCKET_ID,
+        "submitter_public_key": base64.b64encode(joint_fixture.keypair.public).decode(
+            "utf-8"
+        ),
+        "upload_date": data.upload_date,
+        "expected_decrypted_sha256": data.checksum,
+        "decrypted_size": data.file_size,
+    }
+    event_in = _incoming_event_upload_received(
+        payload=payload_in, config=joint_fixture.config
+    )
 
-        # create db fingerprint entry
-        mongo_dao = await FingerprintDaoConstructor.construct(
-            dao_factory=joint_fixture.mongodb.dao_factory
-        )
-        seen_event = _populate_subject(payload_in)
-        fingerprint = UploadReceivedFingerprint.generate(seen_event)
+    # create db fingerprint entry
+    mongo_dao = await FingerprintDaoConstructor.construct(
+        dao_factory=joint_fixture.mongodb.dao_factory
+    )
+    seen_event = _populate_subject(payload_in)
+    fingerprint = UploadReceivedFingerprint.generate(seen_event)
 
-        await mongo_dao.insert(fingerprint)
+    await mongo_dao.insert(fingerprint)
 
-        # reset captured logs
-        caplog.clear()
-        await joint_fixture.kafka.publish_event(**event_in)
-        await joint_fixture.event_subscriber.run(forever=False)
-        assert (
-            f"Payload for file ID '{seen_event.file_id}' has already been processed."
-            in caplog.messages
-        )
+    # reset captured logs
+    caplog.clear()
+    await joint_fixture.kafka.publish_event(**event_in)
+    await joint_fixture.event_subscriber.run(forever=False)
+    assert (
+        f"Payload for file ID '{seen_event.file_id}' has already been processed."
+        in caplog.messages
+    )


### PR DESCRIPTION
Remove the use of the second_s3 fixture from tests. The tests had a flaw with resetting state and the current hexkit fixture setup doesn't allow for multiple containers (this might need to be adapted in the future). The intention with the affected tests in this PR was originally to test potential side effects when multiple storage nodes exist. This could/should be tested with integration tests later, but that still might require the ability to instantiate more than one s3 container. 

The changes to both IRS and IFRS tests are basically:
- Remove second_s3 fixture
- Remove `for` loop in tests iterating through s3/second_s3 fixtures, then unindent everything that was under it (responsible for big change block)
- Only use node1 storage location (did not check super closely for this)
- Move `container` fixtures to `conftest.py` in the root test dir for each service
- Move keypair regen and bucket population logic to be outside of joint fixture (now defined in conftest)
- Make joint fixture function scope by default by removing the get_joint_fixture part (and import into conftest so it's always available)
- Remove some pragma statements like F811