### PR TITLE
IFRS: prototype migration framework and object_size migration (GSI-1271)

### DIFF
--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -272,6 +272,51 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`lock_collection`** *(string, required)*: The name of the collection containing the DB Lock document for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsLock"
+  ```
+
+
+  ```json
+  "dcsLock"
+  ```
+
+
+- **`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- **`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
 ## Definitions
 
 

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -272,21 +272,6 @@ The service requires the following configuration parameters:
   ```
 
 
-- **`lock_collection`** *(string, required)*: The name of the collection containing the DB Lock document for this service.
-
-
-  Examples:
-
-  ```json
-  "ifrsLock"
-  ```
-
-
-  ```json
-  "dcsLock"
-  ```
-
-
 - **`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
 
 

--- a/services/ifrs/config_schema.json
+++ b/services/ifrs/config_schema.json
@@ -314,15 +314,6 @@
       "title": "Db Name",
       "type": "string"
     },
-    "lock_collection": {
-      "description": "The name of the collection containing the DB Lock document for this service",
-      "examples": [
-        "ifrsLock",
-        "dcsLock"
-      ],
-      "title": "Lock Collection",
-      "type": "string"
-    },
     "db_version_collection": {
       "description": "The name of the collection containing DB version information for this service",
       "examples": [
@@ -357,7 +348,6 @@
     "kafka_servers",
     "db_connection_str",
     "db_name",
-    "lock_collection",
     "db_version_collection",
     "migration_wait_sec"
   ],

--- a/services/ifrs/config_schema.json
+++ b/services/ifrs/config_schema.json
@@ -313,6 +313,33 @@
       ],
       "title": "Db Name",
       "type": "string"
+    },
+    "lock_collection": {
+      "description": "The name of the collection containing the DB Lock document for this service",
+      "examples": [
+        "ifrsLock",
+        "dcsLock"
+      ],
+      "title": "Lock Collection",
+      "type": "string"
+    },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
     }
   },
   "required": [
@@ -329,7 +356,10 @@
     "files_to_stage_topic",
     "kafka_servers",
     "db_connection_str",
-    "db_name"
+    "db_name",
+    "lock_collection",
+    "db_version_collection",
+    "migration_wait_sec"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/ifrs/dev_config.yaml
+++ b/services/ifrs/dev_config.yaml
@@ -18,3 +18,6 @@ file_staged_event_topic: internal-file-registry
 file_staged_event_type: file_staged_for_download
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
+lock_collection: ifrs_db_lock
+db_version_collection: ifrs_db_versions
+migration_wait_sec: 10

--- a/services/ifrs/dev_config.yaml
+++ b/services/ifrs/dev_config.yaml
@@ -18,6 +18,5 @@ file_staged_event_topic: internal-file-registry
 file_staged_event_type: file_staged_for_download
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
-lock_collection: ifrs_db_lock
-db_version_collection: ifrs_db_versions
+db_version_collection: ifrsDbVersions
 migration_wait_sec: 10

--- a/services/ifrs/example_config.yaml
+++ b/services/ifrs/example_config.yaml
@@ -1,6 +1,6 @@
 db_connection_str: '**********'
 db_name: dev
-db_version_collection: ifrs_db_versions
+db_version_collection: ifrsDbVersions
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
 file_registered_event_topic: internal-file-registry
@@ -19,7 +19,6 @@ kafka_ssl_cafile: ''
 kafka_ssl_certfile: ''
 kafka_ssl_keyfile: ''
 kafka_ssl_password: ''
-lock_collection: ifrs_db_lock
 log_format: null
 log_level: INFO
 log_traceback: true

--- a/services/ifrs/example_config.yaml
+++ b/services/ifrs/example_config.yaml
@@ -1,5 +1,6 @@
 db_connection_str: '**********'
 db_name: dev
+db_version_collection: ifrs_db_versions
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
 file_registered_event_topic: internal-file-registry
@@ -18,9 +19,11 @@ kafka_ssl_cafile: ''
 kafka_ssl_certfile: ''
 kafka_ssl_keyfile: ''
 kafka_ssl_password: ''
+lock_collection: ifrs_db_lock
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_wait_sec: 10
 object_storages:
   test:
     bucket: permanent

--- a/services/ifrs/src/ifrs/__main__.py
+++ b/services/ifrs/src/ifrs/__main__.py
@@ -18,12 +18,10 @@
 import asyncio
 
 from ifrs.main import consume_events
-from ifrs.migrations import run_db_migrations
 
 
 def run_forever():
     """Main entrypoint for setup.cfg"""
-    asyncio.run(run_db_migrations())
     asyncio.run(consume_events(run_forever=True))
 
 

--- a/services/ifrs/src/ifrs/__main__.py
+++ b/services/ifrs/src/ifrs/__main__.py
@@ -18,10 +18,12 @@
 import asyncio
 
 from ifrs.main import consume_events
+from ifrs.migrations import run_db_migrations
 
 
 def run_forever():
     """Main entrypoint for setup.cfg"""
+    asyncio.run(run_db_migrations())
     asyncio.run(consume_events(run_forever=True))
 
 

--- a/services/ifrs/src/ifrs/config.py
+++ b/services/ifrs/src/ifrs/config.py
@@ -19,15 +19,15 @@ from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb import MongoDbConfig
 
 from ifrs.adapters.inbound.event_sub import OutboxSubTranslatorConfig
 from ifrs.adapters.outbound.event_pub import EventPubTranslatorConfig
+from ifrs.migration_logic import MigrationConfig
 
 
 @config_from_yaml(prefix="ifrs")
 class Config(
-    MongoDbConfig,
+    MigrationConfig,
     KafkaConfig,
     OutboxSubTranslatorConfig,
     EventPubTranslatorConfig,

--- a/services/ifrs/src/ifrs/migration_logic/__init__.py
+++ b/services/ifrs/src/ifrs/migration_logic/__init__.py
@@ -12,21 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Temporary database migration logic, some of which will move to a library"""
 
-"""In this module object construction and dependency injection is carried out."""
+from ._manager import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+    MigrationStepError,
+)
+from ._utils import Document, MigrationDefinition, Reversible, validate_doc
 
-from hexkit.log import configure_logging
-
-from ifrs.config import Config
-from ifrs.inject import prepare_outbox_subscriber
-from ifrs.migrations import run_db_migrations
-
-
-async def consume_events(run_forever: bool = True):
-    """Run an event consumer listening to the specified topics."""
-    config = Config()
-    configure_logging(config=config)
-    await run_db_migrations(config=config)
-
-    async with prepare_outbox_subscriber(config=config) as outbox_subscriber:
-        await outbox_subscriber.run(forever=run_forever)
+__all__ = [
+    "Document",
+    "MigrationConfig",
+    "MigrationDefinition",
+    "MigrationManager",
+    "MigrationMap",
+    "MigrationStepError",
+    "Reversible",
+    "validate_doc",
+]

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -1,0 +1,420 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tools to run database migrations in services"""
+
+import logging
+from contextlib import asynccontextmanager
+from time import sleep, time
+from typing import Any, Literal
+
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.providers.mongodb import MongoDbConfig
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from pydantic import BaseModel, Field
+from pymongo.errors import DuplicateKeyError
+
+from ._utils import MigrationDefinition, Reversible
+
+log = logging.getLogger(__name__)
+
+MigrationType = Literal["FORWARD", "BACKWARD"]
+MigrationCls = type[MigrationDefinition]
+MigrationMap = dict[int, MigrationCls]
+
+
+def duration_in_ms(duration: float) -> int:
+    return int(duration * 1000)
+
+
+class MigrationConfig(MongoDbConfig):
+    """Minimal configuration required to run the migration process."""
+
+    lock_collection: str = Field(
+        ...,
+        description="The name of the collection containing the DB Lock document for this service",
+        examples=["ifrsLock", "dcsLock"],
+    )
+    db_version_collection: str = Field(
+        ...,
+        description="The name of the collection containing DB version information for this service",
+        examples=["ifrsDbVersions"],
+    )
+    migration_wait_sec: int = Field(
+        ...,
+        description="The number of seconds to wait before checking the DB version again",
+        examples=[5, 30, 180],
+    )
+
+
+class DbVersionRecord(BaseModel):
+    """Model containing information about DB versions and how they were achieved."""
+
+    version: int = Field(..., description="The database version")
+    details: dict[str, Any] = Field(
+        ...,
+        description="Extra information about the migration to this version. ",
+        examples=[
+            {
+                "completed": "2025-01-17T13:42:58.396538+00:00",
+                "migration_type": "FORWARD",
+                "total_duration_ms": 5000,
+            }
+        ],
+    )
+
+
+class MigrationStepError(RuntimeError):
+    """Raised when a specific migration step fails, e.g. migrating from v4 to v5"""
+
+    def __init__(self, *, current_ver: int, target_ver: int, err_info: str):
+        msg = (
+            f"Unable to migrate from DB version {current_ver} to {target_ver}."
+            + f" Cause:\n  '{err_info}'"
+        )
+        super().__init__(msg)
+
+
+class DbLockError(RuntimeError):
+    """Raised when the DB lock can't be released or acquired due to an error."""
+
+    def __init__(
+        self, *, op: Literal["acquire", "release"], coll_name: str, err_info: str
+    ):
+        msg = (
+            f"Failed to {op} the lock in DB lock collection {coll_name}."
+            + f" Error details:\n  '{err_info}'"
+        )
+        super().__init__(msg)
+
+
+class DbVersioningInitError(RuntimeError):
+    """Raised when DB versioning initialization fails due to an error."""
+
+    def __init__(self, *, err_info: str):
+        msg = f"DB versioning initialization failed. Error details:\n  {err_info}"
+        super().__init__(msg)
+
+
+def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
+    """Gets the current DB version from the documents found in the version collection."""
+    # Make sure we know what the latest version is, not just the max
+    version_docs.sort(key=lambda doc: doc.details["completed"])
+    return version_docs[-1].version if version_docs else 0
+
+
+class MigrationManager:
+    """Top-level logic for ensuring the database is updated before running the service.
+
+    The `migrate_or_wait` method must be called before any instance of the service
+    begins its main execution loop.
+
+    Reserved DB version numbers:
+    - 0 = db versioning not yet implemented
+    - 1 = db versioning implemented
+
+    Example usage:
+    ```
+    from my_service.config import Config  # inherits from MongoDbConfig
+    from ghga_service_commons.migration import MigrationManager, MigrationMap
+
+    DB_VERSION = 2  # the current expected DB version
+    MY_MIGRATION_MAP = MigrationMap({
+        2: V2Migration,
+        # future migrations will go here
+    })
+
+    def migrate_my_service():
+        # Called before starting my_service
+        config = Config()
+
+        with MigrationManager(config, DB_VERSION, MY_MIGRATION_MAP) as mm:
+            mm.migrate_or_wait()
+    ```
+    """
+
+    client: AsyncIOMotorClient
+    db: AsyncIOMotorDatabase
+
+    def __init__(
+        self,
+        config: MigrationConfig,
+        target_version: int,
+        migration_map: MigrationMap,
+    ):
+        """Instantiate the MigrationManager.
+
+        Args
+        - `config`: Config containing db connection str and lock/db versioning collections
+        - `target_version`: Which version the db needs to be at for this version of the service
+        - `migration_map`: A dict with the MigrationDefinition class for each db version
+        """
+        if target_version < 1:
+            raise RuntimeError("Expected database version must be 1 or greater")
+
+        self.config = config
+        self.target_ver = target_version
+        self.migration_map = migration_map
+        self._lock_acquired = False
+        self._entered = False
+        self._migration_type: MigrationType = "FORWARD"
+
+    async def __aenter__(self):
+        """Set up database client and database reference"""
+        self.client = AsyncIOMotorClient(
+            self.config.db_connection_str.get_secret_value()
+        )
+        self.db = self.client[self.config.db_name]
+        self._entered = True
+        return self
+
+    async def __aexit__(self, exc_type_, exc_value, exc_tb):
+        """Release DB lock and close/remove database client"""
+        await self._release_db_lock()
+        self.client.close()
+
+    async def _get_version_docs(self) -> list[DbVersionRecord]:
+        """Gets the DB version information from the database."""
+        collection = self.db[self.config.db_version_collection]
+        version_docs = [DbVersionRecord(**doc) async for doc in collection.find()]
+
+        return version_docs
+
+    @asynccontextmanager
+    async def _lock_db(self):
+        await self._acquire_db_lock()
+        try:
+            yield
+        finally:
+            await self._release_db_lock()
+
+    async def _acquire_db_lock(self):
+        """Try to acquire the lock on the DB and return the result.
+
+        Logs and raises any error that occurs while updating the lock document.
+        """
+        if self._lock_acquired:
+            log.debug("Database lock already acquired")
+            return
+
+        try:
+            lock_col = self.db[self.config.lock_collection]
+            lock_acquired = await lock_col.find_one_and_update(
+                {"lock_acquired": False},
+                {
+                    "$set": {
+                        "lock_acquired": True,
+                        "acquired_at": now_as_utc().isoformat(),
+                    }
+                },
+            )
+        except BaseException as exc:
+            error = DbLockError(
+                op="acquire", coll_name=self.config.lock_collection, err_info=str(exc)
+            )
+            log.error(error)
+            raise error from exc
+
+        self._lock_acquired = bool(lock_acquired)
+        if self._lock_acquired:
+            log.info("Database lock acquired")
+
+    async def _release_db_lock(self) -> None:
+        """Release the DB lock.
+
+        Logs and re-raises any errors that occur during the update.
+        """
+        if not self._lock_acquired:
+            log.debug("Database lock already released")
+            return
+        try:
+            lock_col = self.db[self.config.lock_collection]
+            await lock_col.find_one_and_update(
+                {"lock_acquired": True},
+                {"$set": {"lock_acquired": False, "acquired_at": ""}},
+            )
+            self._lock_acquired = False
+        except BaseException as exc:
+            error = DbLockError(
+                op="release",
+                coll_name=self.config.lock_collection,
+                err_info=str(exc),
+            )
+            log.critical(error)
+            raise error from exc
+        log.info("Database lock released")
+
+    async def _record_migration(self, *, version: int, total_duration_ms: int):
+        """Insert a DbVersionRecord with processing information"""
+        details: dict[str, Any] = {
+            "completed": now_as_utc().isoformat(),
+            "total_duration_ms": total_duration_ms,
+            "migration_type": self._migration_type,
+        }
+        record = DbVersionRecord(version=version, details=details)
+        version_collection = self.db[self.config.db_version_collection]
+        await version_collection.insert_one(record.model_dump())
+
+    async def _initialize_versioning(self) -> bool:
+        """Create and acquire the DB lock, then add the versioning collection.
+
+        Returns `True` if setup was performed, else `False`.
+        """
+        init_start = time()
+        lock_collection = self.db[self.config.lock_collection]
+        lock_doc = [_ async for _ in lock_collection.find()]
+        if not lock_doc:
+            # lock document has not been created yet, so add it
+            try:
+                await lock_collection.insert_one(
+                    {
+                        "_id": 0,
+                        "lock_acquired": False,
+                        "acquired_at": "",
+                    }
+                )
+            except DuplicateKeyError:
+                # another instance inserted the doc first, so stop and wait to retry
+                return False
+
+        # Lock database so other instances can't attempt migrations
+        async with self._lock_db():
+            if not self._lock_acquired:
+                return False
+
+            # Initialize db version collection
+            await self._record_migration(
+                version=1,
+                total_duration_ms=duration_in_ms(time() - init_start),
+            )
+        return True
+
+    def _get_sequence(self, *, current_ver: int, target_ver: int) -> list[int]:
+        """Return an ordered list of the version migrations to apply/unapply"""
+        # In forward case, we don't need to apply current ver
+        # in backward case, we don't want to unapply the target ver
+        step_range = (
+            range(current_ver, target_ver, -1)
+            if self._migration_type == "BACKWARD"
+            else range(current_ver + 1, target_ver + 1)
+        )
+        steps = list(step_range)
+        return steps
+
+    def _fetch_migration_cls(self, version: int) -> MigrationCls:
+        """Return the stored migration for the specified version.
+
+        Raise an error if the  doesn't exist or doesn't implement unapply when needed.
+        """
+        try:
+            migration_cls = self.migration_map[version]
+            if self._migration_type == "BACKWARD" and not issubclass(
+                migration_cls, Reversible
+            ):
+                raise RuntimeError(
+                    f"Planning to unapply migration v{version}, but"
+                    + f" it doesn't subclass `{Reversible.__name__}`!"
+                )
+            return migration_cls
+        except KeyError as err:
+            mig_type = self._migration_type.lower()
+            raise NotImplementedError(
+                f"No {mig_type} migration implemented for version {version}"
+            ) from err
+
+    async def _perform_migrations(self, *, current_ver: int):
+        """Migrate forward or backward to reach target DB version.
+
+        Raises `MigrationError` if unsuccessful.
+        """
+        seq = self._get_sequence(current_ver=current_ver, target_ver=self.target_ver)
+        migrations = [self._fetch_migration_cls(ver) for ver in seq]
+        unapplying = self._migration_type == "BACKWARD"
+        try:
+            # Execute & time each migration in order to get to the target DB version
+            for v, migration_cls in zip(seq, migrations, strict=True):
+                # Determine if this is the last migration to apply/unapply
+                last_ver_called = self.target_ver + 1 if unapplying else self.target_ver
+                is_final_migration = v == last_ver_called
+
+                # instantiate MigrationDefinition
+                migration = migration_cls(
+                    db=self.db,
+                    unapplying=unapplying,
+                    is_final_migration=is_final_migration,
+                )
+
+                # Call apply/unapply based on migration type
+                await migration.unapply() if unapplying else await migration.apply()
+        except BaseException as exc:
+            error = MigrationStepError(
+                current_ver=current_ver, target_ver=self.target_ver, err_info=str(exc)
+            )
+            log.critical(error)
+            raise error from exc
+
+    async def _migrate_db(self) -> bool | None:
+        """Ensure the database is up to date before running the actual app.
+
+        If the database is already up to date, no changes are made. If the database is
+        out of date, migration code is executed to make the database current.
+
+        Returns True if migrations are finished or up-to-date and False otherwise.
+        """
+        version_docs = await self._get_version_docs()
+        version = _get_db_version_from_records(version_docs)
+
+        if version == 0:
+            try:
+                init_complete = await self._initialize_versioning()
+            except BaseException as exc:
+                error = DbVersioningInitError(err_info=str(exc))
+                log.critical(error)
+                raise error from exc
+            if not init_complete:
+                return False
+            version = 1
+
+        if version == self.target_ver:
+            # DB is up to date, run service
+            return True
+
+        # DB version is not what it should be: acquire lock and migrate
+        async with self._lock_db():
+            if not self._lock_acquired:
+                return False
+
+            self._migration_type = (
+                "FORWARD" if version < self.target_ver else "BACKWARD"
+            )
+
+            start = time()
+            await self._perform_migrations(current_ver=version)
+            duration_ms = duration_in_ms(time() - start)
+
+            # record the db version
+            await self._record_migration(
+                version=self.target_ver,
+                total_duration_ms=duration_ms,
+            )
+        return True
+
+    async def migrate_or_wait(self):
+        """Try to migrate the database or wait until migrations are completed."""
+        if not self._entered:
+            raise RuntimeError("MigrationManager must be used as a context manager")
+
+        # need to implement some kind of total time limit, warning logging, etc. later
+        while not await self._migrate_db():
+            sleep(self.config.migration_wait_sec)

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -319,7 +319,9 @@ class MigrationManager:
                 await migration.unapply() if unapplying else await migration.apply()
             except BaseException as exc:
                 error = MigrationStepError(
-                    current_ver=version, target_ver=self.target_ver, err_info=str(exc)
+                    current_ver=version - 1,
+                    target_ver=self.target_ver,
+                    err_info=str(exc),
                 )
                 log.critical(error)
                 raise error from exc

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -15,8 +15,9 @@
 """Tools to run database migrations in services"""
 
 import logging
+from asyncio import sleep
 from contextlib import asynccontextmanager, suppress
-from time import sleep, time
+from time import time
 from typing import Literal, TypedDict
 
 from ghga_service_commons.utils.utc_dates import now_as_utc
@@ -380,4 +381,4 @@ class MigrationManager:
 
         # need to implement some kind of total time limit, warning logging, etc. later
         while not await self._migrate_db():
-            sleep(self.config.migration_wait_sec)
+            await sleep(self.config.migration_wait_sec)

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -305,9 +305,9 @@ class MigrationManager:
         ver_sequence = self._get_version_sequence(current_ver=current_ver)
         migrations = [self._fetch_migration_cls(ver) for ver in ver_sequence]
         unapplying = self._migration_type == "BACKWARD"
-        try:
-            # Execute & time each migration in order to get to the target DB version
-            for version, migration_cls in zip(ver_sequence, migrations, strict=True):
+        # Execute & time each migration in order to get to the target DB version
+        for version, migration_cls in zip(ver_sequence, migrations, strict=True):
+            try:
                 # Determine if this is the last migration to apply/unapply
                 last_ver_called = self.target_ver + 1 if unapplying else self.target_ver
                 is_final_migration = version == last_ver_called
@@ -321,12 +321,12 @@ class MigrationManager:
 
                 # Call apply/unapply based on migration type
                 await migration.unapply() if unapplying else await migration.apply()
-        except BaseException as exc:
-            error = MigrationStepError(
-                current_ver=current_ver, target_ver=self.target_ver, err_info=str(exc)
-            )
-            log.critical(error)
-            raise error from exc
+            except BaseException as exc:
+                error = MigrationStepError(
+                    current_ver=version, target_ver=self.target_ver, err_info=str(exc)
+                )
+                log.critical(error)
+                raise error from exc
 
     async def _migrate_db(self) -> bool:
         """Ensure the database is up to date before running the actual app.

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -309,8 +309,7 @@ class MigrationManager:
         for version, migration_cls in zip(ver_sequence, migrations, strict=True):
             try:
                 # Determine if this is the last migration to apply/unapply
-                last_ver_called = self.target_ver + 1 if unapplying else self.target_ver
-                is_final_migration = version == last_ver_called
+                is_final_migration = version == ver_sequence[-1]
 
                 # instantiate MigrationDefinition
                 migration = migration_cls(

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -280,24 +280,22 @@ class MigrationManager:
                 await lock_collection.insert_one(
                     {
                         "_id": 0,
-                        "lock_acquired": False,
-                        "acquired_at": "",
+                        "lock_acquired": True,
+                        "acquired_at": now_as_utc().isoformat(),
                     }
                 )
             except DuplicateKeyError:
                 # another instance inserted the doc first, so stop and wait to retry
                 return False
 
-        # Lock database so other instances can't attempt migrations
-        async with self._lock_db():
-            if not self._lock_acquired:
-                return False
+        if not self._lock_acquired:
+            return False
 
-            # Initialize db version collection
-            await self._record_migration(
-                version=1,
-                total_duration_ms=duration_in_ms(time() - init_start),
-            )
+        # Initialize db version collection
+        await self._record_migration(
+            version=1,
+            total_duration_ms=duration_in_ms(time() - init_start),
+        )
         return True
 
     def _get_sequence(self, *, current_ver: int, target_ver: int) -> list[int]:

--- a/services/ifrs/src/ifrs/migration_logic/_manager.py
+++ b/services/ifrs/src/ifrs/migration_logic/_manager.py
@@ -108,27 +108,23 @@ class MigrationManager:
     The `migrate_or_wait` method must be called before any instance of the service
     begins its main execution loop.
 
-    Reserved DB version numbers:
-    - 0 = db versioning not yet implemented
-    - 1 = db versioning implemented
+    Version 1 is reserved for the framework as a way to mark when versioning was added.
 
     Example usage:
     ```
     from my_service.config import Config  # inherits from MongoDbConfig
