### PR TITLE
Docker publish now only runs on release

### DIFF
--- a/.github/workflows/ci_docker.yaml
+++ b/.github/workflows/ci_docker.yaml
@@ -32,8 +32,10 @@ env:
   FIS_CONFIG_YAML: ./services/fis/dev_config.yaml
 
 jobs:
-  get-changed-services:
+  get-tag:
     runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.get-release-tag.outputs.commit }}
 
     steps:
       - name: Get latest tag preceding this release
@@ -42,30 +44,53 @@ jobs:
           tags=$(git tag | sort --sort=version | tail -n 2)
           if [[ $(echo $tags | wc -l) == 2 ]]
           then
-             echo "version=$(echo $tags head -n 1)" >> $GITHUB_OUTPUT
+            $tag=$(echo $tags | head -n1)
+            $commit=$(git rev-parse "$tag"^{commit})
+            echo "commit=$commit" >> $GITHUB_OUTPUT
+          else
+            echo "commit=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Get affected services since ${{ steps.get-release-tag.outputs.version }}
-        id: get-affected-services-with-base
-        if: ${{ steps.get-release-tag.outputs.version != '' }}
-        uses: ./.github/workflows/get_affected_services.yaml
-        with:
-          base-sha: ${{ steps.get-release-tag.outputs.version }}
+  get-changed-services-with-base:
+    needs: get-tag
+    if: ${{ needs.get-tag.outputs.commit != '' }}
+    uses: ./.github/workflows/get_affected_services.yaml
+    with:
+      base-sha: ${{ needs.get-tag.outputs.commit }}
 
-      - name: Get affected services since inception
-        id: get-affected-services
-        if: ${{ steps.get-release-tag.outputs.version == '' }}
-        uses: ./.github/workflows/get_affected_services.yaml
-        with:
-          base-sha: $(git log --oneline | tail -n1 | awk '{print $1}')
+  get-changed-services:
+    needs: get-tag
+    if: ${{ needs.get-tag.outputs.commit == '' }}
+    uses: ./.github/workflows/get_affected_services.yaml
+    with:
+      base-sha: $(git log --oneline | tail -n1 | awk '{print $1}')
+
+
+  changed-services:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [get-changed-services, get-changed-services-with-base]
+    outputs:
+      services: ${{ steps.prepare-output.outputs.services }}
+
+    steps:
+      - name: Prepare output
+        id: prepare-output
+        run: |
+          if ${{ needs.get-changed-services.outputs.services != '' }}
+          then
+            echo "services=${{ needs.get-changed-services.outputs.services }}" >> $GITHUB_OUTPUT
+          else
+            echo "services=${{ needs.get-changed-services-with-base.outputs.services }}" >> $GITHUB_OUTPUT
+          fi
 
   push-to-docker:
     runs-on: ubuntu-latest
-    if: ${{ needs.get-changed-services.outputs.services != '' }}
+    if: ${{ needs.changed-services.outputs.services != '' }}
     needs: get-changed-services
     strategy:
       matrix:
-        service: ${{ fromJson(needs.get-changed-services.outputs.services) }}
+        service: ${{ fromJson(needs.changed-services.outputs.services) }}
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci_docker.yaml
+++ b/.github/workflows/ci_docker.yaml
@@ -77,7 +77,7 @@ jobs:
   # Run this if we have a commit hash for a tag
   # We assume there is not a large range of commits and we can go with the default
   # fetch depth here
-  get-changed-services-with-base:
+  check-changes-with-release-tag:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit != '' }}
     uses: ./.github/workflows/get_affected_services.yaml
@@ -87,7 +87,7 @@ jobs:
   # Run this, if there's no tag yet.
   # Needs custom fetch depth for comparison to fit large history
   # Checkout depth of 0 means fetch everything
-  get-changed-services:
+  check-changes-without-release-tag:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit == '' }}
     uses: ./.github/workflows/get_affected_services.yaml
@@ -100,7 +100,7 @@ jobs:
   changed-services:
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [get-changed-services, get-changed-services-with-base]
+    needs: [check-changes-with-release-tag, check-changes-without-release-tag]
     outputs:
       services: ${{ steps.prepare-output.outputs.services }}
 
@@ -109,17 +109,20 @@ jobs:
       - name: Prepare output
         id: prepare-output
         run: |
-          if ${{ needs.get-changed-services.outputs.services != '' }}
+          if ${{ needs.check-changes-with-release-tag.outputs.services != '' }}
           then
