### PR TITLE
Idempotency guards

### DIFF
--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:4.0.1
+docker pull ghga/file-ingest-service:5.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:4.0.1 .
+docker build -t ghga/file-ingest-service:5.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:4.0.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:5.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -159,6 +159,10 @@ paths:
               schema: {}
           description: Received and stored secret successfully.
         '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
           description: Either the payload is malformed or could not be decrypted.
       security:
       - HTTPBearer: []
@@ -199,6 +203,10 @@ paths:
         '409':
           description: Metadata for the given file ID has already been processed.
         '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
           description: Either the payload is malformed or could not be decrypted.
       security:
       - HTTPBearer: []

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -105,7 +105,7 @@ components:
       scheme: bearer
       type: http
 info:
-  description: A service to ingest s3 file upload metadata produced by thedata-steward-kit
+  description: A service to ingest s3 file upload metadata produced by the data-steward-kit
     upload command
   title: File Ingest Service
   version: 4.0.1
@@ -127,6 +127,8 @@ paths:
             application/json:
               schema: {}
           description: Received and decrypted data successfully.
+        '409':
+          description: Metadata for the given file ID has already been processed.
         '422':
           content:
             application/json:
@@ -198,6 +200,8 @@ paths:
             application/json:
               schema: {}
           description: Received and decrypted data successfully.
+        '409':
+          description: Metadata for the given file ID has already been processed.
         '422':
           content:
             application/json:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -108,7 +108,7 @@ info:
   description: A service to ingest s3 file upload metadata produced by the data-steward-kit
     upload command
   title: File Ingest Service
-  version: 4.0.1
+  version: 5.0.0
 openapi: 3.1.0
 paths:
   /federated/ingest_metadata:
@@ -159,11 +159,7 @@ paths:
               schema: {}
           description: Received and stored secret successfully.
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+          description: Either the payload is malformed or could not be decrypted.
       security:
       - HTTPBearer: []
       summary: Store file encryption/decryption secret and return secret ID.
@@ -203,11 +199,7 @@ paths:
         '409':
           description: Metadata for the given file ID has already been processed.
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+          description: Either the payload is malformed or could not be decrypted.
       security:
       - HTTPBearer: []
       summary: Processes encrypted output data from the S3 upload script and ingests

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "4.0.1"
+version = "5.0.0"
 description = "File Ingest Service - A lightweight service to propagate file upload metadata to the GHGA file backend services"
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/adapters/inbound/fastapi_/configure.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/configure.py
@@ -33,7 +33,7 @@ def get_openapi_schema(api) -> dict[str, Any]:
     return get_openapi(
         title="File Ingest Service",
         version=__version__,
-        description="A service to ingest s3 file upload metadata produced by the"
+        description="A service to ingest s3 file upload metadata produced by the "
         + "data-steward-kit upload command",
         tags=[{"name": "FileIngestService"}],
         routes=api.routes,

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -67,6 +67,11 @@ async def ingest_legacy_metadata(
     except (DecryptionError, WrongDecryptedFormatError) as error:
         raise HTTPException(status_code=422, detail=str(error)) from error
 
+    if await upload_metadata_processor.has_already_been_processed(
+        file_id=decrypted_metadata.file_id
+    ):
+        return Response(status_code=202)
+
     file_secret = decrypted_metadata.file_secret
 
     try:
@@ -100,9 +105,13 @@ async def ingest_metadata(
     """Process metadata, file secret id and send success event"""
     secret_id = payload.secret_id
 
-    await upload_metadata_processor.populate_by_event(
-        upload_metadata=payload, secret_id=secret_id
-    )
+    if not await upload_metadata_processor.has_already_been_processed(
+        file_id=payload.file_id
+    ):
+        await upload_metadata_processor.populate_by_event(
+            upload_metadata=payload, secret_id=secret_id
+        )
+
     return Response(status_code=202)
 
 
@@ -120,9 +129,12 @@ async def ingest_secret(
     _token: Annotated[IngestTokenAuthContext, require_token],
 ):
     """Decrypt payload and deposit file secret in exchange for a secret id"""
-    file_secret = await upload_metadata_processor.decrypt_secret(
-        encrypted=encrypted_payload
-    )
+    try:
+        file_secret = await upload_metadata_processor.decrypt_secret(
+            encrypted=encrypted_payload
+        )
+    except DecryptionError as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
 
     secret_id = await upload_metadata_processor.store_secret(file_secret=file_secret)
     return {"secret_id": secret_id}

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -54,6 +54,11 @@ async def health():
     status_code=status.HTTP_202_ACCEPTED,
     response_description="Received and decrypted data successfully.",
     deprecated=True,
+    responses={
+        status.HTTP_409_CONFLICT: {
+            "description": "Metadata for the given file ID has already been processed."
+        }
+    },
 )
 async def ingest_legacy_metadata(
     encrypted_payload: EncryptedPayload,
@@ -101,6 +106,11 @@ async def ingest_legacy_metadata(
     tags=["FileIngestService"],
     status_code=status.HTTP_202_ACCEPTED,
     response_description="Received and decrypted data successfully.",
+    responses={
+        status.HTTP_409_CONFLICT: {
+            "description": "Metadata for the given file ID has already been processed."
+        }
+    },
 )
 async def ingest_metadata(
     payload: UploadMetadata,

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -70,7 +70,7 @@ async def ingest_legacy_metadata(
     if await upload_metadata_processor.has_already_been_processed(
         file_id=decrypted_metadata.file_id
     ):
-        return Response(status_code=202)
+        return Response(status_code=204)
 
     file_secret = decrypted_metadata.file_secret
 
@@ -105,12 +105,14 @@ async def ingest_metadata(
     """Process metadata, file secret id and send success event"""
     secret_id = payload.secret_id
 
-    if not await upload_metadata_processor.has_already_been_processed(
+    if await upload_metadata_processor.has_already_been_processed(
         file_id=payload.file_id
     ):
-        await upload_metadata_processor.populate_by_event(
-            upload_metadata=payload, secret_id=secret_id
-        )
+        return Response(status_code=204)
+
+    await upload_metadata_processor.populate_by_event(
+        upload_metadata=payload, secret_id=secret_id
+    )
 
     return Response(status_code=202)
 

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -59,7 +59,12 @@ async def health():
             "description": "Metadata for the given file ID has already been processed."
         },
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
-            "description": "Either the payload is malformed or could not be decrypted."
+            "description": "Either the payload is malformed or could not be decrypted.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                }
+            },
         },
     },
 )
@@ -147,8 +152,13 @@ async def ingest_metadata(
     response_description="Received and stored secret successfully.",
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
-            "description": "Either the payload is malformed or could not be decrypted."
-        }
+            "description": "Either the payload is malformed or could not be decrypted.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                }
+            },
+        },
     },
 )
 async def ingest_secret(

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -57,7 +57,10 @@ async def health():
     responses={
         status.HTTP_409_CONFLICT: {
             "description": "Metadata for the given file ID has already been processed."
-        }
+        },
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "Either the payload is malformed or could not be decrypted."
+        },
     },
 )
 async def ingest_legacy_metadata(
@@ -142,6 +145,11 @@ async def ingest_metadata(
     tags=["FileIngestService"],
     status_code=status.HTTP_200_OK,
     response_description="Received and stored secret successfully.",
+    responses={
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "Either the payload is malformed or could not be decrypted."
+        }
+    },
 )
 async def ingest_secret(
     encrypted_payload: EncryptedPayload,

--- a/services/fis/src/fis/adapters/outbound/vault/client.py
+++ b/services/fis/src/fis/adapters/outbound/vault/client.py
@@ -131,7 +131,7 @@ class VaultAdapter(VaultAdapterPort):
                 role_id=self._role_id, secret_id=self._secret_id
             )
 
