### PR TITLE
IRS Outbox Subscriber (GSI-779)

### DIFF
--- a/services/irs/README.md
+++ b/services/irs/README.md
@@ -14,13 +14,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/interrogation-room-service):
 ```bash
-docker pull ghga/interrogation-room-service:2.3.0
+docker pull ghga/interrogation-room-service:3.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/interrogation-room-service:2.3.0 .
+docker build -t ghga/interrogation-room-service:3.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -28,7 +28,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/interrogation-room-service:2.3.0 --help
+docker run -p 8080:8080 ghga/interrogation-room-service:3.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/irs/README.md
+++ b/services/irs/README.md
@@ -14,13 +14,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/interrogation-room-service):
 ```bash
-docker pull ghga/interrogation-room-service:2.2.0
+docker pull ghga/interrogation-room-service:2.3.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/interrogation-room-service:2.2.0 .
+docker build -t ghga/interrogation-room-service:2.3.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -28,7 +28,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/interrogation-room-service:2.2.0 --help
+docker run -p 8080:8080 ghga/interrogation-room-service:2.3.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -112,6 +112,16 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`upload_received_event_topic`** *(string)*: Name of the topic to publish events that inform about new file uploads.
+
+
+  Examples:
+
+  ```json
+  "file_uploads"
+  ```
+
+
 - **`file_registered_event_topic`** *(string)*: Name of the topic used for events indicating that a new file has been internally registered.
 
 
@@ -129,26 +139,6 @@ The service requires the following configuration parameters:
 
   ```json
   "file_registered"
-  ```
-
-
-- **`upload_received_event_topic`** *(string)*: Name of the topic to publish events that inform about new file uploads.
-
-
-  Examples:
-
-  ```json
-  "file_uploads"
-  ```
-
-
-- **`upload_received_event_type`** *(string)*: The type to use for events that inform about new file uploads.
-
-
-  Examples:
-
-  ```json
-  "file_upload_received"
   ```
 
 

--- a/services/irs/config_schema.json
+++ b/services/irs/config_schema.json
@@ -170,6 +170,14 @@
       "title": "Interrogation Failure Type",
       "type": "string"
     },
