### PR TITLE
[major] DCS: Fetch (encrypted) object size from S3 incoming event

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:3.0.0
+docker pull ghga/download-controller-service:4.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:3.0.0 .
+docker build -t ghga/download-controller-service:4.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:3.0.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:4.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 3.0.0
+  version: 4.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "3.0.0"
+version = "4.0.0"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/src/dcs/adapters/inbound/event_sub.py
+++ b/services/dcs/src/dcs/adapters/inbound/event_sub.py
@@ -87,6 +87,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             decryption_secret_id=validated_payload.decryption_secret_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,
+            encrypted_size=validated_payload.encrypted_size,
             creation_date=validated_payload.upload_date,
             s3_endpoint_alias=validated_payload.s3_endpoint_alias,
         )

--- a/services/dcs/src/dcs/core/models.py
+++ b/services/dcs/src/dcs/core/models.py
@@ -51,6 +51,7 @@ class DrsObjectBase(BaseModel):
     decryption_secret_id: str
     decrypted_sha256: str
     decrypted_size: int
+    encrypted_size: int
     creation_date: str
     s3_endpoint_alias: str
 

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -73,6 +73,7 @@ EXAMPLE_FILE = models.AccessTimeDrsObject(
     creation_date=utc_dates.now_as_utc().isoformat(),
     decrypted_size=12345,
     decryption_secret_id="some-secret",
+    encrypted_size=23456,
     s3_endpoint_alias=STORAGE_ALIAS,
     last_accessed=utc_dates.now_as_utc(),
 )

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -183,6 +183,7 @@ async def test_register_file_twice(populated_fixture: PopulatedFixture, caplog):
         decrypted_sha256=example_file.decrypted_sha256,
         decrypted_size=example_file.decrypted_size,
         creation_date=now_as_utc().isoformat(),
+        encrypted_size=example_file.encrypted_size,
         s3_endpoint_alias=example_file.s3_endpoint_alias,
     )
 


### PR DESCRIPTION
Populate encrypted object size from incoming event instead of fetching it from S3 every time.
Skip existence lookup and move it into error handling branch, i.e. RetryLater response is now the error handling branch of getting the presigned URL.

Added some debug logging around service external calls measuring exection time.