### PR TITLE
pcs and fis: Fix publish-events command

### DIFF
--- a/services/fis/src/fis/cli.py
+++ b/services/fis/src/fis/cli.py
@@ -49,7 +49,7 @@ def sync_run_api():
 @cli.command(name="publish-events")
 def sync_run_publish_events(
     all: Annotated[
-        bool, typer.Argument(help="Set to (re)publish all events regardless of status")
+        bool, typer.Option(help="Set to (re)publish all events regardless of status")
     ] = False,
 ):
     """Publish pending events."""

--- a/services/fis/tests_fis/test_outbox_dao.py
+++ b/services/fis/tests_fis/test_outbox_dao.py
@@ -104,6 +104,7 @@ class DummySubTranslator(DaoSubscriberProtocol):
 
     async def deleted(self, resource_id: str) -> None:
         """Dummy"""
+        raise NotImplementedError()
 
 
 async def test_partial_publish(joint_fixture: JointFixture):

--- a/services/pcs/src/pcs/cli.py
+++ b/services/pcs/src/pcs/cli.py
@@ -34,7 +34,7 @@ def sync_run_rest_app():
 @cli.command(name="publish-events")
 def sync_run_publish_events(
     all: Annotated[
-        bool, typer.Argument(help="Set to (re)publish all events regardless of status")
+        bool, typer.Option(help="Set to (re)publish all events regardless of status")
     ] = False,
 ):
     """Publish pending events."""


### PR DESCRIPTION
When `all` is annotated with `typer.Argument`, it doesn't work like a flag very well. Using `typer.Option` gives it the intuitive behavior, i.e. `fis publish-events` or `fis publish-events --all`. Using typer.Argument and `--all` results in an error.