-    from ghga_service_commons.migration import MigrationManager, MigrationMap
+    from <module with this class> import MigrationManager
+    from <module with migration code> import V2Migration, V3Migration
 
     DB_VERSION = 2  # the current expected DB version
-    MY_MIGRATION_MAP = MigrationMap({
-        2: V2Migration,
-        # future migrations will go here
-    })
+    MY_MIGRATION_MAP = {2: V2Migration, 3: V3Migration} # etc.
 
     def migrate_my_service():
         # Called before starting my_service
         config = Config()
 
-        with MigrationManager(config, DB_VERSION, MY_MIGRATION_MAP) as mm:
-            mm.migrate_or_wait()
+        async with MigrationManager(config, DB_VERSION, MY_MIGRATION_MAP) as mm:
+            await mm.migrate_or_wait()
     ```
     """
 

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -96,13 +96,13 @@ class MigrationDefinition:
         recommendation to restore the database.
         """
         try:
+            # copy indexes if needed (not implemented yet)
+            if copy_indexes:
+                raise NotImplementedError("Index copying is not yet implemented")
             # Yield to run the actual migration
             yield
             await self.stage_new_collections(coll_names)
 
-            # copy indexes if needed (not implemented yet)
-            if copy_indexes:
-                raise NotImplementedError("Index copying is not yet implemented")
             # Drop old collections. Don't do the index copy check unless we perform the
             #  index copying via this method. Otherwise we can't be sure it wasn't
             #  handled some other way

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -124,7 +124,7 @@ class MigrationDefinition:
             output_doc = await method(doc)
 
             # do validation against model only if we're on the last migration because
-            # the model defined in code may is not guaranteed to match until that time
+            # the model defined in code is not guaranteed to match until that time
             if validation_model and (self._is_final_migration or force_validate):
                 validate_doc(output_doc, model=validation_model, id_field=id_field)
 

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -102,7 +102,7 @@ class MigrationDefinition:
 
             # copy indexes if needed (not implemented yet)
             if copy_indexes:
-                pass
+                raise NotImplementedError("Index copying is not yet implemented")
             # Drop old collections. Don't do the index copy check unless we perform the
             #  index copying via this method. Otherwise we can't be sure it wasn't
             #  handled some other way

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -1,0 +1,210 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utils for defining and applying database migrations"""
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from copy import deepcopy
+from typing import Any
+
+from hexkit.providers.mongodb.provider import document_to_dto, dto_to_document
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
+
+Document = dict[str, Any]
+
+
+def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):
+    """Ensure that new content passes model validation.
+
+    Also check that `dto_to_document` results in the same document.
+    """
+    as_model = document_to_dto(deepcopy(doc), id_field=id_field, dto_model=model)
+    doc_from_model = dto_to_document(as_model, id_field=id_field)
+    if doc != doc_from_model:
+        raise RuntimeError(
+            f"Doc validation failed for model '{model.__name__}',"
+            + f" expected: {str(doc_from_model)}, but got {doc}"
+        )
+
+
+class MigrationDefinition:
+    """Contains all logic to migrate the database from one version to the next."""
+
+    version: int
+
+    def __init__(
+        self,
+        *,
+        db: AsyncIOMotorDatabase,
+        unapplying: bool,
+        is_final_migration: bool,
+    ):
+        """Instantiate the MigrationDefinition.
+
+        Subclass overrides need to call `super().__init__` or include its code.
+        """
+        if not self.version:
+            raise ValueError("Migration version has not been assigned")
+
+        self._db = db
+        unapply = "_unapply" if unapplying else ""
+        self._temp_prefix = f"tmp_v{self.version}{unapply}"
+        self._new_prefix = f"{self._temp_prefix}_new"
+        self._old_prefix = f"{self._temp_prefix}_old"
+        self._is_final_migration = is_final_migration
+        self._indexes_applied = False
+        self._collections_staged = False
+        self._log_blurb = f"for {'downgrade' if unapplying else 'upgrade'} to DB version {self.version}"
+
+    @staticmethod
+    def _add_prefix(name: str, prefix: str) -> str:
+        """Adds a prefix to a string or returns the string unchanged."""
+        if name.startswith(prefix):
+            return name
+        return f"{prefix}_{name}"
+
+    def new_temp_name(self, coll_name: str) -> str:
+        """Add `self._new_prefix` to a plain collection name."""
+        return self._add_prefix(coll_name, self._new_prefix)
+
+    def get_prefixed_old_name(self, coll_name: str) -> str:
+        """Add `self._old_prefix` to plain collection name."""
+        return self._add_prefix(coll_name, self._old_prefix)
+
+    def get_new_temp_names(self, coll_name: list[str]) -> list[str]:
+        """Add `self._new_prefix` to a list of plain collection names."""
+        return [self.new_temp_name(name) for name in coll_name]
+
+    def get_old_temp_names(self, coll_name: list[str]) -> list[str]:
+        """Add `self._old_prefix` to a list of plain collection names."""
+        return [self.get_prefixed_old_name(name) for name in coll_name]
+
+    async def migrate_docs_in_collection(
+        self,
+        *,
+        coll_name: str,
+        change_function: Callable[[Document], Awaitable[Document]],
+        validation_model: type[BaseModel] | None = None,
+        id_field: str = "",
+        force_validate: bool = False,
+    ):
+        """Migrate a collection by calling `change_function` on each document within.
+
+        If `validation_model` is supplied, model will be used to cross-check the
+        resulting doc data when this is the last migration to be applied/unapplied OR
+        `always_validate` is True.
+        """
+        if self._collections_staged:
+            raise RuntimeError("Collections already staged, changes shouldn't be made.")
+
+        old_collection = self._db[coll_name]
+        method = change_function
+
+        temp_new_coll_name = self.new_temp_name(coll_name)
+        temp_new_collection = self._db[temp_new_coll_name]
+
+        # naive implementation - update to use batching and bulk inserts
+        async for doc in old_collection.find():
+            output_doc = await method(doc)
+
+            # do validation against model only if we're on the last migration because
+            # the model defined in code may is not guaranteed to match until that time
+            if validation_model and (self._is_final_migration or force_validate):
+                validate_doc(output_doc, model=validation_model, id_field=id_field)
+
+            # insert into new collection
+            await temp_new_collection.insert_one(output_doc)
+        log.debug("Changes applied to collection '%s' %s", coll_name, self._log_blurb)
+
+    async def stage_collection(self, coll_name: str):
+        """Stage a single collection"""
+        old_collection = self._db[coll_name]
+        temp_old_coll_name = self.get_prefixed_old_name(coll_name)
+        await old_collection.rename(temp_old_coll_name)
+
+        temp_new_coll_name = self.new_temp_name(coll_name)
+        new_collection = self._db[temp_new_coll_name]
+        await new_collection.rename(coll_name)
+        log.debug("Staged changes for collection %s", coll_name)
+
+    async def stage_new_collections(self, coll_names: str | list[str]):
+        """Rename old collections to temporarily move them aside without dropping them.
+        Remove temporary prefix from updated collections.
+
+        Assumes apply or unapply has completed.
+        """
+        if isinstance(coll_names, str):
+            coll_names = [coll_names]
+        for coll_name in coll_names:
+            await self.stage_collection(coll_name)
+        self._collections_staged = True
+        log.info("Temp collections staged %s", self._log_blurb)
+
+    async def copy_indexes(self, coll_names: list[str]):
+        """Copy the indexes from old collections to new."""
+        # self._indexes_applied = True
+        # log.info("Indexes copied to new collections %s", self._log_blurb)
+        raise NotImplementedError()
+
+    async def drop_old_collections(
+        self, coll_names: str | list[str], enforce_indexes: bool
+    ):
+        """Drop collections.
+
+        Args
+        - `coll_names`: list of the original un-prefixed collection names modified in
+            this migration.
+        - `enforce_indexes`: Raise an error if indexes haven't been copied over to the
+            replacement collections. This is not always useful, since the collections
+            might undergo changes that make old indexes obsolete. This should be set to
+            True for modifications that don't involve changes to the collections' indexes.
+        """
+        if enforce_indexes and not self._indexes_applied:
+            raise RuntimeError("Indexes have not been applied to migrated collections")
+        if isinstance(coll_names, str):
+            coll_names = [coll_names]
+        for to_drop in [f"{self._old_prefix}_{coll_name}" for coll_name in coll_names]:
+            collection = self._db[to_drop]
+            await collection.drop()
+
+    @abstractmethod
+    async def apply(self):
+        """Make the changes required to move the DB version to `self.version`."""
+        ...
+
+    async def unapply(self):
+        """Placeholder for a method to reverse the migration changes.
+
+        To implement, additionally subclass Reversible:
+
+        ```
+        class MyMigration(MigrationDefinition, Reversible):
+            ...
+        ```
+        """
+        raise NotImplementedError()
+
+
+class Reversible(ABC):
+    """Mixin class to mark a migration class as reversible."""
+
+    @abstractmethod
+    async def unapply(self):
+        """Reverse changes made by `apply()`."""
+        ...

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -39,7 +39,8 @@ def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):
     if doc != doc_from_model:
         raise RuntimeError(
             f"Doc validation failed for model '{model.__name__}',"
-            + f" expected: {str(doc_from_model)}, but got {doc}"
+            + f" expected: {str(doc_from_model)}, but got {doc}. Ensure the model"
+            + " definition is up-to-date."
         )
 
 

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -195,8 +195,8 @@ class MigrationDefinition:
 
         # Rename the old collection by giving it a prefix
         # e.g. "users" -> "tmp_v7_old_users"
-        old_collection = self._db[original_coll_name]
         temp_old_coll_name = self.old_temp_name(original_coll_name)
+        old_collection = self._db[original_coll_name]
         await old_collection.rename(temp_old_coll_name)
 
         # Rename the new, temp collection by removing its prefix

--- a/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
+++ b/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
@@ -51,7 +51,7 @@ class V2Migration(MigrationDefinition, Reversible):
 
     async def apply(self):
         """Populate `object_size` field on docs in the file_metadata collection"""
-        async with self.auto_finalize(METADATA_COLLECTION, copy_indexes=False):
+        async with self.auto_finalize(METADATA_COLLECTION):
             await self.migrate_docs_in_collection(
                 coll_name=METADATA_COLLECTION,
                 change_function=self.add_object_size,
@@ -61,7 +61,7 @@ class V2Migration(MigrationDefinition, Reversible):
 
     async def unapply(self):
         """Remove `object_size`"""
-        async with self.auto_finalize(METADATA_COLLECTION, copy_indexes=False):
+        async with self.auto_finalize(METADATA_COLLECTION):
             await self.migrate_docs_in_collection(
                 coll_name=METADATA_COLLECTION,
                 change_function=self.remove_object_size,

--- a/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
+++ b/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
@@ -51,22 +51,20 @@ class V2Migration(MigrationDefinition, Reversible):
 
     async def apply(self):
         """Populate `object_size` field on docs in the file_metadata collection"""
-        await self.migrate_docs_in_collection(
-            coll_name=METADATA_COLLECTION,
-            change_function=self.add_object_size,
-            validation_model=FileMetadata,
-            id_field="file_id",
-        )
-        await self.stage_new_collections(METADATA_COLLECTION)
-        await self.drop_old_collections(METADATA_COLLECTION, enforce_indexes=False)
+        async with self.auto_finalize(METADATA_COLLECTION, copy_indexes=False):
+            await self.migrate_docs_in_collection(
+                coll_name=METADATA_COLLECTION,
+                change_function=self.add_object_size,
+                validation_model=FileMetadata,
+                id_field="file_id",
+            )
 
     async def unapply(self):
         """Remove `object_size`"""
-        await self.migrate_docs_in_collection(
-            coll_name=METADATA_COLLECTION,
-            change_function=self.remove_object_size,
-            validation_model=FileMetadata,
-            id_field="file_id",
-        )
-        await self.stage_new_collections(METADATA_COLLECTION)
-        await self.drop_old_collections(METADATA_COLLECTION, enforce_indexes=False)
+        async with self.auto_finalize(METADATA_COLLECTION, copy_indexes=False):
+            await self.migrate_docs_in_collection(
+                coll_name=METADATA_COLLECTION,
+                change_function=self.remove_object_size,
+                validation_model=FileMetadata,
+                id_field="file_id",
+            )

--- a/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
+++ b/services/ifrs/src/ifrs/migration_logic/ifrs_migrations.py
@@ -1,0 +1,72 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Migration definitions for the IFRS"""
+
+from ghga_service_commons.utils.multinode_storage import S3ObjectStorages
+
+from ifrs.config import Config
+from ifrs.core.models import FileMetadata
+from ifrs.migration_logic import Document, MigrationDefinition, Reversible
+
+METADATA_COLLECTION = "file_metadata"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Adds `object_size`"""
+
+    version = 2
+
+    def __init__(self, *args, **kwargs):
+        """Initialize migration class and set up object storages to get object size"""
+        super().__init__(*args, **kwargs)
+        config = Config()
+        self.storages = S3ObjectStorages(config=config)
+
+    async def add_object_size(self, doc: Document) -> Document:
+        """Populate the `object_size` field"""
+        object_id = doc["object_id"]
+        storage_alias = doc["storage_alias"]
+        permanent_bucket_id, object_storage = self.storages.for_alias(storage_alias)
+        doc["object_size"] = await object_storage.get_object_size(
+            bucket_id=permanent_bucket_id, object_id=object_id
+        )
+        return doc
+
+    async def remove_object_size(self, doc: Document) -> Document:
+        """Remove the `object_size` field"""
+        doc.pop("object_size", "")
+        return doc
+
+    async def apply(self):
+        """Populate `object_size` field on docs in the file_metadata collection"""
+        await self.migrate_docs_in_collection(
+            coll_name=METADATA_COLLECTION,
+            change_function=self.add_object_size,
+            validation_model=FileMetadata,
+            id_field="file_id",
+        )
+        await self.stage_new_collections(METADATA_COLLECTION)
+        await self.drop_old_collections(METADATA_COLLECTION, enforce_indexes=False)
+
+    async def unapply(self):
+        """Remove `object_size`"""
+        await self.migrate_docs_in_collection(
+            coll_name=METADATA_COLLECTION,
+            change_function=self.remove_object_size,
+            validation_model=FileMetadata,
+            id_field="file_id",
+        )
+        await self.stage_new_collections(METADATA_COLLECTION)
+        await self.drop_old_collections(METADATA_COLLECTION, enforce_indexes=False)

--- a/services/ifrs/src/ifrs/migrations.py
+++ b/services/ifrs/src/ifrs/migrations.py
@@ -1,0 +1,46 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database version checking & migration before startup"""
+
+from ifrs.config import Config
+from ifrs.migration_logic import MigrationManager, MigrationMap
+from ifrs.migration_logic.ifrs_migrations import V2Migration
+
+MIGRATION_MAP: MigrationMap = {2: V2Migration}
+DB_TARGET_VERSION = 2
+
+
+async def run_db_migrations(
+    *,
+    config: Config,
+    target_version: int = DB_TARGET_VERSION,
+):
+    """Check if the database is up to date and attempt to migrate the data if not.
+
+    The service must not start until this function is successful.
+
+    Args
+    - `config`: Config containing db connection str and lock/db versioning collections
+    - `target_version`: Which version the db needs to be at for this version of the service
+
+    `target_version` can be specified to aid in testing.
+    """
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/services/ifrs/tests_ifrs/fixtures/test_config.yaml
+++ b/services/ifrs/tests_ifrs/fixtures/test_config.yaml
@@ -19,3 +19,6 @@ file_staged_event_topic: internal-file-registry
 file_staged_event_type: file_staged_for_download
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
+lock_collection: ifrs_db_lock
+db_version_collection: ifrs_db_versions
+migration_wait_sec: 2

--- a/services/ifrs/tests_ifrs/fixtures/test_config.yaml
+++ b/services/ifrs/tests_ifrs/fixtures/test_config.yaml
@@ -19,6 +19,5 @@ file_staged_event_topic: internal-file-registry
 file_staged_event_type: file_staged_for_download
 file_deleted_event_topic: internal-file-registry
 file_deleted_event_type: file_deleted
-lock_collection: ifrs_db_lock
-db_version_collection: ifrs_db_versions
+db_version_collection: ifrsDbVersions
 migration_wait_sec: 2

--- a/services/ifrs/tests_ifrs/test_migrations.py
+++ b/services/ifrs/tests_ifrs/test_migrations.py
@@ -1,0 +1,120 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for database migrations"""
+
+from random import randint
+
+import pytest
+from ghga_service_commons.utils.multinode_storage import (
+    S3ObjectStorageNodeConfig,
+    S3ObjectStoragesConfig,
+)
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+from hexkit.providers.s3.testutils import S3Fixture, temp_file_object
+
+from ifrs.core.models import FileMetadataBase
+from ifrs.migration_logic._manager import MigrationStepError
+from ifrs.migrations import run_db_migrations
+from tests_ifrs.fixtures.config import get_config
+from tests_ifrs.fixtures.example_data import EXAMPLE_METADATA_BASE
+
+
+@pytest.mark.asyncio
+async def test_v2_migration(
+    mongodb: MongoDbFixture,
+    s3: S3Fixture,
+    populate_s3_buckets,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test the migration script for v2 where we add the size of the encrypted object
+    to the docs in the file_metadata collection.
+    """
+    # Create the test config for the object storage
+    node_config = S3ObjectStorageNodeConfig(bucket="permanent", credentials=s3.config)
+    object_storage_config = S3ObjectStoragesConfig(
+        object_storages={
+            "test": node_config,
+        }
+    )
+
+    # Patch the config
+    config = get_config(sources=[mongodb.config, object_storage_config])
+    monkeypatch.setattr("ifrs.migration_logic.ifrs_migrations.Config", lambda: config)
+    client = mongodb.client
+    coll = client[config.db_name]["file_metadata"]
+
+    # Set up test data - we want some random object sizes to verify we're not accidentally
+    #  reading some dummy value somewhere. Record the sizes so we can check later that
+    #  what we retrieve is correct.
+    test_data = []
+    sizes = []
+    base = EXAMPLE_METADATA_BASE.model_dump()
+    base.pop("file_id")
+    for n in range(1, 10):
+        metadata_base = base.copy()
+        metadata_base["_id"] = f"examplefile00{n}"
+        metadata_base["object_id"] = f"objectid00{n}"
+        test_data.append(metadata_base)
+        size = randint(1000, 4000)
+        sizes.append(size)
+        coll.insert_one(metadata_base)
+
+        # Upload a temp file object with the given size to our S3 fixture
+        with temp_file_object(
+            bucket_id="permanent", object_id=f"objectid00{n}", size=size
+        ) as f:
+            await s3.populate_file_objects([f])
+
+    post_insert = [_ for _ in coll.find()]
+    assert len(post_insert) == 9
+    for doc in post_insert:
+        assert "object_size" not in doc
+
+    # Run the database migrations, which should create the lock/versioning collection
+    #  and then update the 'file_metadata' collection.
+    await run_db_migrations(config=config)
+
+    # Make sure the docs from file_metadata were updated with the right size values
+    post_apply = [_ for _ in coll.find()]
+    assert len(post_apply) == 9
+    for doc, size in zip(post_apply, sizes, strict=True):
+        assert "object_size" in doc
+        assert doc["object_size"] == size
+
+    # Unapply the v2 migration, which will fail because the current model requires
+    #  the `object_size` field.
+    with pytest.raises(MigrationStepError):
+        await run_db_migrations(config=config, target_version=1)
+
+    # Make sure the docs from file_metadata were updated with the right size values
+    post_failed_unapply = [_ for _ in coll.find()]
+    assert len(post_failed_unapply) == 9
+    for doc, size in zip(post_failed_unapply, sizes, strict=True):
+        assert "object_size" in doc
+        assert doc["object_size"] == size
+
+    # Monkeypatch the pydantic model to resemble the old version so we can test reversal
+    class PatchedFileMetadata(FileMetadataBase):
+        object_id: str
+
+    monkeypatch.setattr(
+        "ifrs.migration_logic.ifrs_migrations.FileMetadata", PatchedFileMetadata
+    )
+    await run_db_migrations(config=config, target_version=1)
+
+    post_unapply = [_ for _ in coll.find()]
+    assert len(post_unapply) == 9
+    for doc in post_unapply:
+        assert "object_size" not in doc


### PR DESCRIPTION
Adds a very rough version of the migration framework which aims to minimize the amount of related code required to be maintained across services without being too restricting/prescriptive.

**Step 1**: The logic for every migration should subclass `MigrationDefinition` and, usually, `Reversible` as well:
```python
class V2Migration(MigrationDefinition, Reversible):
    """Adds `object_size` and migrates the database to version 2"""

    version = 2

    async def apply(self):
        async with self.auto_finalize("file_metadata"):
            await self.migrate_docs_in_collection(
                coll_name=METADATA_COLLECTION,
                change_function=my_change_function,
                validation_model=FileMetadata,
                id_field="file_id",
            )

    async def unapply(self):
        ...
