### PR TITLE
Fix trivy in GitHub action

### DIFF
--- a/.github/workflows/push_to_docker/action.yaml
+++ b/.github/workflows/push_to_docker/action.yaml
@@ -82,6 +82,8 @@ runs:
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
+      env:
+        TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
       with:
         image-ref: "docker.io/${{ inputs.tag }}"
         format: "table"


### PR DESCRIPTION
There are these discussions about the issue: https://github.com/aquasecurity/trivy/discussions/7668 and https://github.com/aquasecurity/trivy-action/issues/389

There is a PR in progress for this still open https://github.com/aquasecurity/trivy-action/pull/433

People mention a workaround to specify alternative DB. https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10879681 It seems like if you specify multiple DB repositories Trivy retries the next one if the primary repository fails. There are three repositories for Trivy DB and they are updated every 6 hours together.