### PR TITLE
IFRS - Improve file staging error handling (GSI-1190)

### DIFF
--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:2.1.1
+docker pull ghga/internal-file-registry-service:2.1.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:2.1.1 .
+docker build -t ghga/internal-file-registry-service:2.1.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:2.1.1 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:2.1.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "2.1.1"
+version = "2.1.2"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/core/file_registry.py
+++ b/services/ifrs/src/ifrs/core/file_registry.py
@@ -220,15 +220,7 @@ class FileRegistry(FileRegistryPort):
             file.storage_alias
         )
 
-        if await object_storage.does_object_exist(
-            bucket_id=outbox_bucket_id, object_id=outbox_object_id
-        ):
-            # the content is already where it should go, there is nothing to do
-            log.info(
-                "Object corresponding to file ID '%s' is already in storage.", file_id
-            )
-            return
-
+        # Make sure the file exists in permanent storage before trying to copy it
         if not await object_storage.does_object_exist(
             bucket_id=permanent_bucket_id, object_id=file.object_id
         ):

--- a/services/ifrs/src/ifrs/core/file_registry.py
+++ b/services/ifrs/src/ifrs/core/file_registry.py
@@ -193,7 +193,7 @@ class FileRegistry(FileRegistryPort):
                 the permanent storage. This is an internal service error, which should
                 not happen, and not the fault of the client.
             self.CopyOperationError:
-                When
+                When an error occurs while attempting to copy the object to the outbox.
         """
         try:
             file = await self._file_metadata_dao.get_by_id(file_id)

--- a/services/ifrs/src/ifrs/ports/inbound/file_registry.py
+++ b/services/ifrs/src/ifrs/ports/inbound/file_registry.py
@@ -92,12 +92,12 @@ class FileRegistryPort(ABC):
             super().__init__(message)
 
     class CopyOperationError(FatalError):
-        """Thrown if an unresolvable error occurs while staging a file to the outbox."""
+        """Thrown if an unresolvable error occurs while copying a file between buckets."""
 
-        def __init__(self, file_id: str, exc_text: str):
+        def __init__(self, file_id: str, dest_bucket_id: str, exc_text: str):
             message = (
-                f"Fatal error occurred while staging file with the ID '{file_id}'"
-                + f" to the outbox. The exception is: {exc_text}"
+                f"Fatal error occurred while copying file with the ID '{file_id}'"
+                + f" to the bucket '{dest_bucket_id}'. The exception is: {exc_text}"
             )
             super().__init__(message)
 

--- a/services/ifrs/src/ifrs/ports/inbound/file_registry.py
+++ b/services/ifrs/src/ifrs/ports/inbound/file_registry.py
@@ -91,6 +91,16 @@ class FileRegistryPort(ABC):
             )
             super().__init__(message)
 
+    class CopyOperationError(FatalError):
+        """Thrown if an unresolvable error occurs while staging a file to the outbox."""
+
+        def __init__(self, file_id: str, exc_text: str):
+            message = (
+                f"Fatal error occurred while staging file with the ID '{file_id}'"
+                + f" to the outbox. The exception is: {exc_text}"
+            )
+            super().__init__(message)
+
     @abstractmethod
     async def register_file(
         self,
@@ -146,6 +156,8 @@ class FileRegistryPort(ABC):
             self.FileInRegistryButNotInStorageError:
                 When encountering inconsistency between the registry (the database) and
                 the permanent storage. This a fatal error.
+            self.CopyOperationError:
+                When an error occurs while attempting to copy the object to the outbox.
         """
         ...
 

--- a/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
@@ -327,8 +327,9 @@ async def test_error_during_copy(joint_fixture: JointFixture, caplog):
     # Verify the log message exists
     assert caplog.records
     assert caplog.records[0].message == (
-        "Fatal error occurred while staging file with the ID 'examplefile001' to the"
-        + " outbox. The exception is: The bucket with ID 'outbox-bucket' does not exist."
+        "Fatal error occurred while copying file with the ID 'examplefile001' to the"
+        + " bucket 'outbox-bucket'. The exception is: The bucket with ID 'outbox-bucket'"
+        + " does not exist."
     )
 
     # Upload the file to the outbox bucket so we trigger ObjectAlreadyExistsError
@@ -347,7 +348,7 @@ async def test_error_during_copy(joint_fixture: JointFixture, caplog):
 
     assert caplog.records
     assert caplog.records[0].getMessage() == (
-        "Object corresponding to file ID 'examplefile001' is already in storage."
+        "Object corresponding to file ID 'examplefile001' is already in the outbox."
     )
 
 
@@ -384,5 +385,5 @@ async def test_copy_when_file_exists_in_outbox(joint_fixture: JointFixture, capl
     # Check the log
     assert caplog.records
     assert caplog.records[0].getMessage() == (
-        "Object corresponding to file ID 'examplefile001' is already in storage."
+        "Object corresponding to file ID 'examplefile001' is already in the outbox."
     )

--- a/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
@@ -26,6 +26,7 @@ from hexkit.providers.akafka.provider.daosub import CHANGE_EVENT_TYPE
 from hexkit.providers.s3.testutils import (
     FileObject,
     S3Fixture,  # noqa: F401
+    temp_file_object,
     tmp_file,  # noqa: F401
 )
 
@@ -276,7 +277,6 @@ async def test_storage_db_inconsistency(joint_fixture: JointFixture):
         ),
     ],
 )
