### PR TITLE
DCS: Response cache headers (GSI-1243)

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -379,21 +379,6 @@ The service requires the following configuration parameters:
   ```
 
 
-- **`url_expiration_buffer`** *(integer)*: Buffer time in seconds before the presigned URL expires, used to instruct clients to refresh their download URL shortly before it expires. Should be less than presigned_url_expires_after. Exclusive minimum: `0`. Default: `5`.
-
-
-  Examples:
-
-  ```json
-  5
-  ```
-
-
-  ```json
-  10
-  ```
-
-
 - **`cache_timeout`** *(integer)*: Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
 
 

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:2.1.0
+docker pull ghga/download-controller-service:3.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:2.1.0 .
+docker build -t ghga/download-controller-service:3.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:2.1.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:3.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -379,7 +379,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- **`cache_timeout`** *(integer)*: Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
+- **`outbox_cache_timeout`** *(integer)*: Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
 
 
   Examples:

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:2.0.6
+docker pull ghga/download-controller-service:2.0.7
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:2.0.6 .
+docker build -t ghga/download-controller-service:2.0.7 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:2.0.6 --help
+docker run -p 8080:8080 ghga/download-controller-service:2.0.7 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:2.0.7
+docker pull ghga/download-controller-service:2.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:2.0.7 .
+docker build -t ghga/download-controller-service:2.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:2.0.7 --help
+docker run -p 8080:8080 ghga/download-controller-service:2.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -376,6 +376,21 @@ The service requires the following configuration parameters:
 
   ```json
   60
+  ```
+
+
+- **`url_expiration_buffer`** *(integer)*: Buffer time in seconds before the presigned URL expires, used to instruct clients to refresh their download URL shortly before it expires. Should be less than presigned_url_expires_after. Exclusive minimum: `0`. Default: `5`.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  10
   ```
 
 

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -386,6 +386,17 @@
       "title": "Presigned URL expiration time in seconds",
       "type": "integer"
     },
+    "url_expiration_buffer": {
+      "default": 5,
+      "description": "Buffer time in seconds before the presigned URL expires, used to instruct clients to refresh their download URL shortly before it expires. Should be less than presigned_url_expires_after.",
+      "examples": [
+        5,
+        10
+      ],
+      "exclusiveMinimum": 0,
+      "title": "Download URL expiration buffer time (sec)",
+      "type": "integer"
+    },
     "cache_timeout": {
       "default": 7,
       "description": "Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request.",

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -386,14 +386,14 @@
       "title": "Presigned URL expiration time in seconds",
       "type": "integer"
     },
