### PR TITLE
FIS Add Republish Command (GSI-814)

### DIFF
--- a/services/fis/src/fis/cli.py
+++ b/services/fis/src/fis/cli.py
@@ -31,6 +31,7 @@
 """Entrypoint of the package"""
 
 import asyncio
+from typing import Annotated
 
 import typer
 
@@ -46,6 +47,10 @@ def sync_run_api():
 
 
 @cli.command(name="publish-events")
-def sync_run_publish_events(all: bool = False):
-    """Publish pending events. Use `--all` to (re)publish all events regardless of status."""
+def sync_run_publish_events(
+    all: Annotated[
+        bool, typer.Argument(help="Set to (re)publish all events regardless of status")
+    ] = False,
+):
+    """Publish pending events."""
     asyncio.run(publish_events(all=all))

--- a/services/fis/src/fis/cli.py
+++ b/services/fis/src/fis/cli.py
@@ -34,7 +34,7 @@ import asyncio
 
 import typer
 
-from fis.main import run_rest
+from fis.main import publish_events, run_rest
 
 cli = typer.Typer()
 
@@ -43,3 +43,9 @@ cli = typer.Typer()
 def sync_run_api():
     """Run the HTTP REST API."""
     asyncio.run(run_rest())
+
+
+@cli.command(name="publish-events")
+def sync_run_publish_events(all: bool = False):
+    """Publish pending events. Use `--all` to (re)publish all events regardless of status."""
+    asyncio.run(publish_events(all=all))

--- a/services/fis/src/fis/main.py
+++ b/services/fis/src/fis/main.py
@@ -18,7 +18,7 @@ from ghga_service_commons.api import run_server
 from hexkit.log import configure_logging
 
 from fis.config import Config
-from fis.inject import prepare_rest_app
+from fis.inject import get_file_validation_success_dao, prepare_rest_app
 
 
 async def run_rest():
@@ -28,3 +28,19 @@ async def run_rest():
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
+
+
+async def publish_events(*, all: bool = False):
+    """Publish pending events.
+
+    If `all` is True, it will additionally republish all outbox events that have already
+    been published.
+    """
+    config = Config()
+    configure_logging(config=config)
+
+    async with get_file_validation_success_dao(config=config) as dao:
+        if all:
+            await dao.republish()
+        else:
+            await dao.publish_pending()

--- a/services/fis/src/fis/main.py
+++ b/services/fis/src/fis/main.py
@@ -31,7 +31,7 @@ async def run_rest():
 
 
 async def publish_events(*, all: bool = False):
-    """Publish pending events. Use `--all` to (re)publish all events regardless of status."""
+    """Publish pending events. Set `--all` to (re)publish all events regardless of status."""
     config = Config()
     configure_logging(config=config)
 

--- a/services/fis/src/fis/main.py
+++ b/services/fis/src/fis/main.py
@@ -31,11 +31,7 @@ async def run_rest():
 
 
 async def publish_events(*, all: bool = False):
-    """Publish pending events.
-
-    If `all` is True, it will additionally republish all outbox events that have already
-    been published.
-    """
+    """Publish pending events. Use `--all` to (re)publish all events regardless of status."""
     config = Config()
     configure_logging(config=config)
 

--- a/services/fis/tests_fis/test_outbox_dao.py
+++ b/services/fis/tests_fis/test_outbox_dao.py
@@ -17,14 +17,38 @@
 import pytest
 from ghga_event_schemas.pydantic_ import FileUploadValidationSuccess
 from ghga_service_commons.utils.utc_dates import now_as_utc
-from hexkit.correlation import new_correlation_id, set_correlation_id
+from hexkit.correlation import get_correlation_id, set_new_correlation_id
+from hexkit.protocols.daosub import DaoSubscriberProtocol
+from hexkit.providers.akafka import KafkaOutboxSubscriber
 from hexkit.providers.akafka.testutils import ExpectedEvent
+from hexkit.providers.mongokafka.provider import dto_to_document
 
+from fis.config import Config
 from fis.inject import get_file_validation_success_dao
 from tests_fis.fixtures.joint import TEST_PAYLOAD, JointFixture
 