-@pytest.mark.asyncio()
 async def test_outbox_subscriber_routing(
     joint_fixture: JointFixture,
     upsertion_event: JsonObject,
@@ -297,3 +297,92 @@ async def test_outbox_subscriber_routing(
 
     await joint_fixture.outbox_subscriber.run(forever=False)
     mock.assert_awaited_once()
+
+
+async def test_error_during_copy(joint_fixture: JointFixture, caplog):
+    """Errors during `object_storage.copy_object` should be logged without crashing."""
+    # Insert FileMetadata record into the DB
+    dao = joint_fixture.file_metadata_dao
+    await dao.insert(EXAMPLE_METADATA)
+
+    s3_alias = EXAMPLE_METADATA.storage_alias
+    source_bucket = joint_fixture.config.object_storages[s3_alias].bucket
+    outbox_bucket = "outbox-bucket"
+
+    # Upload a matching object to S3
+    with temp_file_object(source_bucket, EXAMPLE_METADATA.object_id) as file:
+        await joint_fixture.s3.populate_file_objects([file])
+
+    # Run the file-staging operation to encounter an error (outbox bucket doesn't exist)
+    caplog.clear()
+    caplog.set_level("CRITICAL")
+    with pytest.raises(joint_fixture.file_registry.CopyOperationError):
+        await joint_fixture.file_registry.stage_registered_file(
+            file_id=EXAMPLE_METADATA.file_id,
+            decrypted_sha256=EXAMPLE_METADATA.decrypted_sha256,
+            outbox_bucket_id=outbox_bucket,
+            outbox_object_id=EXAMPLE_METADATA.object_id,
+        )
+
+    # Verify the log message exists
+    assert caplog.records
+    assert caplog.records[0].message == (
+        "Fatal error occurred while staging file with the ID 'examplefile001' to the"
+        + " outbox. The exception is: The bucket with ID 'outbox-bucket' does not exist."
+    )
+
+    # Upload the file to the outbox bucket so we trigger ObjectAlreadyExistsError
+    with temp_file_object(outbox_bucket, EXAMPLE_METADATA.object_id) as file:
+        await joint_fixture.s3.populate_file_objects([file])
+
+    # Run the file-staging operation to encounter the error
+    caplog.clear()
+    caplog.set_level("INFO")
+    await joint_fixture.file_registry.stage_registered_file(
+        file_id=EXAMPLE_METADATA.file_id,
+        decrypted_sha256=EXAMPLE_METADATA.decrypted_sha256,
+        outbox_bucket_id=outbox_bucket,
+        outbox_object_id=EXAMPLE_METADATA.object_id,
+    )
+
+    assert caplog.records
+    assert caplog.records[0].getMessage() == (
+        "Object corresponding to file ID 'examplefile001' is already in storage."
+    )
+
+
+async def test_copy_when_file_exists_in_outbox(joint_fixture: JointFixture, caplog):
+    """Test that `FileRegistry.stage_registered_file` returns early if a copy is
+    unnecessary.
+    """
+    # Insert FileMetadata record into the DB
+    dao = joint_fixture.file_metadata_dao
+    await dao.insert(EXAMPLE_METADATA)
+
+    # Populate the source and dest buckets
+    s3_alias = EXAMPLE_METADATA.storage_alias
+    source_bucket = joint_fixture.config.object_storages[s3_alias].bucket
+    outbox_bucket = "outbox-bucket"
+    with temp_file_object(source_bucket, EXAMPLE_METADATA.object_id) as file:
+        await joint_fixture.s3.populate_file_objects([file])
+
+    with temp_file_object(outbox_bucket, EXAMPLE_METADATA.object_id) as file:
+        await joint_fixture.s3.populate_file_objects([file])
+
+    # Run the file-staging operation, which should return early (it will catch the
+    # error raised by the hexkit provider, which asserts that the file doesn't exist
+    # in the outbox)
+    caplog.clear()
+    caplog.set_level("INFO")
+    await joint_fixture.file_registry.stage_registered_file(
+        file_id=EXAMPLE_METADATA.file_id,
+        decrypted_sha256=EXAMPLE_METADATA.decrypted_sha256,
+        outbox_bucket_id=outbox_bucket,
+        outbox_object_id=EXAMPLE_METADATA.object_id,
+    )
+
+    # Check the log
+    assert caplog.records
+    assert caplog.records[0].getMessage() == (
+        "Object corresponding to file ID 'examplefile001' is already in storage."
+    )

--- a/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
@@ -300,7 +300,7 @@ async def test_outbox_subscriber_routing(
 
 
 async def test_error_during_copy(joint_fixture: JointFixture, caplog):
-    """Errors during `object_storage.copy_object` should be logged without crashing."""
+    """Errors during `object_storage.copy_object` should be logged and re-raised."""
     # Insert FileMetadata record into the DB
     dao = joint_fixture.file_metadata_dao
     await dao.insert(EXAMPLE_METADATA)


### PR DESCRIPTION
Bumps ifrs version to 2.1.2

The S3 provider in hexkit already checks to make sure the object doesn't exist in the destination bucket, so I removed the same check from the IFRS -- instead, it will catch the corresponding error, log, and return (same behavior as before).

The potential other errors, listed below, are all logged and re-raised:
- The object metadata is missing important info like ContentLength
- The object is over 5 TiB
- Miscellaneous errors in the boto3 copy/multipart upload operation itself