-    def store_secret(self, *, secret: str) -> str:
+    def store_secret(self, *, secret: SecretStr) -> str:
         """
         Store a secret under a subpath of the given prefix.
         Generates a UUID4 as key, uses it for the subpath and returns it.
@@ -144,7 +144,7 @@ class VaultAdapter(VaultAdapterPort):
             # set cas to 0 as we only want a static secret
             self._client.secrets.kv.v2.create_or_update_secret(
                 path=f"{self._path}/{key}",
-                secret={key: secret},
+                secret={key: secret.get_secret_value()},
                 cas=0,
                 mount_point=self._secrets_mount_point,
             )

--- a/services/fis/src/fis/core/models.py
+++ b/services/fis/src/fis/core/models.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Models for internal representation"""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class EncryptedPayload(BaseModel):
@@ -46,7 +46,7 @@ class UploadMetadataBase(BaseModel):
 class LegacyUploadMetadata(UploadMetadataBase):
     """Legacy model including file encryption/decryption secret"""
 
-    file_secret: str
+    file_secret: SecretStr
 
 
 class UploadMetadata(UploadMetadataBase):

--- a/services/fis/src/fis/ports/inbound/ingest.py
+++ b/services/fis/src/fis/ports/inbound/ingest.py
@@ -54,6 +54,11 @@ class LegacyUploadMetadataProcessorPort(ABC):
         ...
 
     @abstractmethod
+    async def has_already_been_processed(self, *, file_id: str) -> bool:
+        """Check if file metadata has already been seen and successfully processed."""
+        ...
+
+    @abstractmethod
     async def populate_by_event(
         self, *, upload_metadata: models.LegacyUploadMetadata, secret_id: str
     ):
@@ -72,6 +77,11 @@ class UploadMetadataProcessorPort(ABC):
     @abstractmethod
     async def decrypt_secret(self, *, encrypted: models.EncryptedPayload) -> str:
         """Decrypt file secret payload"""
+        ...
+
+    @abstractmethod
+    async def has_already_been_processed(self, *, file_id: str) -> bool:
+        """Check if file metadata has already been seen and successfully processed."""
         ...
 
     @abstractmethod

