### PR TITLE
UCS Outbox Subscriber (GSI-774)

### DIFF
--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:3.1.0
+docker pull ghga/upload-controller-service:4.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:3.1.0 .
+docker build -t ghga/upload-controller-service:4.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:3.1.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:4.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -86,6 +86,16 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`files_to_delete_topic`** *(string)*: The name of the topic for events informing about files to be deleted.
+
+
+  Examples:
+
+  ```json
+  "file_deletions"
+  ```
+
+
 - **`file_metadata_event_topic`** *(string)*: Name of the topic to receive new or changed metadata on files that shall be registered for uploaded.
 
 
@@ -103,26 +113,6 @@ The service requires the following configuration parameters:
 
   ```json
   "file_metadata_upserts"
-  ```
-
-
-- **`files_to_delete_topic`** *(string)*: The name of the topic for events informing about files to be deleted.
-
-
-  Examples:
-
-  ```json
-  "file_deletions"
-  ```
-
-
-- **`files_to_delete_type`** *(string)*: The type used for events informing about a file to be deleted.
-
-
-  Examples:
-
-  ```json
-  "file_deletion_requested"
   ```
 
 

--- a/services/ucs/config_schema.json
+++ b/services/ucs/config_schema.json
@@ -129,6 +129,14 @@
       "title": "Upload Received Event Type",
       "type": "string"
     },
+    "files_to_delete_topic": {
+      "description": "The name of the topic for events informing about files to be deleted.",
+      "examples": [
+        "file_deletions"
+      ],
+      "title": "Files To Delete Topic",
+      "type": "string"
+    },
     "file_metadata_event_topic": {
       "description": "Name of the topic to receive new or changed metadata on files that shall be registered for uploaded.",
       "examples": [
@@ -143,22 +151,6 @@
         "file_metadata_upserts"
       ],
       "title": "File Metadata Event Type",
-      "type": "string"
-    },
-    "files_to_delete_topic": {
-      "description": "The name of the topic for events informing about files to be deleted.",
-      "examples": [
-        "file_deletions"
-      ],
-      "title": "Files To Delete Topic",
-      "type": "string"
-    },
-    "files_to_delete_type": {
-      "description": "The type used for events informing about a file to be deleted.",
-      "examples": [
-        "file_deletion_requested"
-      ],
-      "title": "Files To Delete Type",
       "type": "string"
     },
     "upload_accepted_event_topic": {
@@ -450,10 +442,9 @@
     "file_deleted_event_type",
     "upload_received_event_topic",
     "upload_received_event_type",
+    "files_to_delete_topic",
     "file_metadata_event_topic",
     "file_metadata_event_type",
-    "files_to_delete_topic",
-    "files_to_delete_type",
     "upload_accepted_event_topic",
     "upload_accepted_event_type",
     "upload_rejected_event_topic",

--- a/services/ucs/dev_config.yaml
+++ b/services/ucs/dev_config.yaml
@@ -8,7 +8,6 @@ object_storages:
       s3_access_key_id: test
       s3_secret_access_key: test
 files_to_delete_topic: file_deletions
-files_to_delete_type: file_deletion_requested
 file_deleted_event_topic: file_downloads
 file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata

--- a/services/ucs/example_config.yaml
+++ b/services/ucs/example_config.yaml
@@ -12,7 +12,6 @@ file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
 files_to_delete_topic: file_deletions
-files_to_delete_type: file_deletion_requested
 generate_correlation_id: true
 host: 127.0.0.1
 kafka_security_protocol: PLAINTEXT

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -433,7 +433,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 3.1.0
+  version: 4.0.0
 openapi: 3.1.0
 paths:
   /files/{file_id}:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ucs"
-version = "3.1.0"
+version = "4.0.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/event_sub.py
+++ b/services/ucs/src/ucs/adapters/inbound/event_sub.py
@@ -15,9 +15,12 @@
 
 """Receive events informing about files that are expected to be uploaded."""
 
+import logging
+
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
+from hexkit.protocols.daosub import DaoSubscriberProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -25,6 +28,8 @@ from pydantic_settings import BaseSettings
 from ucs.core import models
 from ucs.ports.inbound.file_service import FileMetadataServicePort
 from ucs.ports.inbound.upload_service import UploadServicePort
+
+log = logging.getLogger(__name__)
 
 
 class EventSubTranslatorConfig(BaseSettings):
@@ -46,18 +51,6 @@ class EventSubTranslatorConfig(BaseSettings):
         ),
         examples=["file_metadata_upserts"],
     )