-    "cache_timeout": {
+    "outbox_cache_timeout": {
       "default": 7,
       "description": "Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request.",
       "examples": [
         7,
         30
       ],
-      "title": "Cache Timeout",
+      "title": "Outbox Cache Timeout",
       "type": "integer"
     },
     "auth_key": {

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -386,17 +386,6 @@
       "title": "Presigned URL expiration time in seconds",
       "type": "integer"
     },
-    "url_expiration_buffer": {
-      "default": 5,
-      "description": "Buffer time in seconds before the presigned URL expires, used to instruct clients to refresh their download URL shortly before it expires. Should be less than presigned_url_expires_after.",
-      "examples": [
-        5,
-        10
-      ],
-      "exclusiveMinimum": 0,
-      "title": "Download URL expiration buffer time (sec)",
-      "type": "integer"
-    },
     "cache_timeout": {
       "default": 7,
       "description": "Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request.",

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -14,7 +14,6 @@ auth_check_claims:
 auth_key: '{}'
 auth_map_claims: {}
 auto_reload: true
-cache_timeout: 7
 cors_allow_credentials: false
 cors_allowed_headers: []
 cors_allowed_methods: []
@@ -56,6 +55,7 @@ object_storages:
       s3_secret_access_key: '**********'
       s3_session_token: null
 openapi_url: /openapi.json
+outbox_cache_timeout: 7
 port: 8080
 presigned_url_expires_after: 30
 retry_after_max: 300

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -65,4 +65,5 @@ service_name: dcs
 staging_speed: 100
 unstaged_download_collection: unstagedDownloadRequested
 unstaged_download_event_topic: file-downloads
+url_expiration_buffer: 5
 workers: 1

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -65,5 +65,4 @@ service_name: dcs
 staging_speed: 100
 unstaged_download_collection: unstagedDownloadRequested
 unstaged_download_event_topic: file-downloads
-url_expiration_buffer: 5
 workers: 1

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 2.0.6
+  version: 2.0.7
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 2.1.0
+  version: 3.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 2.0.7
+  version: 2.1.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "2.0.6"
+version = "2.0.7"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "2.0.7"
+version = "2.1.0"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "2.1.0"
+version = "3.0.0"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/dummies.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/dummies.py
@@ -27,5 +27,6 @@ from dcs.ports.inbound.data_repository import DataRepositoryPort
 
 data_repo_port = DependencyDummy("data_repo_port")
 auth_provider = DependencyDummy("auth_provider")
+download_url_max_age = DependencyDummy("download_url_max_age")
 
 DataRepositoryDummy = Annotated[DataRepositoryPort, Depends(data_repo_port)]

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/dummies.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/dummies.py
@@ -23,10 +23,12 @@ from typing import Annotated
 from fastapi import Depends
 from ghga_service_commons.api.di import DependencyDummy
 
+from dcs.core.data_repository import DataRepositoryConfig
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 
 data_repo_port = DependencyDummy("data_repo_port")
 auth_provider = DependencyDummy("auth_provider")
-download_url_max_age = DependencyDummy("download_url_max_age")
+data_repo_config = DependencyDummy("data_repo_config")
 
 DataRepositoryDummy = Annotated[DataRepositoryPort, Depends(data_repo_port)]
+DataRepoConfigDependency = Annotated[DataRepositoryConfig, Depends(data_repo_config)]

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -108,7 +108,7 @@ async def get_drs_object(
         raise http_exceptions.HttpWrongFileAuthorizationError()
 
     expires_after = config.presigned_url_expires_after
-    cache_control_header = {"Cache-Control": f"max-age={expires_after}"}
+    cache_control_header = {"Cache-Control": f"max-age={expires_after}, private"}
 
     try:
         drs_object = await data_repository.access_drs_object(drs_id=object_id)

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -108,7 +108,9 @@ async def get_drs_object(
         raise http_exceptions.HttpWrongFileAuthorizationError()
 
     expires_after = config.presigned_url_expires_after
-    cache_control_header = {"Cache-Control": f"max-age={expires_after}"}
+    cache_control_header = {
+        "Cache-Control": f"max-age={expires_after}, must-revalidate"
+    }
     try:
         drs_object = await data_repository.access_drs_object(drs_id=object_id)
         return Response(

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -108,9 +108,8 @@ async def get_drs_object(
         raise http_exceptions.HttpWrongFileAuthorizationError()
 
     expires_after = config.presigned_url_expires_after
-    cache_control_header = {
-        "Cache-Control": f"max-age={expires_after}, must-revalidate"
-    }
+    cache_control_header = {"Cache-Control": f"max-age={expires_after}"}
+
     try:
         drs_object = await data_repository.access_drs_object(drs_id=object_id)
         return Response(

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -176,4 +176,6 @@ async def get_envelope(
     ) as communication_error:
         raise http_exceptions.HttpInternalServerError() from communication_error
 
-    return http_responses.HttpEnvelopeResponse(envelope=envelope)
+    response = http_responses.HttpEnvelopeResponse(envelope=envelope)
+    response.headers["Cache-Control"] = "no-store"
+    return response

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -118,9 +118,11 @@ async def get_drs_object(
 
     except data_repository.RetryAccessLaterError as retry_later_error:
         # tell client to retry after 5 minutes
-        return http_responses.HttpObjectNotInOutboxResponse(
+        response = http_responses.HttpObjectNotInOutboxResponse(
             retry_after=retry_later_error.retry_after
         )
+        response.headers["Cache-Control"] = "no-store"
+        return response
 
     except data_repository.DrsObjectNotFoundError as object_not_found_error:
         raise http_exceptions.HttpObjectNotFoundError(

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -107,11 +107,8 @@ async def get_drs_object(
     if not work_order_context.file_id == object_id:
         raise http_exceptions.HttpWrongFileAuthorizationError()
 
-    # Instruct clients to refresh their download URL shortly before it expires
     expires_after = config.presigned_url_expires_after
-    buffer = config.url_expiration_buffer
-    url_max_age = max(buffer, expires_after - buffer)
-    cache_control_header = {"Cache-Control": f"max-age={url_max_age}"}
+    cache_control_header = {"Cache-Control": f"max-age={expires_after}"}
     try:
         drs_object = await data_repository.access_drs_object(drs_id=object_id)
         return Response(

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -89,6 +89,14 @@ class DataRepositoryConfig(BaseSettings):
         title="Presigned URL expiration time in seconds",
         examples=[30, 60],
     )
+    url_expiration_buffer: PositiveInt = Field(
+        default=5,
+        description="Buffer time in seconds before the presigned URL expires, used to"
+        + " instruct clients to refresh their download URL shortly before it expires."
+        + " Should be less than presigned_url_expires_after.",
+        title="Download URL expiration buffer time (sec)",
+        examples=[5, 10],
+    )
     cache_timeout: int = Field(
         7,
         description="Time in days since last access after which a file present in the "

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -28,7 +28,7 @@ from ghga_service_commons.utils.multinode_storage import (
     S3ObjectStoragesConfig,
 )
 from hexkit.protocols.objstorage import ObjectStorageProtocol
-from pydantic import Field, PositiveInt, field_validator, model_validator
+from pydantic import Field, PositiveInt, field_validator
 from pydantic_settings import BaseSettings
 
 from dcs.adapters.outbound.http import exceptions
@@ -89,14 +89,6 @@ class DataRepositoryConfig(BaseSettings):
         title="Presigned URL expiration time in seconds",
         examples=[30, 60],
     )
-    url_expiration_buffer: PositiveInt = Field(
-        default=5,
-        description="Buffer time in seconds before the presigned URL expires, used to"
-        + " instruct clients to refresh their download URL shortly before it expires."
-        + " Should be less than presigned_url_expires_after.",
-        title="Download URL expiration buffer time (sec)",
-        examples=[5, 10],
-    )
     cache_timeout: int = Field(
         default=7,
         description="Time in days since last access after which a file present in the "
@@ -117,19 +109,6 @@ class DataRepositoryConfig(BaseSettings):
             raise ValueError(message)
 
         return value
-
-    @model_validator(mode="after")
-    def check_url_expiration_buffer(self):
-        """Check that the buffer is less than the expiration time."""
-        value = self.url_expiration_buffer
-        if value >= self.presigned_url_expires_after:
-            message = (
-                "url_expiration_buffer must be less than presigned_url_expires_after"
-                + f", got: {value} (should be less than"
-                + f" {self.presigned_url_expires_after})"
-            )
-            raise ValueError(message)
-        return self
 
 
 class DataRepository(DataRepositoryPort):

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -89,7 +89,7 @@ class DataRepositoryConfig(BaseSettings):
         title="Presigned URL expiration time in seconds",
         examples=[30, 60],
     )
-    cache_timeout: int = Field(
+    outbox_cache_timeout: int = Field(
         default=7,
         description="Time in days since last access after which a file present in the "
         + "outbox should be unstaged and has to be requested from permanent storage again "
@@ -257,8 +257,8 @@ class DataRepository(DataRepositoryPort):
         Check if files present in the outbox have outlived their allocated time and remove
         all that do.
         For each file in the outbox, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the cache_timeout option
-        is met or exceeded, the corresponding file is removed from the outbox.
+        to the current datetime. If the threshold configured in the outbox_cache_timeout
+        option is met or exceeded, the corresponding file is removed from the outbox.
         """
         # Run on demand through CLI, so crashing should be ok if the alias is not configured
         log.info(
@@ -274,7 +274,9 @@ class DataRepository(DataRepositoryPort):
             log.critical(storage_alias_not_configured)
             raise storage_alias_not_configured from exc
 
-        threshold = utc_dates.now_as_utc() - timedelta(days=self._config.cache_timeout)
+        threshold = utc_dates.now_as_utc() - timedelta(
+            days=self._config.outbox_cache_timeout
+        )
 
         # filter to get all files in outbox that should be removed
         object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
@@ -293,7 +295,7 @@ class DataRepository(DataRepositoryPort):
                 log.critical(cleanup_error)
                 raise cleanup_error from error
 
-            # only remove file if last access is later than cache timeout days ago
+            # only remove file if last access is later than oubtox_cache_timeout days ago
             if drs_object.last_accessed <= threshold:
                 log.info(
                     f"Deleting object '{object_id}' from storage '{

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -129,6 +129,9 @@ async def prepare_rest_app(
     ):
         app.dependency_overrides[dummies.auth_provider] = lambda: auth_context
         app.dependency_overrides[dummies.data_repo_port] = lambda: data_repository
+        app.dependency_overrides[dummies.download_url_max_age] = (
+            lambda: config.presigned_url_expires_after
+        )
         yield app
 
 

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -129,9 +129,7 @@ async def prepare_rest_app(
     ):
         app.dependency_overrides[dummies.auth_provider] = lambda: auth_context
         app.dependency_overrides[dummies.data_repo_port] = lambda: data_repository
-        app.dependency_overrides[dummies.download_url_max_age] = (
-            lambda: config.presigned_url_expires_after
-        )
+        app.dependency_overrides[dummies.data_repo_config] = lambda: config
         yield app
 
 

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -112,7 +112,7 @@ class DataRepositoryPort(ABC):
         Check if files present in the outbox have outlived their allocated time and remove
         all that do.
         For each file in the outbox, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the cache_timeout option
+        to the current datetime. If the threshold configured in the outbox_cache_timeout option
         is met or exceeded, the corresponding file is removed from the outbox.
         """
         ...

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -284,7 +284,7 @@ async def cleanup_fixture(
     test_file_expired.file_id = expired_file_id
     test_file_expired.object_id = expired_object_id
     test_file_expired.last_accessed = utc_dates.now_as_utc() - timedelta(
-        days=joint_fixture.config.cache_timeout
+        days=joint_fixture.config.outbox_cache_timeout
     )
 
     # populate DB entries

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -27,12 +27,12 @@ from ghga_service_commons.api.testing import AsyncTestClient
 from ghga_service_commons.utils.utc_dates import now_as_utc
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
-from dcs.adapters.inbound.fastapi_.routes import router
 from dcs.config import Config
 from dcs.core import models
 from dcs.inject import prepare_rest_app
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from tests_dcs.fixtures.joint import EXAMPLE_FILE, JointFixture, PopulatedFixture
+from tests_dcs.fixtures.mock_api.app import router
 from tests_dcs.fixtures.utils import (
     generate_token_signing_keys,
     generate_work_order_token,

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -200,12 +200,8 @@ async def test_register_file_twice(populated_fixture: PopulatedFixture, caplog):
 
 @pytest.mark.parametrize(
     "url_validity, buffer, expected_url_max_age",
-    [
-        (60, 10, 50),
-        (15, 10, 10),
-        (5, 10, 10),
-    ],
-    ids=["Normal", "UseBufferAsMinimum", "ValidityLessThanBuffer"],
+    [(60, 10, 50), (15, 10, 10)],
+    ids=["Normal", "UseBufferAsMinimum"],
 )
 async def test_cache_headers(
     joint_fixture: JointFixture,

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -17,20 +17,15 @@
 
 import re
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 import pytest_asyncio
 from fastapi import status
-from ghga_service_commons.api.testing import AsyncTestClient
 from ghga_service_commons.utils.utc_dates import now_as_utc
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
-from dcs.config import Config
 from dcs.core import models
-from dcs.core.data_repository import DataRepositoryConfig
-from dcs.inject import prepare_rest_app
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from tests_dcs.fixtures.joint import EXAMPLE_FILE, JointFixture, PopulatedFixture
 from tests_dcs.fixtures.mock_api.app import router
@@ -196,61 +191,3 @@ async def test_register_file_twice(populated_fixture: PopulatedFixture, caplog):
     failure_message = f"Could not register file with id '{
         example_file.file_id}' as an entry already exists for this id."
     assert failure_message in caplog.messages
-
-
-@pytest.mark.parametrize(
-    "url_validity, buffer, expected_url_max_age",
-    [(60, 10, 50), (15, 10, 10)],
-    ids=["Normal", "UseBufferAsMinimum"],
-)
-async def test_cache_headers(
-    joint_fixture: JointFixture,
-    url_validity: int,
-    buffer: int,
-    expected_url_max_age: int,
-    monkeypatch,
-):
-    """Test that the cache headers are set correctly"""
-    joint_config = joint_fixture.config.model_dump()
-    joint_config.update(
-        presigned_url_expires_after=url_validity,
-        url_expiration_buffer=buffer,
-    )
-    config = Config(**joint_config)
-    work_order_token = generate_work_order_token(
-        file_id="test-file",
-        jwk=joint_fixture.jwk,
-        valid_seconds=120,
-    )
-    headers = httpx.Headers({"Authorization": f"Bearer {work_order_token}"})
-    monkeypatch.setattr(
-        joint_fixture.data_repository,
-        "access_drs_object",
-        AsyncMock(return_value=EXAMPLE_FILE),
-    )
-    async with prepare_rest_app(
-        config=config, data_repo_override=joint_fixture.data_repository
-    ) as app:
-        async with AsyncTestClient(app) as client:
-            response = await client.get("/objects/test-file", headers=headers)
-
-        assert "Cache-Control" in response.headers
-        assert response.headers["Cache-Control"] == f"max-age={expected_url_max_age}"
-
-
-async def test_cache_param_validation():
-    """Test that the http cache-related config parameters are validated correctly"""
-    with pytest.raises(ValueError):
-        DataRepositoryConfig(
-            drs_server_uri="",
-            ekss_base_url="",
-            presigned_url_expires_after=0,
-            url_expiration_buffer=10,
-        )
-    with pytest.raises(ValueError):
-        DataRepositoryConfig(
-            drs_server_uri="",
-            ekss_base_url="",
-            presigned_url_expires_after=10,
-            url_expiration_buffer=10,
-        )

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -29,6 +29,7 @@ from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.config import Config
 from dcs.core import models
+from dcs.core.data_repository import DataRepositoryConfig
 from dcs.inject import prepare_rest_app
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from tests_dcs.fixtures.joint import EXAMPLE_FILE, JointFixture, PopulatedFixture
@@ -239,3 +240,21 @@ async def test_cache_headers(
 
         assert "Cache-Control" in response.headers
         assert response.headers["Cache-Control"] == f"max-age={expected_url_max_age}"
+
+
+async def test_cache_param_validation():
+    """Test that the http cache-related config parameters are validated correctly"""
+    with pytest.raises(ValueError):
+        DataRepositoryConfig(
+            drs_server_uri="",
+            ekss_base_url="",
+            presigned_url_expires_after=0,
+            url_expiration_buffer=10,
+        )
+    with pytest.raises(ValueError):
+        DataRepositoryConfig(
+            drs_server_uri="",
+            ekss_base_url="",
+            presigned_url_expires_after=10,
+            url_expiration_buffer=10,
+        )

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -153,6 +153,8 @@ async def test_happy_journey(
         f"/objects/{drs_id}/envelopes", timeout=5
     )
     assert response.status_code == status.HTTP_200_OK
+    assert "Cache-Control" in response.headers
+    assert response.headers["Cache-Control"] == "no-store"
 
     response = await joint_fixture.rest_client.get(
         "/objects/invalid_id/envelopes", timeout=5

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -99,7 +99,8 @@ async def test_happy_journey(
     ):
         response = await joint_fixture.rest_client.get(f"/objects/{drs_id}", timeout=5)
     assert response.status_code == status.HTTP_202_ACCEPTED
-    assert "Cache-Control" not in response.headers
+    assert "Cache-Control" in response.headers
+    assert response.headers["Cache-Control"] == "no-store"
     retry_after = int(response.headers["Retry-After"])
     # the example file is small, so we expect the minimum wait time
     assert retry_after == joint_fixture.config.retry_after_min

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -140,7 +140,7 @@ async def test_happy_journey(
     assert "Cache-Control" in drs_object_response.headers
     cache_headers = drs_object_response.headers["Cache-Control"]
     max_age_header = f"max-age={joint_fixture.config.presigned_url_expires_after}"
-    assert max_age_header == cache_headers
+    assert cache_headers == f"{max_age_header}, private"
 
     # download file bytes:
     presigned_url = drs_object_response.json()["access_methods"][0]["access_url"]["url"]

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -136,11 +136,13 @@ async def test_happy_journey(
     ):
         drs_object_response = await joint_fixture.rest_client.get(f"/objects/{drs_id}")
 
+    # Verify that the response contains the expected cache-control headers
+    #  the expected headers are "must-revalidate" and "max-age={n}"
     assert "Cache-Control" in drs_object_response.headers
-    assert (
-        drs_object_response.headers["Cache-Control"]
-        == f"max-age={joint_fixture.config.presigned_url_expires_after}"
-    )
+    cache_headers = drs_object_response.headers["Cache-Control"].split(", ")
+    max_age_header = f"max-age={joint_fixture.config.presigned_url_expires_after}"
+    assert max_age_header in cache_headers
+    assert "must-revalidate" in cache_headers
 
     # download file bytes:
     presigned_url = drs_object_response.json()["access_methods"][0]["access_url"]["url"]

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -137,12 +137,10 @@ async def test_happy_journey(
         drs_object_response = await joint_fixture.rest_client.get(f"/objects/{drs_id}")
 
     # Verify that the response contains the expected cache-control headers
-    #  the expected headers are "must-revalidate" and "max-age={n}"
     assert "Cache-Control" in drs_object_response.headers
-    cache_headers = drs_object_response.headers["Cache-Control"].split(", ")
+    cache_headers = drs_object_response.headers["Cache-Control"]
     max_age_header = f"max-age={joint_fixture.config.presigned_url_expires_after}"
-    assert max_age_header in cache_headers
-    assert "must-revalidate" in cache_headers
+    assert max_age_header == cache_headers
 
     # download file bytes:
     presigned_url = drs_object_response.json()["access_methods"][0]["access_url"]["url"]

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -139,7 +139,7 @@ async def test_happy_journey(
     assert "Cache-Control" in drs_object_response.headers
     assert (
         drs_object_response.headers["Cache-Control"]
-        == f"max-age={joint_fixture.config.presigned_url_expires_after - 5}"
+        == f"max-age={joint_fixture.config.presigned_url_expires_after}"
     )
 
     # download file bytes:


### PR DESCRIPTION
Added `cache-control` header with `max-age` to the response for the main endpoint `GET /objects/{object_id}`. 

The value used for `max-age` is set to the config value `presigned_url_expires_after`.
The primary integration test was updated to check for the header.