--- a/services/fis/src/fis/ports/inbound/ingest.py
+++ b/services/fis/src/fis/ports/inbound/ingest.py
@@ -16,6 +16,8 @@
 
 from abc import ABC, abstractmethod
 
+from pydantic import SecretStr
+
 from fis.core import models
 
 
@@ -66,7 +68,7 @@ class LegacyUploadMetadataProcessorPort(ABC):
         ...
 
     @abstractmethod
-    async def store_secret(self, *, file_secret: str) -> str:
+    async def store_secret(self, *, file_secret: SecretStr) -> str:
         """Communicate with HashiCorp Vault to store file secret and get secret ID"""
         ...
 
@@ -75,7 +77,7 @@ class UploadMetadataProcessorPort(ABC):
     """Port for S3 upload metadata processor"""
 
     @abstractmethod
-    async def decrypt_secret(self, *, encrypted: models.EncryptedPayload) -> str:
+    async def decrypt_secret(self, *, encrypted: models.EncryptedPayload) -> SecretStr:
         """Decrypt file secret payload"""
         ...
 
@@ -92,6 +94,6 @@ class UploadMetadataProcessorPort(ABC):
         ...
 
     @abstractmethod
-    async def store_secret(self, *, file_secret: str) -> str:
+    async def store_secret(self, *, file_secret: SecretStr) -> str:
         """Communicate with HashiCorp Vault to store file secret and get secret ID"""
         ...

--- a/services/fis/src/fis/ports/outbound/vault/client.py
+++ b/services/fis/src/fis/ports/outbound/vault/client.py
@@ -16,6 +16,8 @@
 
 from abc import ABC, abstractmethod
 
+from pydantic import SecretStr
+
 
 class VaultAdapterPort(ABC):
     """Port for vault adapter"""
@@ -24,7 +26,7 @@ class VaultAdapterPort(ABC):
         """Wrapper for errors encountered on secret insertion"""
 
     @abstractmethod
-    def store_secret(self, *, secret: str) -> str:
+    def store_secret(self, *, secret: SecretStr) -> str:
         """
         Store a secret under a subpath of the given prefix.
         Generates a UUID4 as key, uses it for the subpath and returns it.

--- a/services/fis/tests_fis/test_api_call.py
+++ b/services/fis/tests_fis/test_api_call.py
@@ -150,7 +150,10 @@ async def test_api_calls(monkeypatch, joint_fixture: JointFixture):
             headers=headers,
         )
 
-    assert response.status_code == 204
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": f"Metadata for file {TEST_PAYLOAD.file_id} has already been processed."
+    }
     assert len(event_recorder.recorded_events) == 0
 
     # test missing authorization
@@ -250,7 +253,10 @@ async def test_legacy_api_calls(monkeypatch, joint_fixture: JointFixture):
             json=encrypted_payload.model_dump(),
             headers=headers,
         )
-    assert response.status_code == 204
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": f"Metadata for file {TEST_PAYLOAD.file_id} has already been processed."
+    }
     assert len(event_recorder.recorded_events) == 0
 
     # test missing authorization

--- a/services/fis/tests_fis/test_ingest.py
+++ b/services/fis/tests_fis/test_ingest.py
@@ -79,7 +79,7 @@ async def test_legacy_decryption_sad(joint_fixture: JointFixture):
 
     payload = LegacyUploadMetadata(
         **TEST_PAYLOAD.model_dump(),
-        file_secret=base64.b64encode(os.urandom(32)).decode("utf-8"),  # type: ignore
+        file_secret=base64.b64encode(os.urandom(32)).decode("utf-8"),
     )
 
     encrypted_payload = EncryptedPayload(

--- a/services/fis/tests_fis/test_ingest.py
+++ b/services/fis/tests_fis/test_ingest.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.asyncio()
 
 async def test_legacy_decryption_happy(joint_fixture: JointFixture):
     """Test decryption with valid keypair and correct file upload metadata format."""
-    # Can't use the LegacyUploadMetadata directly, as dump_json will obfuscate the secret
+    # Can't use LegacyUploadMetadata directly, as dump_json will obfuscate the secret
     file_secret = base64.b64encode(os.urandom(32)).decode("utf-8")
     payload = TEST_PAYLOAD.model_dump()
     payload["file_secret"] = file_secret


### PR DESCRIPTION
This PR adds two simple lookups to the File Ingest Service, one for each ingest endpoint to abort any further processing if the file ID has already been processed.

As the entry in the outbox DAO is only created once everything else is done, we can reasonably assume that the presence of a corresponding entry means the ingest of a specific file has succeeded previously - at least inside the FIS.
This will still produce additional new secret entries in vault for the legacy path if something should crash before an entry is created, but the information is only propagated once in this case.

Also, decided to return to 202 for the no-op as well, as we don't need to distinguish between the new and already seen case on the client side and this would require a small change to the DS-Kit if we go with any other status code.