-
-    files_to_delete_topic: str = Field(
-        default=...,
-        description="The name of the topic for events informing about files to be deleted.",
-        examples=["file_deletions"],
-    )
-    files_to_delete_type: str = Field(
-        default=...,
-        description="The type used for events informing about a file to be deleted.",
-        examples=["file_deletion_requested"],
-    )
-
     upload_accepted_event_topic: str = Field(
         default=...,
         description=(
@@ -100,13 +93,11 @@ class EventSubTranslator(EventSubscriberProtocol):
     ):
         """Initialize with config parameters and core dependencies."""
         self.topics_of_interest = [
-            config.files_to_delete_topic,
             config.file_metadata_event_topic,
             config.upload_accepted_event_topic,
             config.upload_rejected_event_topic,
         ]
         self.types_of_interest = [
-            config.files_to_delete_type,
             config.file_metadata_event_type,
             config.upload_accepted_event_type,
             config.upload_rejected_event_type,
@@ -150,14 +141,6 @@ class EventSubTranslator(EventSubscriberProtocol):
 
         await self._upload_service.reject_latest(file_id=validated_payload.file_id)
 
-    async def _consume_deletion_requested(self, *, payload: JsonObject) -> None:
-        """Consume file deletion event"""
-        validated_payload = get_validated_payload(
-            payload=payload, schema=event_schemas.FileDeletionRequested
-        )
-
-        await self._upload_service.deletion_requested(file_id=validated_payload.file_id)
-
     async def _consume_validated(
         self,
         *,
@@ -173,7 +156,48 @@ class EventSubTranslator(EventSubscriberProtocol):
             await self._consume_upload_accepted(payload=payload)
         elif type_ == self._config.upload_rejected_event_type:
             await self._consume_validation_failure(payload=payload)
-        elif type_ == self._config.files_to_delete_type:
-            await self._consume_deletion_requested(payload=payload)
         else:
             raise RuntimeError(f"Unexpected event of type: {type_}")
+
+
+class OutboxSubTranslatorConfig(BaseSettings):
+    """Config for the outbox subscriber"""
+
+    files_to_delete_topic: str = Field(
+        default=...,
+        description="The name of the topic for events informing about files to be deleted.",
+        examples=["file_deletions"],
+    )
+
+
+class FileDeletionRequestedListener(
+    DaoSubscriberProtocol[event_schemas.FileDeletionRequested]
+):
+    """A class that consumes FileDeletionRequested events."""
+
+    event_topic: str
+    dto_model = event_schemas.FileDeletionRequested
+
+    def __init__(
+        self,
+        *,
+        config: OutboxSubTranslatorConfig,
+        upload_service: UploadServicePort,
+    ):
+        self._upload_service = upload_service
+        self.event_topic = config.files_to_delete_topic
+
+    async def changed(
+        self, resource_id: str, update: event_schemas.FileDeletionRequested
+    ) -> None:
+        """Consume change event for File Deletion Requests.
+        Idempotence is handled by the core, so no intermediary is required.
+        """
+        await self._upload_service.deletion_requested(file_id=update.file_id)
+
+    async def deleted(self, resource_id: str) -> None:
+        """Consume event indicating the deletion of a File Deletion Request."""
+        log.warning(
+            "Received DELETED-type event for FileDeletionRequested with resource ID '%s'",
+            resource_id,
+        )

--- a/services/ucs/src/ucs/config.py
+++ b/services/ucs/src/ucs/config.py
@@ -22,11 +22,16 @@ from hexkit.log import LoggingConfig
 from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 
-from ucs.adapters.inbound.event_sub import EventSubTranslatorConfig
+from ucs.adapters.inbound.event_sub import (
+    EventSubTranslatorConfig,
+    OutboxSubTranslatorConfig,
+)
 from ucs.adapters.outbound.event_pub import EventPubTranslatorConfig
 
+SERVICE_NAME = "ucs"
 
-@config_from_yaml(prefix="ucs")
+
+@config_from_yaml(prefix=SERVICE_NAME)
 class Config(
     ApiConfigBase,
     MongoDbConfig,
@@ -34,8 +39,9 @@ class Config(
     KafkaConfig,
     LoggingConfig,
     EventSubTranslatorConfig,
+    OutboxSubTranslatorConfig,
     EventPubTranslatorConfig,
 ):
     """Config parameters and their defaults."""
 
-    service_name: str = "ucs"
+    service_name: str = SERVICE_NAME

--- a/services/ucs/src/ucs/core/models.py
+++ b/services/ucs/src/ucs/core/models.py
@@ -17,7 +17,6 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -46,31 +45,33 @@ class UploadAttempt(BaseModel):
 
     upload_id: str
     file_id: str = Field(
-        ..., description="The ID of the file corresponding to this upload."
+        default=..., description="The ID of the file corresponding to this upload."
     )
     object_id: str = Field(
-        ..., description="The bucket-specific ID used within the S3 object storage."
+        default=...,
+        description="The bucket-specific ID used within the S3 object storage.",
     )
     status: UploadStatus
     part_size: int = Field(
-        ..., description="Part size to be used for upload. Specified in bytes."
+        default=..., description="Part size to be used for upload. Specified in bytes."
     )
     creation_date: datetime = Field(
-        ..., description="Datetime when the upload attempt was created."
+        default=..., description="Datetime when the upload attempt was created."
     )
-    completion_date: Optional[datetime] = Field(
-        None,
+    completion_date: datetime | None = Field(
+        default=None,
         description=(
             "Datetime when the upload attempt was declared as completed by the client."
             + " `None` if the upload is ongoing."
         ),
     )
     submitter_public_key: str = Field(
-        ..., description="The public key used by the submittter to encrypt the file."
+        default=...,
+        description="The public key used by the submittter to encrypt the file.",
     )
     model_config = ConfigDict(from_attributes=True, title="Multi-Part Upload Details")
     storage_alias: str = Field(
-        ...,
+        default=...,
         description="Alias for the object storage location where the given object is stored.",
     )
 
@@ -88,8 +89,8 @@ class FileMetadataUpsert(BaseModel):
 class FileMetadata(FileMetadataUpsert):
     """A model containing the full metadata on a file."""
 
-    latest_upload_id: Optional[str] = Field(
-        None,
+    latest_upload_id: str | None = Field(
+        default=None,
         description=(
             "ID of the latest upload (attempt). `Null/None`"
             + " if no update has been initiated, yet."

--- a/services/ucs/src/ucs/inject.py
+++ b/services/ucs/src/ucs/inject.py
@@ -17,7 +17,6 @@
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Optional
 
 from fastapi import FastAPI
 from ghga_service_commons.utils.context import asyncnullcontext
@@ -64,7 +63,7 @@ async def prepare_core(
 def prepare_core_with_override(
     *,
     config: Config,
-    core_override: Optional[tuple[UploadServicePort, FileMetadataServicePort]] = None,
+    core_override: tuple[UploadServicePort, FileMetadataServicePort] | None = None,
 ):
     """Resolve the prepare_core context manager based on config and override (if any)."""
     return (
@@ -78,7 +77,7 @@ def prepare_core_with_override(
 async def prepare_rest_app(
     *,
     config: Config,
-    core_override: Optional[tuple[UploadServicePort, FileMetadataServicePort]] = None,
+    core_override: tuple[UploadServicePort, FileMetadataServicePort] | None = None,
 ) -> AsyncGenerator[FastAPI, None]:
     """Construct and initialize a REST API app along with all its dependencies.
     By default, the core dependencies are automatically prepared but you can also
@@ -103,7 +102,7 @@ async def prepare_rest_app(
 async def prepare_event_subscriber(
     *,
     config: Config,
-    core_override: Optional[tuple[UploadServicePort, FileMetadataServicePort]] = None,
+    core_override: tuple[UploadServicePort, FileMetadataServicePort] | None = None,
 ) -> AsyncGenerator[KafkaEventSubscriber, None]:
     """Construct and initialize an event subscriber with all its dependencies.
     By default, the core dependencies are automatically prepared but you can also

--- a/services/ucs/tests_ucs/fixtures/config.py
+++ b/services/ucs/tests_ucs/fixtures/config.py
@@ -16,7 +16,6 @@
 """Test config"""
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic_settings import BaseSettings
 from ucs.config import Config
@@ -27,7 +26,7 @@ TEST_CONFIG_YAML = BASE_DIR / "test_config.yaml"
 
 
 def get_config(
-    sources: Optional[list[BaseSettings]] = None,
+    sources: list[BaseSettings] | None = None,
     default_config_yaml: Path = TEST_CONFIG_YAML,
 ) -> Config:
     """Merges parameters from the default TEST_CONFIG_YAML with params inferred

--- a/services/ucs/tests_ucs/fixtures/test_config.yaml
+++ b/services/ucs/tests_ucs/fixtures/test_config.yaml
@@ -8,7 +8,6 @@ object_storages:
       s3_access_key_id: test
       s3_secret_access_key: test
 files_to_delete_topic: file_deletions
-files_to_delete_type: file_deletion_requested
 file_deleted_event_topic: file_downloads
 file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata

--- a/services/ucs/tests_ucs/test_edge_cases.py
+++ b/services/ucs/tests_ucs/test_edge_cases.py
@@ -388,15 +388,13 @@ async def test_deletion_with_no_file(joint_fixture: JointFixture):
     )
 
     # Consume inbound event
-    deletion_successful_event = event_schemas.FileDeletionSuccess(file_id=file_id)
     async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.file_deleted_event_topic
     ) as recorder:
-        await joint_fixture.outbox_subscriber.run(forever=False)
+        await joint_fixture.upload_service.deletion_requested(file_id=file_id)
 
     # Check for event
-    assert len(recorder.recorded_events) == 1
-    assert recorder.recorded_events[0].payload == deletion_successful_event.model_dump()
+    assert len(recorder.recorded_events) == 0
 
 
 async def test_deletion_logs(joint_fixture: JointFixture, logot: Logot):

--- a/services/ucs/tests_ucs/test_typical_journey.py
+++ b/services/ucs/tests_ucs/test_typical_journey.py
@@ -390,7 +390,7 @@ async def test_happy_deletion(joint_fixture: JointFixture):
     deletion_event = event_schemas.FileDeletionRequested(file_id=file_id)
     await joint_fixture.kafka.publish_event(
         payload=json.loads(deletion_event.model_dump_json()),
-        type_=joint_fixture.config.files_to_delete_type,
+        type_="upserted",
         topic=joint_fixture.config.files_to_delete_topic,
     )
 
@@ -399,7 +399,7 @@ async def test_happy_deletion(joint_fixture: JointFixture):
     async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.file_deleted_event_topic
     ) as recorder:
-        await joint_fixture.event_subscriber.run(forever=False)
+        await joint_fixture.outbox_subscriber.run(forever=False)
 
     assert len(recorder.recorded_events) == 1
     assert recorder.recorded_events[0].payload == deletion_successful_event.model_dump()


### PR DESCRIPTION
Adds an outbox subscriber/translator with minimal changes otherwise. Idempotence is built in to the core, so no IdempotenceHandler is needed.

Previously, the UCS would publish a `FileDeletionSuccessful` event anytime it consumed a `FileDeletionRequested` event, even if nothing was there to be deleted (e.g. in the case of an re-processing or something). This has been changed so an event is only published if an upload attempt is discovered. I didn't know whether to base it on the object deletion or the upload attempts and went with the broader thing, but this can easily be changed.