-            echo "services=${{ toJSON(needs.get-changed-services.outputs.services) }}" >> $GITHUB_OUTPUT
+            echo "services=${{ toJSON(needs.check-changes-with-release-tag.outputs.services) }}" >> $GITHUB_OUTPUT
           else
-            echo "services=${{ toJSON(needs.get-changed-services-with-base.outputs.services) }}" >> $GITHUB_OUTPUT
+            echo "services=${{ toJSON(needs.check-changes-without-release-tag.outputs.services) }}" >> $GITHUB_OUTPUT
           fi
 
   push-to-docker:
     runs-on: ubuntu-latest
     needs: changed-services
-    if: ${{ needs.changed-services.outputs.services != '' }}
+    # Job failure propagates downwards through the job graph
+    # As one of the check-changes-* jobs has to fail, the failure state needs to be
+    # explicitly ignored adding the always condition to the existing check
+    if: ${{ needs.changed-services.outputs.services != '' && always() }}
     strategy:
       matrix:
         service: ${{ fromJson(needs.changed-services.outputs.services) }}

--- a/.github/workflows/ci_docker.yaml
+++ b/.github/workflows/ci_docker.yaml
@@ -45,17 +45,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Get commit hash for previous release tag from git history
+      # As we are running this on publish, a new tag for the current release is already
+      # created
       - name: Get latest tag preceding this release
         id: get-release-tag
         run: |
+          # get the two latest tags
           tags=$(git tag | sort --sort=version | tail -n 2)
+          # check if there are actually two
           if [ $(echo "$tags" | wc -l) -eq 2 ]
           then
+            # get commit hash for tag and write to output
             tag=$(echo "$tags" | head -n1)
             commit=$(git rev-parse "$tag"^{commit})
             echo "commit=$commit" >> $GITHUB_OUTPUT
           fi
 
+      # If there is no previous tag, some variables need to be set up
+      # base_sha is the first commit to the repo - awk is used to just print the
+      # first column of the output which is the short form hash)
+      # fetch_depth is set up as number of all commits on the branch
       - name: Set up needed variables
         id: setup-variables
         if: ${{ steps.get-release-tag.outputs.commit == '' }}
@@ -63,7 +73,10 @@ jobs:
           echo "base_sha=$(git log --oneline | tail -n1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "fetch_depth_compare=$(git log --oneline | wc -l)" >> $GITHUB_OUTPUT
 
-
+  #
+  # Run this if we have a commit hash for a tag
+  # We assume there is not a large range of commits and we can go with the default
+  # fetch depth here
   get-changed-services-with-base:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit != '' }}
@@ -71,6 +84,9 @@ jobs:
     with:
       base_sha: ${{ needs.get-tag.outputs.commit }}
 
+  # Run this, if there's no tag yet.
+  # Needs custom fetch depth for comparison to fit large history
+  # Checkout depth of 0 means fetch everything
   get-changed-services:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit == '' }}
@@ -88,6 +104,7 @@ jobs:
     outputs:
       services: ${{ steps.prepare-output.outputs.services }}
 
+    # Bundle output into one variable depending on chosen branch
     steps:
       - name: Prepare output
         id: prepare-output

--- a/.github/workflows/ci_docker.yaml
+++ b/.github/workflows/ci_docker.yaml
@@ -36,34 +36,49 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       commit: ${{ steps.get-release-tag.outputs.commit }}
+      base_sha: ${{ steps.setup-variables.outputs.base_sha }}
+      fetch_depth_compare: ${{ steps.setup-variables.outputs.fetch_depth_compare }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Get latest tag preceding this release
         id: get-release-tag
         run: |
           tags=$(git tag | sort --sort=version | tail -n 2)
-          if [[ $(echo $tags | wc -l) == 2 ]]
+          if [ $(echo "$tags" | wc -l) -eq 2 ]
           then
-            $tag=$(echo $tags | head -n1)
-            $commit=$(git rev-parse "$tag"^{commit})
+            tag=$(echo "$tags" | head -n1)
+            commit=$(git rev-parse "$tag"^{commit})
             echo "commit=$commit" >> $GITHUB_OUTPUT
-          else
-            echo "commit=" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up needed variables
+        id: setup-variables
+        if: ${{ steps.get-release-tag.outputs.commit == '' }}
+        run: |
+          echo "base_sha=$(git log --oneline | tail -n1 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "fetch_depth_compare=$(git log --oneline | wc -l)" >> $GITHUB_OUTPUT
+
 
   get-changed-services-with-base:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit != '' }}
     uses: ./.github/workflows/get_affected_services.yaml
     with:
