### PR TITLE
Server keypair validators and decoding error handling

### DIFF
--- a/services/ekss/README.md
+++ b/services/ekss/README.md
@@ -65,13 +65,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/encryption-key-store-service):
 ```bash
-docker pull ghga/encryption-key-store-service:1.4.4
+docker pull ghga/encryption-key-store-service:1.5.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/encryption-key-store-service:1.4.4 .
+docker build -t ghga/encryption-key-store-service:1.5.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -79,7 +79,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/encryption-key-store-service:1.4.4 --help
+docker run -p 8080:8080 ghga/encryption-key-store-service:1.5.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ekss/openapi.yaml
+++ b/services/ekss/openapi.yaml
@@ -289,14 +289,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpDecodingError'
-          description: One of the inputs provided to the API could not be decoded
-            as base64 string.
+          description: One of the provided inputs could not be decoded as base64 string.
         '502':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpSecretInsertionError'
-          description: Failed to successfully inset secret into vault.
+          description: Failed to successfully insert secret into vault.
         '504':
           content:
             application/json:
@@ -373,8 +372,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpDecodingError'
-          description: One of the inputs provided to the API could not be decoded
-            as base64 string.
+          description: One of the provided inputs could not be decoded as base64 string.
       summary: Get personalized envelope containing Crypt4GH file encryption/decryption
         key
       tags:

--- a/services/ekss/openapi.yaml
+++ b/services/ekss/openapi.yaml
@@ -9,6 +9,31 @@ components:
           type: array
       title: HTTPValidationError
       type: object
+    HttpDecodingError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpDecodingErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: decodingError
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpDecodingError
+      type: object
+    HttpDecodingErrorData:
+      additionalProperties: true
+      properties: {}
+      title: HttpDecodingErrorData
+      type: object
     HttpEnvelopeDecryptionError:
       additionalProperties: false
       properties:
@@ -244,37 +269,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboundEnvelopeContent'
-          description: ''
+          description: Successfully created and stored secret for re-encryption.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpMalformedOrMissingEnvelopeError'
-          description: Bad Request
+          description: Crypt4GH header envelope is either missing or malformed in
+            the provided payload.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpEnvelopeDecryptionError'
-          description: Forbidden
+          description: Could not decrypt Crypt4GH header envelope with the given key
+            pair.
         '422':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+                $ref: '#/components/schemas/HttpDecodingError'
+          description: One of the inputs provided to the API could not be decoded
+            as base64 string.
         '502':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpSecretInsertionError'
-          description: Bad Gateway
+          description: Failed to successfully inset secret into vault.
         '504':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpVaultConnectionError'
-          description: Gateway Timeout
+          description: Failed to establish a connection to vault.
       summary: Extract file encryption/decryption secret and file content offset from
         enevelope
       tags:
@@ -293,13 +321,13 @@ paths:
           type: string
       responses:
         '204':
-          description: ''
+          description: Succesfully deleted secret.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpSecretNotFoundError'
-          description: Not Found
+          description: Could not find a secret for the given secret ID.
         '422':
           content:
             application/json:
@@ -333,19 +361,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OutboundEnvelopeContent'
-          description: ''
+          description: Created personalized Crypt4GH envelope.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpSecretNotFoundError'
-          description: Not Found
+          description: Could not find a secret for the given secret ID.
         '422':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+                $ref: '#/components/schemas/HttpDecodingError'
+          description: One of the inputs provided to the API could not be decoded
+            as base64 string.
       summary: Get personalized envelope containing Crypt4GH file encryption/decryption
         key
       tags:

--- a/services/ekss/openapi.yaml
+++ b/services/ekss/openapi.yaml
@@ -234,7 +234,7 @@ info:
   description: A service managing storage and retrieval of symmetric keys in a HashiCorp
     Vault.
   title: Encryption Key Store Service
-  version: 1.4.4
+  version: 1.5.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/ekss/pyproject.toml
+++ b/services/ekss/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ekss"
-version = "1.4.4"
+version = "1.5.0"
 description = "Encryption Key Store Service - providing crypt4gh file secret extraction, storage and envelope generation"
 readme = "README.md"
 authors = [

--- a/services/ekss/src/ekss/adapters/inbound/fastapi_/exceptions.py
+++ b/services/ekss/src/ekss/adapters/inbound/fastapi_/exceptions.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 
 class HttpMalformedOrMissingEnvelopeError(HttpCustomExceptionBase):
-    """Thrown when envelope decryption fails due to a missing or malformed envelope."""
+    """Raised when envelope decryption fails due to a missing or malformed envelope."""
 
     exception_id = "malformedOrMissingEnvelopeError"
 
@@ -36,7 +36,7 @@ class HttpMalformedOrMissingEnvelopeError(HttpCustomExceptionBase):
 
 
 class HttpEnvelopeDecryptionError(HttpCustomExceptionBase):
-    """Thrown when no available secret crypt4GH key can successfully decrypt the file envelope."""
+    """Raised when no available secret crypt4GH key can successfully decrypt the file envelope."""
 
     exception_id = "envelopeDecryptionError"
 
@@ -53,7 +53,7 @@ class HttpEnvelopeDecryptionError(HttpCustomExceptionBase):
 
 
 class HttpSecretInsertionError(HttpCustomExceptionBase):
-    """Thrown when a secret could not be inserted into the vault"""
+    """Raised when a secret could not be inserted into the vault"""
 
     exception_id = "secretInsertionError"
 
@@ -70,7 +70,7 @@ class HttpSecretInsertionError(HttpCustomExceptionBase):
 
 
 class HttpVaultConnectionError(HttpCustomExceptionBase):
-    """Thrown when the EKSS could not connect to the vault"""
+    """Raised when the EKSS could not connect to the vault"""
 
     exception_id = "vaultConnectionError"
 
@@ -87,7 +87,7 @@ class HttpVaultConnectionError(HttpCustomExceptionBase):
 
 
 class HttpSecretNotFoundError(HttpCustomExceptionBase):
-    """Thrown when no secret with the given id could be found"""
+    """Raised when no secret with the given id could be found"""
 
     exception_id = "secretNotFoundError"
 
@@ -99,5 +99,19 @@ class HttpSecretNotFoundError(HttpCustomExceptionBase):
         super().__init__(
             status_code=status_code,
             description="The secret for the given id was not found.",
+            data={},
+        )
+
+
+class HttpDecodingError(HttpCustomExceptionBase):
+    """Raised when a byte string could not be decoded using base64"""
+
+    exception_id = "decodingError"
+
+    def __init__(self, *, affected: str, status_code: int = 422):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=f"Could not decode the the given string as base64: {affected}",
             data={},
         )

--- a/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
+++ b/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
@@ -58,7 +58,7 @@ ERROR_RESPONSES = {
     },
     "decodingError": {
         "description": (
-            "One of the inputs provided to the API could not be decoded as base64 string."
+            "One of the provided inputs could not be decoded as base64 string."
         ),
         "model": exceptions.HttpDecodingError.get_body_model(),
     },

--- a/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
+++ b/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
@@ -33,24 +33,34 @@ from ekss.core.envelope_encryption import get_envelope
 router = APIRouter(tags=["EncryptionKeyStoreService"])
 ERROR_RESPONSES = {
     "malformedOrMissingEnvelope": {
-        "description": (""),
+        "description": (
+            "Crypt4GH header envelope is either missing or malformed in the provided payload."
+        ),
         "model": exceptions.HttpMalformedOrMissingEnvelopeError.get_body_model(),
     },
     "envelopeDecryptionError": {
-        "description": (""),
+        "description": (
+            "Could not decrypt Crypt4GH header envelope with the given key pair."
+        ),
         "model": exceptions.HttpEnvelopeDecryptionError.get_body_model(),
     },
     "secretInsertionError": {
-        "description": (""),
+        "description": ("Failed to successfully inset secret into vault."),
         "model": exceptions.HttpSecretInsertionError.get_body_model(),
     },
     "vaultConnectionError": {
-        "description": (""),
+        "description": ("Failed to establish a connection to vault."),
         "model": exceptions.HttpVaultConnectionError.get_body_model(),
     },
     "secretNotFoundError": {
-        "description": (""),
+        "description": ("Could not find a secret for the given secret ID."),
         "model": exceptions.HttpSecretNotFoundError.get_body_model(),
+    },
+    "decodingError": {
+        "description": (
+            "One of the inputs provided to the API could not be decoded as base64 string."
+        ),
+        "model": exceptions.HttpDecodingError.get_body_model(),
     },
 }
 
@@ -71,10 +81,11 @@ async def health():
     operation_id="postEncryptionData",
     status_code=status.HTTP_200_OK,
     response_model=models.InboundEnvelopeContent,
-    response_description="",
+    response_description="Successfully created and stored secret for re-encryption.",
     responses={
         status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["malformedOrMissingEnvelope"],
         status.HTTP_403_FORBIDDEN: ERROR_RESPONSES["envelopeDecryptionError"],
+        status.HTTP_422_UNPROCESSABLE_ENTITY: ERROR_RESPONSES["decodingError"],
         status.HTTP_502_BAD_GATEWAY: ERROR_RESPONSES["secretInsertionError"],
         status.HTTP_504_GATEWAY_TIMEOUT: ERROR_RESPONSES["vaultConnectionError"],
     },
@@ -87,8 +98,16 @@ async def post_encryption_secrets(
     """Extract file encryption/decryption secret, create secret ID and extract
     file content offset
     """
-    client_pubkey = base64.b64decode(envelope_query.public_key)
-    file_part = base64.b64decode(envelope_query.file_part)
+    try:
+        client_pubkey = base64.b64decode(envelope_query.public_key)
+    except Exception as error:
+        raise exceptions.HttpDecodingError(affected="client public key") from error
+
+    try:
+        file_part = base64.b64decode(envelope_query.file_part)
+    except Exception as error:
+        raise exceptions.HttpDecodingError(affected="file part") from error
+
     try:
         submitter_secret, offset = await extract_envelope_content(
             file_part=file_part,
@@ -123,9 +142,10 @@ async def post_encryption_secrets(
     operation_id="getEncryptionData",
     status_code=status.HTTP_200_OK,
     response_model=models.OutboundEnvelopeContent,
-    response_description="",
+    response_description="Created personalized Crypt4GH envelope.",
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["secretNotFoundError"],
+        status.HTTP_422_UNPROCESSABLE_ENTITY: ERROR_RESPONSES["decodingError"],
     },
 )
 async def get_header_envelope(
@@ -133,10 +153,12 @@ async def get_header_envelope(
 ):
     """Create header envelope for the file secret with given ID encrypted with a given public key"""
     try:
+        client_pubkey = base64.urlsafe_b64decode(client_pk)
+    except Exception as error:
+        raise exceptions.HttpDecodingError(affected="client public key") from error
+    try:
         header_envelope = await get_envelope(
-            secret_id=secret_id,
-            client_pubkey=base64.urlsafe_b64decode(client_pk),
-            vault=vault,
+            secret_id=secret_id, client_pubkey=client_pubkey, vault=vault
         )
     except SecretRetrievalError as error:
         raise exceptions.HttpSecretNotFoundError() from error
@@ -151,7 +173,7 @@ async def get_header_envelope(
     summary="Delete the associated secret",
     operation_id="deleteSecret",
     status_code=status.HTTP_204_NO_CONTENT,
-    response_description="",
+    response_description="Succesfully deleted secret.",
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["secretNotFoundError"],
     },

--- a/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
+++ b/services/ekss/src/ekss/adapters/inbound/fastapi_/router.py
@@ -45,7 +45,7 @@ ERROR_RESPONSES = {
         "model": exceptions.HttpEnvelopeDecryptionError.get_body_model(),
     },
     "secretInsertionError": {
-        "description": ("Failed to successfully inset secret into vault."),
+        "description": ("Failed to successfully insert secret into vault."),
         "model": exceptions.HttpSecretInsertionError.get_body_model(),
     },
     "vaultConnectionError": {

--- a/services/ekss/tests_ekss/integration/test_post_endpoint.py
+++ b/services/ekss/tests_ekss/integration/test_post_endpoint.py
@@ -95,6 +95,28 @@ async def test_corrupted_header(
 
 
 @pytest.mark.asyncio
+async def test_invalid_pubkey(
+    *,
+    first_part_fixture: FirstPartFixture,  # noqa: F811
+):
+    """Test request response for /secrets endpoint with first char replaced in envelope"""
+    app.dependency_overrides[config_injector] = lambda: first_part_fixture.vault.config
+
+    payload = first_part_fixture.content
+    content = base64.b64encode(payload).decode("utf-8")
+
+    request_body = {
+        "public_key": "abc",
+        "file_part": content,
+    }
+
+    response = client.post(url="/secrets", json=request_body)
+    assert response.status_code == 422
+    body = response.json()
+    assert body["exception_id"] == "decodingError"
+
+
+@pytest.mark.asyncio
 async def test_missing_envelope(
     *,
     first_part_fixture: FirstPartFixture,  # noqa: F811
@@ -117,3 +139,27 @@ async def test_missing_envelope(
     assert response.status_code == 400
     body = response.json()
     assert body["exception_id"] == "malformedOrMissingEnvelopeError"
+
+
+@pytest.mark.asyncio
+async def test_non_base64_envelope(
+    *,
+    first_part_fixture: FirstPartFixture,  # noqa: F811
+):
+    """Test request response for /secrets endpoint with first char replaced in envelope"""
+    app.dependency_overrides[config_injector] = lambda: first_part_fixture.vault.config
+
+    payload = first_part_fixture.content
+    content = "abc" + base64.b64encode(payload).decode("utf-8")
+
+    request_body = {
+        "public_key": base64.b64encode(first_part_fixture.client_pubkey).decode(
+            "utf-8"
+        ),
+        "file_part": content,
+    }
+
+    response = client.post(url="/secrets", json=request_body)
+    assert response.status_code == 422
+    body = response.json()
+    assert body["exception_id"] == "decodingError"

--- a/services/ekss/tests_ekss/integration/test_post_endpoint.py
+++ b/services/ekss/tests_ekss/integration/test_post_endpoint.py
@@ -99,7 +99,7 @@ async def test_invalid_pubkey(
     *,
     first_part_fixture: FirstPartFixture,  # noqa: F811
 ):
-    """Test request response for /secrets endpoint with first char replaced in envelope"""
+    """Test request response for /secrets endpoint with an invalid public key"""
     app.dependency_overrides[config_injector] = lambda: first_part_fixture.vault.config
 
     payload = first_part_fixture.content
@@ -146,7 +146,7 @@ async def test_non_base64_envelope(
     *,
     first_part_fixture: FirstPartFixture,  # noqa: F811
 ):
-    """Test request response for /secrets endpoint with first char replaced in envelope"""
+    """Test request response for /secrets endpoint with malformed envelope"""
     app.dependency_overrides[config_injector] = lambda: first_part_fixture.vault.config
 
     payload = first_part_fixture.content

--- a/services/ekss/tests_ekss/unit/test_config_validators.py
+++ b/services/ekss/tests_ekss/unit/test_config_validators.py
@@ -1,0 +1,52 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testing the basics of the service API"""
+
+import pytest
+
+from ekss.config import CONFIG, Config
+
+
+def test_private_key():
+    """Test server private key validator"""
+    public_key = CONFIG.server_public_key
+    private_key = CONFIG.server_private_key.get_secret_value()
+
+    with pytest.raises(ValueError, match="Incorrect padding"):
+        _ = Config(server_public_key=public_key, server_private_key="abc" + private_key)  # type:ignore
+
+    with pytest.raises(
+        ValueError, match="Length of decoded private key did not match expectation"
+    ):
+        _ = Config(
+            server_public_key=public_key, server_private_key="abcd" + private_key
+        )  # type:ignore
+
+
+def test_public_key():
+    """Test server public key validator"""
+    public_key = CONFIG.server_public_key
+    private_key = CONFIG.server_private_key.get_secret_value()
+
+    with pytest.raises(ValueError, match="Incorrect padding"):
+        _ = Config(server_public_key="abc" + public_key, server_private_key=private_key)  # type:ignore
+
+    with pytest.raises(
+        ValueError, match="Length of decoded public key did not match expectation"
+    ):
+        _ = Config(
+            server_public_key="abcd" + public_key, server_private_key=private_key
+        )  # type:ignore

--- a/services/ekss/tests_ekss/unit/test_config_validators.py
+++ b/services/ekss/tests_ekss/unit/test_config_validators.py
@@ -26,14 +26,14 @@ def test_private_key():
     private_key = CONFIG.server_private_key.get_secret_value()
 
     with pytest.raises(ValueError, match="Incorrect padding"):
-        _ = Config(server_public_key=public_key, server_private_key="abc" + private_key)  # type:ignore
+        _ = Config(server_public_key=public_key, server_private_key="abc" + private_key)
 
     with pytest.raises(
         ValueError, match="Length of decoded private key did not match expectation"
     ):
         _ = Config(
             server_public_key=public_key, server_private_key="abcd" + private_key
-        )  # type:ignore
+        )
 
 
 def test_public_key():
@@ -42,11 +42,10 @@ def test_public_key():
     private_key = CONFIG.server_private_key.get_secret_value()
 
     with pytest.raises(ValueError, match="Incorrect padding"):
-        _ = Config(server_public_key="abc" + public_key, server_private_key=private_key)  # type:ignore
-
+        _ = Config(server_public_key="abc" + public_key, server_private_key=private_key)
     with pytest.raises(
         ValueError, match="Length of decoded public key did not match expectation"
     ):
         _ = Config(
             server_public_key="abcd" + public_key, server_private_key=private_key
-        )  # type:ignore
+        )


### PR DESCRIPTION
- Both the server public and private key are now decoded and the length is checked in a validator to catch issues early and crash on startup instead of on the first request.
- An additional Response, HttpDecodingError, is now produced by both endpoints receiving base64 encoded data. Failure to decode either the client/requester public key or the file part means something went wrong before the data hits the EKSS and accordingly should be handled by the caller instead of crashing the EKSS