### PR TITLE
Check for empty array in workflow strategy input

### DIFF
--- a/.github/workflows/check_config_docs.yaml
+++ b/.github/workflows/check_config_docs.yaml
@@ -18,7 +18,7 @@ jobs:
   check-config:
     name: Check config schema and example
     needs: get-changed-services
-    if: ${{ needs.get-changed-services.outputs.services != '' }}
+    if: ${{ needs.get-changed-services.outputs.services != '' && needs.get-changed-services.outputs.services != '[]' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check_openapi_specs.yaml
+++ b/.github/workflows/check_openapi_specs.yaml
@@ -19,7 +19,7 @@ jobs:
   check-openapi-specs:
     name: Check config schema and example
     needs: get-changed-services
-    if: ${{ needs.get-changed-services.outputs.services != '' }}
+    if: ${{ needs.get-changed-services.outputs.services != '' && needs.get-changed-services.outputs.services != '[]' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check_readmes.yaml
+++ b/.github/workflows/check_readmes.yaml
@@ -42,7 +42,7 @@ jobs:
   check-service-readme:
     name: Check README file for ${{matrix.service}}
     needs: get-changed-services
-    if: ${{ needs.get-changed-services.outputs.services != '' }}
+    if: ${{ needs.get-changed-services.outputs.services != '' && needs.get-changed-services.outputs.services != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -29,7 +29,7 @@ jobs:
   push-to-docker:
     runs-on: ubuntu-latest
     needs: changed-services
-    if: ${{ needs.changed-services.outputs.services != '' }}
+    if: ${{ needs.changed-services.outputs.services != '' && needs.changed-services.outputs.services != '[]' }}
     strategy:
       matrix:
         service: ${{ fromJson(needs.changed-services.outputs.services) }}

--- a/.github/workflows/docker_on_release.yaml
+++ b/.github/workflows/docker_on_release.yaml
@@ -122,7 +122,7 @@ jobs:
     # Job failure propagates downwards through the job graph
     # As one of the check-changes-* jobs has to fail, the failure state needs to be
     # explicitly ignored adding the always condition to the existing check
-    if: ${{ needs.changed-services.outputs.services != '' && always() }}
+    if: ${{ needs.changed-services.outputs.services != '' && needs.changed-services.outputs.services != '[]' && always() }}
     strategy:
       matrix:
         service: ${{ fromJson(needs.changed-services.outputs.services) }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
   test:
     needs: get-changed-services
-    if: ${{ needs.get-changed-services.outputs.services != '' }}
+    if: ${{ needs.get-changed-services.outputs.services != '' && needs.get-changed-services.outputs.services != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
If condition dealt with the totally broken case so far, but did not catch the legitimate empty array when no services were affected.