### PR TITLE
Specify missing property in GitHub action

### DIFF
--- a/.github/workflows/push_to_docker/action.yaml
+++ b/.github/workflows/push_to_docker/action.yaml
@@ -51,10 +51,12 @@ runs:
 
     - name: Symlink requirement files
       id: symlink-requirements
+      shell: bash
       run: cp -r lock services/${{ inputs.service }}/lock
 
     - name: Prepare Dockerfile
       id: prepare-dockerfile
+      shell: bash
       run: cp Dockerfile services/${{ inputs.service }}/ && sed -i "s/\(ENTRYPOINT \)\[\]/\1[\"${{ inputs.service }}\"]/" services/${{ inputs.service }}/Dockerfile
 
     - uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
This PR adds missing property to the GitHub action template. 

The failing action run: [Required property is missing: shell](https://github.com/ghga-de/file-services-backend/actions/runs/11839884234/job/32992461894)


Apparently when using composite actions we have to specify the shell in each step. Related documentation: https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action#creating-an-action-metadata-file