```

**Step 2**: Define the current database version and the migration map. 
>In this prototype, version 0 = "DB versioning is not set up" and version 1 = "DB versioning has been created", and our migrations begin with version 2. Does not have to be that way, that's just what I landed on for now.
```python
from my_migrations import V2Migration, V3Migration, V4Migration  # etc.

MIGRATION_MAP = {2: V2Migration, 3: V3Migration, 4: V4Migration}
DB_VERSION = 4
```

**Step 3**: Instantiate the `MigrationManager` via `async with`, then call `.migrate_or_wait()`:
```python
MIGRATION_MAP = {2: V2Migration, 3: V3Migration, 4: V4Migration}
DB_VERSION = 4

async def run_db_migrations(*, config: Config, target_version: int = DB_VERSION):
    """Check if the database is up to date and attempt to migrate the data if not."""
    async with MigrationManager(
        config=config,
        target_version=target_version,
        migration_map=MIGRATION_MAP,
    ) as mm:
        await mm.migrate_or_wait()
```

**Step 4**: Perform the DB migrations/version check sometime before firing up the actual service code:
```python
async def consume_events(run_forever: bool = True):
    """Run an event consumer listening to the specified topics."""
    config = Config()
    configure_logging(config=config)
    await run_db_migrations(config=config)

    async with prepare_outbox_subscriber(config=config) as outbox_subscriber:
        await outbox_subscriber.run(forever=run_forever)