+    "upload_received_event_topic": {
+      "description": "Name of the topic to publish events that inform about new file uploads.",
+      "examples": [
+        "file_uploads"
+      ],
+      "title": "Upload Received Event Topic",
+      "type": "string"
+    },
     "file_registered_event_topic": {
       "description": "Name of the topic used for events indicating that a new file has been internally registered.",
       "examples": [
@@ -184,22 +192,6 @@
         "file_registered"
       ],
       "title": "File Registered Event Type",
-      "type": "string"
-    },
-    "upload_received_event_topic": {
-      "description": "Name of the topic to publish events that inform about new file uploads.",
-      "examples": [
-        "file_uploads"
-      ],
-      "title": "Upload Received Event Topic",
-      "type": "string"
-    },
-    "upload_received_event_type": {
-      "description": "The type to use for events that inform about new file uploads.",
-      "examples": [
-        "file_upload_received"
-      ],
-      "title": "Upload Received Event Type",
       "type": "string"
     },
     "object_storages": {
@@ -301,10 +293,9 @@
     "interrogation_topic",
     "interrogation_success_type",
     "interrogation_failure_type",
+    "upload_received_event_topic",
     "file_registered_event_topic",
     "file_registered_event_type",
-    "upload_received_event_topic",
-    "upload_received_event_type",
     "object_storages",
     "db_connection_str",
     "db_name",

--- a/services/irs/dev_config.yaml
+++ b/services/irs/dev_config.yaml
@@ -18,7 +18,6 @@ interrogation_topic: file_interrogation
 interrogation_success_type: file_validation_success
 interrogation_failure_type: file_validation_failure
 upload_received_event_topic: file_uploads
-upload_received_event_type: file_upload_received
 
 object_stale_after_minutes: 1440
 

--- a/services/irs/example_config.yaml
+++ b/services/irs/example_config.yaml
@@ -29,4 +29,3 @@ object_storages:
 service_instance_id: '001'
 service_name: irs
 upload_received_event_topic: file_uploads
-upload_received_event_type: file_upload_received

--- a/services/irs/pyproject.toml
+++ b/services/irs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "irs"
-version = "2.2.0"
+version = "2.3.0"
 description = "Interrogation Room Service"
 readme = "README.md"
 authors = [

--- a/services/irs/pyproject.toml
+++ b/services/irs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "irs"
-version = "2.3.0"
+version = "3.0.0"
 description = "Interrogation Room Service"
 readme = "README.md"
 authors = [

--- a/services/irs/src/irs/adapters/outbound/dao.py
+++ b/services/irs/src/irs/adapters/outbound/dao.py
@@ -22,31 +22,21 @@ from irs.core import models
 from irs.ports.outbound.dao import FingerprintDaoPort, StagingObjectDaoPort
 
 
-class FingerprintDaoConstructor:
-    """Constructor compatible with the hexkit.inject.AsyncConstructable type. Used to
-    construct a DAO for interacting with the database.
-    """
-
-    @staticmethod
-    async def construct(*, dao_factory: DaoFactoryProtocol) -> FingerprintDaoPort:
-        """Get a DAO using the specified provider."""
-        return await dao_factory.get_dao(
-            name="fingerprints",
-            dto_model=models.UploadReceivedFingerprint,
-            id_field="checksum",
-        )
+async def get_fingerprint_dao(*, dao_factory: DaoFactoryProtocol) -> FingerprintDaoPort:
+    """Get a DAO using the specified provider."""
+    return await dao_factory.get_dao(
+        name="fingerprints",
+        dto_model=models.UploadReceivedFingerprint,
+        id_field="checksum",
+    )
 
 
-class StagingObjectDaoConstructor:
-    """Constructor compatible with the hexkit.inject.AsyncConstructable type. Used to
-    construct a DAO for interacting with the database.
-    """
-
-    @staticmethod
-    async def construct(*, dao_factory: DaoFactoryProtocol) -> StagingObjectDaoPort:
-        """Get a DAO using the specified provider."""
-        return await dao_factory.get_dao(
-            name="staging_objects",
-            dto_model=models.StagingObject,
-            id_field="file_id",
-        )
+async def get_staging_object_dao(
+    *, dao_factory: DaoFactoryProtocol
+) -> StagingObjectDaoPort:
+    """Get a DAO using the specified provider."""
+    return await dao_factory.get_dao(
+        name="staging_objects",
+        dto_model=models.StagingObject,
+        id_field="file_id",
+    )

--- a/services/irs/src/irs/config.py
+++ b/services/irs/src/irs/config.py
@@ -22,24 +22,30 @@ from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 from pydantic import Field
 
-from irs.adapters.inbound.event_sub import EventSubTranslatorConfig
+from irs.adapters.inbound.event_sub import (
+    EventSubTranslatorConfig,
+    OutboxSubTranslatorConfig,
+)
 from irs.adapters.outbound.event_pub import EventPubTanslatorConfig
 from irs.core.storage_inspector import StorageInspectorConfig
 
+SERVICE_NAME: str = "irs"
 
-@config_from_yaml(prefix="irs")
+
+@config_from_yaml(prefix=SERVICE_NAME)
 class Config(
     KafkaConfig,
     MongoDbConfig,
     S3ObjectStoragesConfig,
     EventSubTranslatorConfig,
+    OutboxSubTranslatorConfig,
     EventPubTanslatorConfig,
     LoggingConfig,
     StorageInspectorConfig,
 ):
     """Config parameters and their defaults."""
 
-    service_name: str = "irs"
+    service_name: str = SERVICE_NAME
     ekss_base_url: str = Field(
         ...,
         examples=["http://ekss:8080"],

--- a/services/irs/src/irs/main.py
+++ b/services/irs/src/irs/main.py
@@ -15,10 +15,16 @@
 #
 """Top-level object construction and dependency injection"""
 
+import asyncio
+
 from hexkit.log import configure_logging
 
 from irs.config import Config
-from irs.inject import prepare_event_subscriber, prepare_storage_inspector
+from irs.inject import (
+    prepare_event_subscriber,
+    prepare_outbox_subscriber,
+    prepare_storage_inspector,
+)
 
 
 async def consume_events(run_forever: bool = True):
@@ -26,8 +32,14 @@ async def consume_events(run_forever: bool = True):
     config = Config()
     configure_logging(config=config)
 
-    async with prepare_event_subscriber(config=config) as event_subscriber:
-        await event_subscriber.run(forever=run_forever)
+    async with (
+        prepare_event_subscriber(config=config) as event_subscriber,
+        prepare_outbox_subscriber(config=config) as outbox_subscriber,
+    ):
+        await asyncio.gather(
+            event_subscriber.run(forever=run_forever),
+            outbox_subscriber.run(forever=run_forever),
+        )
 
 
 async def check_staging_buckets():

--- a/services/irs/tests_irs/conftest.py
+++ b/services/irs/tests_irs/conftest.py
@@ -36,6 +36,7 @@ from tests_irs.fixtures.joint import (  # noqa: F401
     JointFixture,
     joint_fixture,
 )
+from tests_irs.fixtures.keypair_fixtures import keypair_fixture  # noqa: F401
 
 
 async def _populate_s3_buckets(s3: S3Fixture):

--- a/services/irs/tests_irs/fixtures/joint.py
+++ b/services/irs/tests_irs/fixtures/joint.py
@@ -24,19 +24,16 @@ from ghga_service_commons.utils.multinode_storage import (
     S3ObjectStorageNodeConfig,
     S3ObjectStoragesConfig,
 )
-from hexkit.providers.akafka import KafkaEventSubscriber
+from hexkit.providers.akafka import KafkaEventSubscriber, KafkaOutboxSubscriber
 from hexkit.providers.akafka.testutils import KafkaFixture
 from hexkit.providers.mongodb.testutils import MongoDbFixture
 from hexkit.providers.s3.testutils import S3Fixture
 from irs.config import Config
-from irs.inject import prepare_core, prepare_event_subscriber
+from irs.inject import prepare_core, prepare_event_subscriber, prepare_outbox_subscriber
 from irs.ports.inbound.interrogator import InterrogatorPort
 
 from tests_irs.fixtures.config import get_config
-from tests_irs.fixtures.keypair_fixtures import (
-    KeypairFixture,
-    keypair_fixture,  # noqa: F401
-)
+from tests_irs.fixtures.keypair_fixtures import KeypairFixture
 
 FILE_SIZE = 50 * 1024**2
 INBOX_BUCKET_ID = "test-inbox"
@@ -57,6 +54,7 @@ class JointFixture:
 
     config: Config
     event_subscriber: KafkaEventSubscriber
+    outbox_subscriber: KafkaOutboxSubscriber
     interrogator: InterrogatorPort
     kafka: KafkaFixture
     keypair: KeypairFixture
@@ -67,7 +65,7 @@ class JointFixture:
 
 @pytest_asyncio.fixture(scope="function")
 async def joint_fixture(
-    keypair_fixture: KeypairFixture,  # noqa: F811
+    keypair_fixture: KeypairFixture,
     kafka: KafkaFixture,
     mongodb: MongoDbFixture,
     s3: S3Fixture,
@@ -92,10 +90,14 @@ async def joint_fixture(
         prepare_event_subscriber(
             config=config, interrogator_override=interrogator
         ) as event_subscriber,
+        prepare_outbox_subscriber(
+            config=config, interrogator_override=interrogator
+        ) as outbox_subscriber,
     ):
         yield JointFixture(
             config=config,
             event_subscriber=event_subscriber,
+            outbox_subscriber=outbox_subscriber,
             interrogator=interrogator,
             kafka=kafka,
             keypair=keypair_fixture,

--- a/services/irs/tests_irs/fixtures/test_config.yaml
+++ b/services/irs/tests_irs/fixtures/test_config.yaml
@@ -18,7 +18,6 @@ interrogation_topic: file_interrogation
 interrogation_success_type: file_validation_success
 interrogation_failure_type: file_validation_failure
 upload_received_event_topic: file_uploads
-upload_received_event_type: file_upload_received
 
 object_stale_after_minutes: 1440
 

--- a/services/irs/tests_irs/test_cli.py
+++ b/services/irs/tests_irs/test_cli.py
@@ -19,15 +19,11 @@ from datetime import timedelta
 
 import pytest
 from ghga_service_commons.utils.utc_dates import now_as_utc
-from irs.adapters.outbound.dao import StagingObjectDaoConstructor
+from irs.adapters.outbound.dao import get_staging_object_dao
 from irs.core.models import StagingObject
 from irs.inject import prepare_storage_inspector
 
-from tests_irs.fixtures.joint import (
-    STAGING_BUCKET_ID,
-    JointFixture,
-    keypair_fixture,  # noqa: F401
-)
+from tests_irs.fixtures.joint import STAGING_BUCKET_ID, JointFixture
 from tests_irs.fixtures.test_files import create_test_file
 
 pytestmark = pytest.mark.asyncio()
@@ -73,9 +69,7 @@ async def test_staging_inspector(caplog, joint_fixture: JointFixture):
     )
 
     dao_factory = joint_fixture.mongodb.dao_factory
-    staging_object_dao = await StagingObjectDaoConstructor.construct(
-        dao_factory=dao_factory
-    )
+    staging_object_dao = await get_staging_object_dao(dao_factory=dao_factory)
     await staging_object_dao.insert(staging_object_1)
     await staging_object_dao.insert(staging_object_2)
 

--- a/services/irs/tests_irs/test_outbox_subscriber.py
+++ b/services/irs/tests_irs/test_outbox_subscriber.py
@@ -1,0 +1,79 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for just the outbox subscriber"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from ghga_event_schemas import pydantic_ as event_schemas
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from logot import Logot, logged
+
+from tests_irs.fixtures.joint import JointFixture
+
+pytestmark = pytest.mark.asyncio()
+
+CHANGE_EVENT_TYPE = "upserted"
+DELETE_EVENT_TYPE = "deleted"
+TEST_FILE_ID = "test_id"
+TEST_FILE_UPLOAD_RECEIVED = event_schemas.FileUploadReceived(
+    upload_date=now_as_utc().isoformat(),
+    file_id=TEST_FILE_ID,
+    bucket_id="",
+    decrypted_size=0,
+    expected_decrypted_sha256="",
+    object_id="",
+    submitter_public_key="",
+    s3_endpoint_alias="",
+)
+
+
+async def test_outbox_subscriber_routing(joint_fixture: JointFixture):
+    """Make sure the correct core method is called from the outbox subscriber."""
+    await joint_fixture.kafka.publish_event(
+        payload=TEST_FILE_UPLOAD_RECEIVED.model_dump(),
+        type_=CHANGE_EVENT_TYPE,
+        topic=joint_fixture.config.upload_received_event_topic,
+        key=TEST_FILE_ID,
+    )
+
+    mock = AsyncMock()
+    joint_fixture.interrogator.interrogate = mock
+
+    await joint_fixture.outbox_subscriber.run(forever=False)
+    mock.assert_awaited_once()
+
+
+async def test_deletion_logs(joint_fixture: JointFixture, logot: Logot):
+    """Test that the outbox subscriber logs deletions correctly.
+    Consume a 'DELETED' event type for the outbox event.
+    """
+    # publish test event
+    await joint_fixture.kafka.publish_event(
+        payload=TEST_FILE_UPLOAD_RECEIVED.model_dump(),
+        type_=DELETE_EVENT_TYPE,
+        topic=joint_fixture.config.upload_received_event_topic,
+        key=TEST_FILE_ID,
+    )
+    # consume that event
+    await joint_fixture.outbox_subscriber.run(forever=False)
+
+    # verify the log
+    logot.assert_logged(
+        logged.warning(
+            "Received DELETED-type event for FileUploadReceived"
+            + f" with resource ID '{TEST_FILE_ID}'",
+        )
+    )


### PR DESCRIPTION
Adds an outbox subscriber to handle the FileUploadReceived events. There is no extra idempotence mechanism added in this PR because that is already handled by the Interrogator class via the Fingerprint process. The `changed` method on the outbox translator class has the same action as the event sub translator when consuming the event, and calls the `interrogate` method on the interrogator. 
The `deleted` method will log a warning, as is done in similar implementations for outbox consumption of normal events.
Because there is a config change, the major version number is bumped from 2 -> 3