-      base-sha: ${{ needs.get-tag.outputs.commit }}
+      base_sha: ${{ needs.get-tag.outputs.commit }}
 
   get-changed-services:
     needs: get-tag
     if: ${{ needs.get-tag.outputs.commit == '' }}
     uses: ./.github/workflows/get_affected_services.yaml
     with:
-      base-sha: $(git log --oneline | tail -n1 | awk '{print $1}')
+      base_sha: ${{ needs.get-tag.outputs.base_sha }}
+      fetch_depth_checkout: 0
+      fetch_depth_compare: ${{ needs.get-tag.outputs.fetch_depth_compare }}
 
 
   changed-services:
@@ -79,15 +94,15 @@ jobs:
         run: |
           if ${{ needs.get-changed-services.outputs.services != '' }}
           then
-            echo "services=${{ needs.get-changed-services.outputs.services }}" >> $GITHUB_OUTPUT
+            echo "services=${{ toJSON(needs.get-changed-services.outputs.services) }}" >> $GITHUB_OUTPUT
           else
-            echo "services=${{ needs.get-changed-services-with-base.outputs.services }}" >> $GITHUB_OUTPUT
+            echo "services=${{ toJSON(needs.get-changed-services-with-base.outputs.services) }}" >> $GITHUB_OUTPUT
           fi
 
   push-to-docker:
     runs-on: ubuntu-latest
+    needs: changed-services
     if: ${{ needs.changed-services.outputs.services != '' }}
-    needs: get-changed-services
     strategy:
       matrix:
         service: ${{ fromJson(needs.changed-services.outputs.services) }}

--- a/.github/workflows/ci_docker.yaml
+++ b/.github/workflows/ci_docker.yaml
@@ -16,9 +16,8 @@
 name: "Push to docker on new commit to main"
 
 on:
-  push:
-    branches:
-      - main
+  release:
+      types: [published]
 
 env:
   DOCKERHUB_NAMESPACE: ghga
@@ -34,7 +33,31 @@ env:
 
 jobs:
   get-changed-services:
-    uses: ./.github/workflows/get_affected_services.yaml
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest tag preceding this release
+        id: get-release-tag
+        run: |
+          tags=$(git tag | sort --sort=version | tail -n 2)
+          if [[ $(echo $tags | wc -l) == 2 ]]
+          then
+             echo "version=$(echo $tags head -n 1)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get affected services since ${{ steps.get-release-tag.outputs.version }}
+        id: get-affected-services-with-base
+        if: ${{ steps.get-release-tag.outputs.version != '' }}
+        uses: ./.github/workflows/get_affected_services.yaml
+        with:
+          base-sha: ${{ steps.get-release-tag.outputs.version }}
+
+      - name: Get affected services since inception
+        id: get-affected-services
+        if: ${{ steps.get-release-tag.outputs.version == '' }}
+        uses: ./.github/workflows/get_affected_services.yaml
+        with:
+          base-sha: $(git log --oneline | tail -n1 | awk '{print $1}')
 
   push-to-docker:
     runs-on: ubuntu-latest
@@ -49,7 +72,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         id: setup-python

--- a/.github/workflows/get_affected_services.yaml
+++ b/.github/workflows/get_affected_services.yaml
@@ -3,8 +3,13 @@ name: Get services affected by changes
 on:
   workflow_call:
     inputs:
-      fetch-depth:
-        description: "Number of commits to fetch for comparison on initial checkout"
+      fetch_depth_checkout:
+        description: "Number of commits to fetch on initial checkout"
+        required: true
+        type: number
+        default: 2
+      fetch_depth_compare:
+        description: "Number of commits to fetch for comparison"
         required: true
         type: number
         default: 2
@@ -27,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ inputs.fetch-depth }}
+          fetch-depth: ${{ inputs.fetch_depth_checkout }}
 
       - name: Set up Python 3.12
         id: setup-python
@@ -35,19 +40,28 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Changed Files
-        id: changed-files
-        if: ${{ inputs.base_sha == '' }}
-        uses: tj-actions/changed-files@v44
-
-
       - name: Changed Files since ${{ inputs.base_sha }}
         id: changed-files
         if: ${{ inputs.base_sha != '' }}
         uses: tj-actions/changed-files@v44
         with:
           base_sha: ${{ inputs.base_sha }}
+          fetch_depth: ${{ inputs.fetch_depth_compare }}
 