```

### Notes
The `MigrationDefinition` class defines some useful logic for common operations, such as "staging" migrated data (where we rename the collections to swap the new data with the old), dropping new collections, generating temp table prefixing, applying an update function to each doc in a collection with validation, and a context manager to automate staging/dropping/error case cleanup.

The `MigrationManager` handles higher-level responsibilities and is ignorant of migration implementation details. It cares about whether or not the database is set up for migrations, determining which migrations it needs to run to get from version X to version Y, and running said migrations. It handles the database "lock" document to ensure only one service instance ever performs migrations, as well as maintaining a record past migrations.

Solving the catch-22 of making sure only one instance _initializes_ the lock & versioning collections is straightforward: the code inserts a lock document with a fixed ID. If the result is a `DuplicateKeyError` error, stop and enter the waiting cycle (another instance was faster), otherwise continue with the init & migration logic. The service instance that performs the initialization will already have the lock acquired after finishing setup and can roll right into executing any migrations.

Currently one test case added that covers the following:
- Migration success
- Migration unapply success
- Migration unapply failure due to model mismatch
- Migration idempotence (should be able to run migration check a bunch with no effect if already up to date)

Outstanding items planned or in progress for official framework:
- batch processing (naive one-by-one doc updates right now)
- index copying (need to understand this better)
- (maybe) automatically pass config to instances of MigrationDefinition - only an inconvenience for testing though
- Testing to cover all the edge cases along with unit testing to better catch problems with helper functions
- Better metrics (e.g. # documents affected)
- Logging/error handling is currently unpolished, needs improvement
- Limits or something for retries? Not sure
- `Reversible` subclass thing could probably be done differently
- Better documentation
- Whatever ideas and critiques come up in the meantime