+pytestmark = pytest.mark.asyncio()
 
-@pytest.mark.asyncio()
+
+def make_test_event(file_id: str) -> FileUploadValidationSuccess:
+    """Return a FileUploadValidationSuccess event with the given file ID."""
+    event = FileUploadValidationSuccess(
+        upload_date=now_as_utc().isoformat(),
+        file_id=file_id,
+        object_id="",
+        bucket_id="",
+        s3_endpoint_alias="",
+        decrypted_size=0,
+        decryption_secret_id="",
+        content_offset=0,
+        encrypted_part_size=0,
+        encrypted_parts_md5=[],
+        encrypted_parts_sha256=[],
+        decrypted_sha256="",
+    )
+    return event
+
+
 async def test_dto_to_event(joint_fixture: JointFixture):
     """Make sure the dto_to_event piece of the mongokafka dao is set up right.
 
@@ -52,10 +76,114 @@ async def test_dto_to_event(joint_fixture: JointFixture):
         )
 
         async with (
-            set_correlation_id(new_correlation_id()),
+            set_new_correlation_id(),
             joint_fixture.kafka.expect_events(
                 events=[expected_event],
                 in_topic=config.file_upload_validation_success_topic,
             ),
         ):
             await outbox_dao.upsert(dto)
+
+
+class DummySubTranslator(DaoSubscriberProtocol):
+    """A class that consumes FileDeletionRequested events."""
+
+    event_topic: str = ""
+    dto_model = FileUploadValidationSuccess
+    correlation_ids: list[str]
+    consumed_events: list[str]
+
+    def __init__(self, *, config: Config) -> None:
+        self.event_topic = config.file_upload_validation_success_topic
+        self.correlation_ids = []
+        self.consumed_events = []
+
+    async def changed(
+        self, resource_id: str, update: FileUploadValidationSuccess
+    ) -> None:
+        """Consume event and record correlation ID"""
+        self.correlation_ids.append(get_correlation_id())
+        self.consumed_events.append(resource_id)
+
+    async def deleted(self, resource_id: str) -> None:
+        """Dummy"""
+
+
+async def test_partial_publish(joint_fixture: JointFixture):
+    """Make sure the partial publish only publishes pending events."""
+    db = joint_fixture.mongodb.client.get_database(joint_fixture.config.db_name)
+    collection = db[joint_fixture.config.file_validations_collection]
+    published_event = make_test_event(file_id="published_event")
+    unpublished_event = make_test_event(file_id="unpublished_event")
+
+    expected_published = ExpectedEvent(
+        payload=published_event.model_dump(), type_="upserted", key="published_event"
+    )
+
+    # Publish and verify the 'published' event
+    async with set_new_correlation_id():
+        async with joint_fixture.kafka.expect_events(
+            events=[expected_published],
+            in_topic=joint_fixture.config.file_upload_validation_success_topic,
+        ):
+            await joint_fixture.dao.insert(published_event)
+
+    # Insert the unpublished event manually
+    async with set_new_correlation_id():
+        document = dto_to_document(unpublished_event, id_field="file_id")
+        collection.insert_one(document)
+
+    expected_unpublished = ExpectedEvent(
+        payload=unpublished_event.model_dump(),
+        type_="upserted",
+        key="unpublished_event",
+    )
+
+    # Verify that the only the unpublished event is published
+    async with joint_fixture.kafka.expect_events(
+        events=[expected_unpublished],
+        in_topic=joint_fixture.config.file_upload_validation_success_topic,
+    ):
+        await joint_fixture.dao.publish_pending()
+
+
+async def test_republish(joint_fixture: JointFixture):
+    """Ensure the republish command on the DAO will work.
+
+    Check that the event is republished with the correct correlation ID.
+    """
+    correlation_ids: list[str] = []
+    file_ids: list[str] = ["test_id1", "test_id2"]
+
+    for file_id in file_ids:
+        file_deletion = make_test_event(file_id=file_id)
+        payload = file_deletion.model_dump()
+        event = ExpectedEvent(payload=payload, type_="upserted", key=file_id)
+
+        # Publish one event at a time and verify
+        async with set_new_correlation_id():
+            correlation_ids.append(get_correlation_id())
+            async with joint_fixture.kafka.expect_events(
+                events=[event],
+                in_topic=joint_fixture.config.file_upload_validation_success_topic,
+            ):
+                await joint_fixture.dao.insert(file_deletion)
+
+    # Republish under new correlation ID to ensure it doesn't pollute the action
+    async with set_new_correlation_id():
+        await joint_fixture.dao.republish()
+
+        # consume the republished events with the dummy translator
+        translator = DummySubTranslator(config=joint_fixture.config)
+        async with KafkaOutboxSubscriber.construct(
+            config=joint_fixture.config, translators=[translator]
+        ) as subscriber:
+            await subscriber.run(forever=False)
+            await subscriber.run(forever=False)
+
+        # verify that the correlation IDs match what we expect. Sort first
+        translator.correlation_ids.sort()
+        translator.consumed_events.sort()
+        correlation_ids.sort()
+        assert translator.correlation_ids == correlation_ids
+        assert translator.consumed_events == file_ids

--- a/services/fis/tests_fis/test_outbox_dao.py
+++ b/services/fis/tests_fis/test_outbox_dao.py
@@ -86,24 +86,21 @@ async def test_dto_to_event(joint_fixture: JointFixture):
 
 
 class DummySubTranslator(DaoSubscriberProtocol):
-    """A class that consumes FileDeletionRequested events."""
+    """A class that consumes FileUploadValidationSuccess events."""
 
     event_topic: str = ""
     dto_model = FileUploadValidationSuccess
-    correlation_ids: list[str]
-    consumed_events: list[str]
+    consumed_events: list[tuple[str, str]]  # correlation ID, resource ID
 
     def __init__(self, *, config: Config) -> None:
         self.event_topic = config.file_upload_validation_success_topic
-        self.correlation_ids = []
         self.consumed_events = []
 
     async def changed(
         self, resource_id: str, update: FileUploadValidationSuccess
     ) -> None:
         """Consume event and record correlation ID"""
-        self.correlation_ids.append(get_correlation_id())
-        self.consumed_events.append(resource_id)
+        self.consumed_events.append((get_correlation_id(), resource_id))
 
     async def deleted(self, resource_id: str) -> None:
         """Dummy"""
@@ -139,7 +136,7 @@ async def test_partial_publish(joint_fixture: JointFixture):
         key="unpublished_event",
     )
 
-    # Verify that the only the unpublished event is published
+    # Verify that only the unpublished event is published
     async with joint_fixture.kafka.expect_events(
         events=[expected_unpublished],
         in_topic=joint_fixture.config.file_upload_validation_success_topic,
@@ -152,7 +149,7 @@ async def test_republish(joint_fixture: JointFixture):
 
     Check that the event is republished with the correct correlation ID.
     """
-    correlation_ids: list[str] = []
+    events: list[tuple[str, str]] = []  # correlation ID, resource ID
     file_ids: list[str] = ["test_id1", "test_id2"]
 
     for file_id in file_ids:
@@ -162,7 +159,7 @@ async def test_republish(joint_fixture: JointFixture):
 
         # Publish one event at a time and verify
         async with set_new_correlation_id():
-            correlation_ids.append(get_correlation_id())
+            events.append((get_correlation_id(), file_id))
             async with joint_fixture.kafka.expect_events(
                 events=[event],
                 in_topic=joint_fixture.config.file_upload_validation_success_topic,
@@ -182,8 +179,6 @@ async def test_republish(joint_fixture: JointFixture):
             await subscriber.run(forever=False)
 
         # verify that the correlation IDs match what we expect. Sort first
-        translator.correlation_ids.sort()
         translator.consumed_events.sort()
-        correlation_ids.sort()
-        assert translator.correlation_ids == correlation_ids
-        assert translator.consumed_events == file_ids
+        events.sort()
+        assert translator.consumed_events == events


### PR DESCRIPTION
Exposes the republish functionality with the cli command `publish-events`. By default, this will publish only pending documents. Adding the `--all` flag with republish all events, regardless of publish status.  