+      - name: Changed Files since last commit
+        id: changed-files-no-base
+        if: ${{ inputs.base_sha == '' }}
+        uses: tj-actions/changed-files@v44
+
+      - name: Collect changed files
+        id: collect-changed-files
+        run: |
+          if ${{ steps.changed-files.outputs.all_changed_files != '' }}
+          then
+            echo "changed=${{ steps.changed-files.outputs.all_changed_files }}" >> $GITHUB_OUTPUT
+          else
+            echo "changed=${{ steps.changed-files-no-base.outputs.all_changed_files }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install Typer to check changed services
         id: install-typer
@@ -56,4 +70,4 @@ jobs:
       - name: Generate list of changed services
         id: services-changed
         run: |
-          echo "affected=$(python3 ./scripts/get_affected_services.py ${{ steps.changed-files.outputs.all_changed_files }} )" >> $GITHUB_OUTPUT
+          echo "affected=$(python3 ./scripts/get_affected_services.py ${{ steps.collect-changed-files.outputs.changed }} )" >> $GITHUB_OUTPUT

--- a/.github/workflows/get_affected_services.yaml
+++ b/.github/workflows/get_affected_services.yaml
@@ -2,6 +2,16 @@ name: Get services affected by changes
 
 on:
   workflow_call:
+    inputs:
+      fetch-depth:
+        description: "Number of commits to fetch for comparison on initial checkout"
+        required: true
+        type: number
+        default: 2
+      base_sha:
+        description: "Optional base commit for comparison"
+        required: false
+        type: string
     outputs:
       services:
         description: "Services affected by changes since last commit"
@@ -17,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Set up Python 3.12
         id: setup-python
@@ -27,7 +37,17 @@ jobs:
 
       - name: Changed Files
         id: changed-files
+        if: ${{ inputs.base_sha == '' }}
         uses: tj-actions/changed-files@v44
+
+
+      - name: Changed Files since ${{ inputs.base_sha }}
+        id: changed-files
+        if: ${{ inputs.base_sha != '' }}
+        uses: tj-actions/changed-files@v44
+        with:
+          base_sha: ${{ inputs.base_sha }}
+
 
       - name: Install Typer to check changed services
         id: install-typer

--- a/.github/workflows/get_affected_services.yaml
+++ b/.github/workflows/get_affected_services.yaml
@@ -38,6 +38,10 @@ jobs:
         with:
           python-version: 3.12
 
+      # Handle comparison with explicit commit range
+      # base_sha is the commit hash of the commit where comparison starts
+      # fetch_depth corresponds to the length of the commit history, by default 25
+      # The change action retries up to 20 times, but better to be explicit here
       - name: Changed Files since ${{ inputs.base_sha }}
         id: changed-files
         if: ${{ inputs.base_sha != '' }}
@@ -46,11 +50,16 @@ jobs:
           base_sha: ${{ inputs.base_sha }}
           fetch_depth: ${{ inputs.fetch_depth_compare }}
 
+      # Handle comparison with no explicit commit range
+      # This is the case, when we only want to have the changes from the last commit
       - name: Changed Files since last commit
         id: changed-files-no-base
         if: ${{ inputs.base_sha == '' }}
         uses: tj-actions/changed-files@v44
 
+      # Combine results from last steps into one output
+      # As they are run conditionally, this just forwards the chosen action output to
+      # be available under the same name for the last output step
       - name: Collect changed files
         id: collect-changed-files
         run: |

--- a/.github/workflows/get_affected_services.yaml
+++ b/.github/workflows/get_affected_services.yaml
@@ -5,12 +5,10 @@ on:
     inputs:
       fetch_depth_checkout:
         description: "Number of commits to fetch on initial checkout"
-        required: true
         type: number
         default: 2
       fetch_depth_compare:
         description: "Number of commits to fetch for comparison"
-        required: true
         type: number
         default: 2
       base_sha:


### PR DESCRIPTION
This PR changes the behaviour of the docker-ci workflow and adds new input variables to the get-affected-services workflow.
A distinction betwee fetch-depths has been made between the checkout and compare action, as the documentation for the latter one was lacking in respect to its behaviour when passing 0, so an explicit value is passed instead.

Two cases need to be distinguished on release: 
We already have a previous tag or we don't.

For the first case, comparison is made based on the commit corresponding to the tag representing the previous release.
If no tag exists, the first commit to the repo is used as comparison base instead and needs a sufficiently large fetch depth, so this one is also explicitly set.

I could not verify if the actual publish job works locally, so we will have to see once we do a repo release.