### PR TITLE
Add encrypted_size migration to DCS (GSI-1290)

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -299,6 +299,36 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- **`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
 - **`drs_server_uri`** *(string, required)*: The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.
 
 

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -305,7 +305,7 @@ The service requires the following configuration parameters:
   Examples:
 
   ```json
-  "ifrsDbVersions"
+  "dcsDbVersions"
   ```
 
 

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -333,7 +333,7 @@
     "db_version_collection": {
       "description": "The name of the collection containing DB version information for this service",
       "examples": [
-        "ifrsDbVersions"
+        "dcsDbVersions"
       ],
       "title": "Db Version Collection",
       "type": "string"

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -330,6 +330,24 @@
       "title": "Db Name",
       "type": "string"
     },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
     "drs_server_uri": {
       "description": "The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.",
       "examples": [
@@ -586,6 +604,8 @@
     "kafka_servers",
     "db_connection_str",
     "db_name",
+    "db_version_collection",
+    "migration_wait_sec",
     "drs_server_uri",
     "ekss_base_url",
     "presigned_url_expires_after",

--- a/services/dcs/dev_config.yaml
+++ b/services/dcs/dev_config.yaml
@@ -39,5 +39,7 @@ unstaged_download_collection: unstagedDownloadRequested
 files_to_delete_topic: file-deletions
 file_deleted_event_topic: file-downloads
 file_deleted_event_type: file_deleted
+db_version_collection: dcsDbVersions
+migration_wait_sec: 10
 auth_key: "{}"
 log_level: INFO

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -20,6 +20,7 @@ cors_allowed_methods: []
 cors_allowed_origins: []
 db_connection_str: '**********'
 db_name: dev
+db_version_collection: dcsDbVersions
 docs_url: /docs
 download_served_event_topic: file-downloads
 download_served_event_type: download_served
@@ -45,6 +46,7 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_wait_sec: 10
 object_storages:
   test:
     bucket: outbox

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 3.0.0
+  version: 4.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 4.0.0
+  version: 3.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/src/dcs/config.py
+++ b/services/dcs/src/dcs/config.py
@@ -22,7 +22,6 @@ from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb import MongoDbConfig
 from pydantic import Field
 
 from dcs.adapters.inbound.event_sub import (
@@ -33,6 +32,7 @@ from dcs.adapters.inbound.fastapi_.configure import DrsApiConfig
 from dcs.adapters.outbound.daopub import OutboxDaoConfig
 from dcs.adapters.outbound.event_pub import EventPubTranslatorConfig
 from dcs.core.data_repository import DataRepositoryConfig
+from dcs.migration_logic import MigrationConfig
 
 
 class WorkOrderTokenConfig(AuthConfig):
@@ -54,7 +54,7 @@ class Config(
     DrsApiConfig,
     WorkOrderTokenConfig,
     DataRepositoryConfig,
-    MongoDbConfig,
+    MigrationConfig,
     KafkaConfig,
     EventPubTranslatorConfig,
     EventSubTranslatorConfig,

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -28,12 +28,14 @@ from dcs.inject import (
     prepare_outbox_subscriber,
     prepare_rest_app,
 )
+from dcs.migrations import run_db_migrations
 
 
 async def run_rest_app():
     """Run the HTTP REST API."""
     config = Config()
     configure_logging(config=config)
+    await run_db_migrations(config=config)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -43,6 +45,7 @@ async def consume_events(run_forever: bool = True):
     """Run an event consumer listening to the specified topic."""
     config = Config()
     configure_logging(config=config)
+    await run_db_migrations(config=config)
 
     async with (
         prepare_event_subscriber(config=config) as event_subscriber,
@@ -58,6 +61,7 @@ async def run_outbox_cleanup():
     """Check if outbox buckets contains files that should be cleaned up and perform clean-up."""
     config = Config()
     configure_logging(config=config)
+    await run_db_migrations(config=config)
 
     async with prepare_outbox_cleaner(config=config) as cleanup_outbox:
         await cleanup_outbox
@@ -67,6 +71,7 @@ async def publish_events(*, all: bool = False):
     """Publish pending events. Set `--all` to (re)publish all events regardless of status."""
     config = Config()
     configure_logging(config=config)
+    await run_db_migrations(config=config)
 
     async with get_nonstaged_file_requested_dao(config=config) as dao:
         if all:

--- a/services/dcs/src/dcs/migration_logic/__init__.py
+++ b/services/dcs/src/dcs/migration_logic/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Temporary database migration logic, copied from IFRS until added to hexkit"""
+
+from ._manager import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+    MigrationStepError,
+)
+from ._utils import Document, MigrationDefinition, Reversible, validate_doc
+
+__all__ = [
+    "Document",
+    "MigrationConfig",
+    "MigrationDefinition",
+    "MigrationManager",
+    "MigrationMap",
+    "MigrationStepError",
+    "Reversible",
+    "validate_doc",
+]

--- a/services/dcs/src/dcs/migration_logic/_manager.py
+++ b/services/dcs/src/dcs/migration_logic/_manager.py
@@ -1,0 +1,382 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tools to run database migrations in services"""
+
+import logging
+from asyncio import sleep
+from contextlib import asynccontextmanager, suppress
+from time import time
+from typing import Literal, TypedDict
+
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.providers.mongodb import MongoDbConfig
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from pydantic import Field
+from pymongo.errors import DuplicateKeyError
+
+from ._utils import MigrationDefinition, Reversible
+
+log = logging.getLogger(__name__)
+
+MigrationType = Literal["FORWARD", "BACKWARD"]
+MigrationCls = type[MigrationDefinition]
+MigrationMap = dict[int, MigrationCls]
+
+
+def duration_in_ms(duration: float) -> int:
+    return int(duration * 1000)
+
+
+class MigrationConfig(MongoDbConfig):
+    """Minimal configuration required to run the migration process."""
+
+    db_version_collection: str = Field(
+        ...,
+        description="The name of the collection containing DB version information for this service",
+        examples=["ifrsDbVersions"],
+    )
+    migration_wait_sec: int = Field(
+        ...,
+        description="The number of seconds to wait before checking the DB version again",
+        examples=[5, 30, 180],
+    )
+
+
+class DbVersionRecord(TypedDict):
+    """Model containing information about DB versions and how they were achieved."""
+
+    version: int
+    completed: str
+    migration_type: MigrationType
+    total_duration_ms: int
+
+
+class MigrationStepError(RuntimeError):
+    """Raised when a specific migration step fails, e.g. migrating from v4 to v5"""
+
+    def __init__(self, *, current_ver: int, target_ver: int, err_info: str):
+        msg = (
+            f"Unable to migrate from DB version {current_ver} to {target_ver}."
+            + f" Cause:\n  '{err_info}'"
+        )
+        super().__init__(msg)
+
+
+class DbLockError(RuntimeError):
+    """Raised when the DB lock can't be released or acquired due to an error."""
+
+    def __init__(
+        self, *, op: Literal["acquire", "release"], coll_name: str, err_info: str
+    ):
+        msg = (
+            f"Failed to {op} the lock in collection {coll_name}."
+            + f" Error details:\n  '{err_info}'"
+        )
+        super().__init__(msg)
+
+
+class DbVersioningInitError(RuntimeError):
+    """Raised when DB versioning initialization fails due to an error."""
+
+    def __init__(self, *, err_info: str):
+        msg = f"DB versioning initialization failed. Error details:\n  {err_info}"
+        super().__init__(msg)
+
+
+def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
+    """Gets the current DB version from the documents found in the version collection."""
+    # Make sure we know what the latest version is, not just the max
+    version_docs.sort(key=lambda doc: doc["completed"])
+    return version_docs[-1]["version"] if version_docs else 0
+
+
+class MigrationManager:
+    """Top-level logic for ensuring the database is updated before running the service.
+
+    The `migrate_or_wait` method must be called before any instance of the service
+    begins its main execution loop.
+
+    Version 1 is reserved for the framework as a way to mark when versioning was added.
+
+    Example usage:
+    ```
+    from my_service.config import Config  # inherits from MongoDbConfig
+    from <module with this class> import MigrationManager
+    from <module with migration code> import V2Migration, V3Migration
+
+    DB_VERSION = 2  # the current expected DB version
+    MY_MIGRATION_MAP = {2: V2Migration, 3: V3Migration} # etc.
+
+    def migrate_my_service():
+        # Called before starting my_service
+        config = Config()
+
+        async with MigrationManager(config, DB_VERSION, MY_MIGRATION_MAP) as mm:
+            await mm.migrate_or_wait()
+    ```
+    """
+
+    client: AsyncIOMotorClient
+    db: AsyncIOMotorDatabase
+
+    def __init__(
+        self,
+        config: MigrationConfig,
+        target_version: int,
+        migration_map: MigrationMap,
+    ):
+        """Instantiate the MigrationManager.
+
+        Args
+        - `config`: Config containing db connection str and lock/db versioning collections
+        - `target_version`: Which version the db needs to be at for this version of the service
+        - `migration_map`: A dict with the MigrationDefinition class for each db version
+        """
+        if target_version < 1:
+            raise RuntimeError("Expected database version must be 1 or greater")
+
+        self.config = config
+        self.target_ver = target_version
+        self.migration_map = migration_map
+        self._lock_acquired = False
+        self._entered = False
+        self._migration_type: MigrationType = "FORWARD"
+
+    async def __aenter__(self):
+        """Set up database client and database reference"""
+        self.client = AsyncIOMotorClient(
+            self.config.db_connection_str.get_secret_value()
+        )
+        self.db = self.client[self.config.db_name]
+        self._entered = True
+        return self
+
+    async def __aexit__(self, exc_type_, exc_value, exc_tb):
+        """Release DB lock and close/remove database client"""
+        await self._release_db_lock()
+        self.client.close()
+
+    async def _get_version_docs(self) -> list[DbVersionRecord]:
+        """Gets the DB version information from the database."""
+        collection = self.db[self.config.db_version_collection]
+        # use a filter to avoid picking up the lock doc, just in case
+        version_docs = []
+        async for doc in collection.find({"_id": {"$ne": 0}}):
+            doc.pop("_id")
+            version_docs.append(DbVersionRecord(**doc))  # type: ignore
+        return version_docs
+
+    @asynccontextmanager
+    async def _lock_db(self):
+        await self._acquire_db_lock()
+        try:
+            yield
+        finally:
+            await self._release_db_lock()
+
+    async def _acquire_db_lock(self) -> None:
+        """Try to acquire the lock on the DB and return the result.
+
+        Logs and raises any error that occurs while updating the lock document.
+        """
+        if self._lock_acquired:
+            log.debug("Database lock already acquired")
+            return
+        coll_name = self.config.db_version_collection
+        try:
+            version_coll = self.db[coll_name]
+            with suppress(DuplicateKeyError):
+                await version_coll.insert_one(
+                    {
+                        "_id": 0,
+                        "lock_acquired": True,
+                        "acquired_at": now_as_utc().isoformat(),
+                    }
+                )
+                self._lock_acquired = True
+                log.info("Database lock acquired")
+        except BaseException as exc:
+            error = DbLockError(op="acquire", coll_name=coll_name, err_info=str(exc))
+            log.error(error)
+            raise error from exc
+
+        if not self._lock_acquired:
+            log.debug("Did not acquire DB lock in collection %s", coll_name)
+
+    async def _release_db_lock(self) -> None:
+        """Release the DB lock by deleting the lock document.
+
+        Logs and re-raises any errors that occur during the update.
+        """
+        if not self._lock_acquired:
+            log.debug("Database lock already released")
+            return
+        coll_name = self.config.db_version_collection
+        try:
+            version_coll = self.db[coll_name]
+            await version_coll.find_one_and_delete({"lock_acquired": True})
+            self._lock_acquired = False
+        except BaseException as exc:
+            error = DbLockError(op="release", coll_name=coll_name, err_info=str(exc))
+            log.critical(error)
+            raise error from exc
+        log.info("Database lock released")
+
+    async def _record_migration(self, *, version: int, total_duration_ms: int):
+        """Insert a DbVersionRecord with processing information"""
+        record = DbVersionRecord(
+            version=version,
+            completed=now_as_utc().isoformat(),
+            migration_type=self._migration_type,
+            total_duration_ms=total_duration_ms,
+        )
+        version_collection = self.db[self.config.db_version_collection]
+        await version_collection.insert_one(record)
+
+    async def _initialize_versioning(self) -> bool:
+        """Create and acquire the DB lock, then add the versioning collection.
+
+        Returns `True` if setup was performed, else `False`.
+        """
+        init_start = time()
+        async with self._lock_db():
+            if self._lock_acquired:
+                # Initialize db version collection
+                await self._record_migration(
+                    version=1,
+                    total_duration_ms=duration_in_ms(time() - init_start),
+                )
+                return True
+        return False
+
+    def _get_version_sequence(self, *, current_ver: int) -> list[int]:
+        """Return an ordered list of the version migrations to apply/unapply"""
+        # In forward case, we don't need to apply current ver
+        # in backward case, we don't want to unapply the target ver
+        step_range = (
+            range(current_ver, self.target_ver, -1)
+            if self._migration_type == "BACKWARD"
+            else range(current_ver + 1, self.target_ver + 1)
+        )
+        steps = list(step_range)
+        return steps
+
+    def _fetch_migration_cls(self, version: int) -> MigrationCls:
+        """Return the stored migration for the specified version.
+
+        Raise an error if the  doesn't exist or doesn't implement unapply when needed.
+        """
+        try:
+            migration_cls = self.migration_map[version]
+            if self._migration_type == "BACKWARD" and not issubclass(
+                migration_cls, Reversible
+            ):
+                raise RuntimeError(
+                    f"Planning to unapply migration v{version}, but"
+                    + f" it doesn't subclass `{Reversible.__name__}`!"
+                )
+            return migration_cls
+        except KeyError as err:
+            mig_type = self._migration_type.lower()
+            raise NotImplementedError(
+                f"No {mig_type} migration implemented for version {version}"
+            ) from err
+
+    async def _perform_migrations(self, *, current_ver: int):
+        """Migrate forward or backward to reach target DB version.
+
+        Raises `MigrationError` if unsuccessful.
+        """
+        ver_sequence = self._get_version_sequence(current_ver=current_ver)
+        migrations = [self._fetch_migration_cls(ver) for ver in ver_sequence]
+        unapplying = self._migration_type == "BACKWARD"
+        # Execute & time each migration in order to get to the target DB version
+        for version, migration_cls in zip(ver_sequence, migrations, strict=True):
+            try:
+                # Determine if this is the last migration to apply/unapply
+                is_final_migration = version == ver_sequence[-1]
+
+                # instantiate MigrationDefinition
+                migration = migration_cls(
+                    db=self.db,
+                    unapplying=unapplying,
+                    is_final_migration=is_final_migration,
+                )
+
+                # Call apply/unapply based on migration type
+                await migration.unapply() if unapplying else await migration.apply()
+            except BaseException as exc:
+                error = MigrationStepError(
+                    current_ver=version - 1,
+                    target_ver=self.target_ver,
+                    err_info=str(exc),
+                )
+                log.critical(error)
+                raise error from exc
+
+    async def _migrate_db(self) -> bool:
+        """Ensure the database is up to date before running the actual app.
+
+        If the database is already up to date, no changes are made. If the database is
+        out of date, migration code is executed to make the database current.
+
+        Returns True if migrations are finished or up-to-date and False otherwise.
+        """
+        version_docs = await self._get_version_docs()
+        version = _get_db_version_from_records(version_docs)
+
+        if version == 0:
+            try:
+                init_complete = await self._initialize_versioning()
+            except BaseException as exc:
+                error = DbVersioningInitError(err_info=str(exc))
+                log.critical(error)
+                raise error from exc
+            if not init_complete:
+                return False
+            version = 1
+
+        if version == self.target_ver:
+            # DB is up to date, run service
+            return True
+
+        # DB version is not what it should be: acquire lock and migrate
+        async with self._lock_db():
+            if not self._lock_acquired:
+                return False
+
+            self._migration_type = (
+                "FORWARD" if version < self.target_ver else "BACKWARD"
+            )
+
+            start = time()
+            await self._perform_migrations(current_ver=version)
+            duration_ms = duration_in_ms(time() - start)
+
+            # record the db version
+            await self._record_migration(
+                version=self.target_ver,
+                total_duration_ms=duration_ms,
+            )
+        return True
+
+    async def migrate_or_wait(self):
+        """Try to migrate the database or wait until migrations are completed."""
+        if not self._entered:
+            raise RuntimeError("MigrationManager must be used as a context manager")
+
+        # need to implement some kind of total time limit, warning logging, etc. later
+        while not await self._migrate_db():
+            await sleep(self.config.migration_wait_sec)

--- a/services/dcs/src/dcs/migration_logic/_manager.py
+++ b/services/dcs/src/dcs/migration_logic/_manager.py
@@ -45,7 +45,7 @@ class MigrationConfig(MongoDbConfig):
     db_version_collection: str = Field(
         ...,
         description="The name of the collection containing DB version information for this service",
-        examples=["ifrsDbVersions"],
+        examples=["dcsDbVersions"],
     )
     migration_wait_sec: int = Field(
         ...,

--- a/services/dcs/src/dcs/migration_logic/_utils.py
+++ b/services/dcs/src/dcs/migration_logic/_utils.py
@@ -1,0 +1,293 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utils for defining and applying database migrations"""
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from typing import Any
+
+from hexkit.providers.mongodb.provider import document_to_dto, dto_to_document
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
+
+Document = dict[str, Any]
+
+
+def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):
+    """Ensure that new content passes model validation.
+
+    Also check that `dto_to_document` results in the same document.
+    """
+    as_model = document_to_dto(deepcopy(doc), id_field=id_field, dto_model=model)
+    doc_from_model = dto_to_document(as_model, id_field=id_field)
+    if doc != doc_from_model:
+        raise RuntimeError(
+            f"Doc validation failed for model '{model.__name__}',"
+            + f" expected: {str(doc_from_model)}, but got {doc}. Ensure the model"
+            + " definition is up-to-date."
+        )
+
+
+class MigrationDefinition:
+    """Contains all logic to migrate the database from one version to the next."""
+
+    version: int
+
+    def __init__(
+        self,
+        *,
+        db: AsyncIOMotorDatabase,
+        unapplying: bool,
+        is_final_migration: bool,
+    ):
+        """Instantiate the MigrationDefinition.
+
+        Subclass overrides need to call `super().__init__` or include its code.
+        """
+        if not self.version:
+            raise ValueError("Migration version has not been assigned")
+
+        self._db = db
+        self._temp_prefix = f"tmp_v{self.version}{'_unapply' if unapplying else ''}"
+        self._new_prefix = f"{self._temp_prefix}_new"
+        self._old_prefix = f"{self._temp_prefix}_old"
+        self._log_blurb = f"for {'downgrade' if unapplying else 'upgrade'} to DB version {self.version}"
+
+        # Used to determine if it should be safe to use model definitions for validation
+        self._is_final_migration = is_final_migration
+
+        # Tracks which collections have had indexes copied over from old collections
+        self._indexes_copied: set[str] = set()
+
+        # Tracks which collections have been staged
+        self._staged_collections: set[str] = set()
+
+    @asynccontextmanager
+    async def auto_finalize(
+        self, coll_names: str | list[str], copy_indexes: bool = False
+    ):
+        """Use within `apply()` or `unapply()` as a context manager to automatically
+        stage the temporary migrated collections for the specified collection names and
+        then drop the old collections. Set `copy_indexes` to True if the indexes are
+        expected to be identical between the old and new collection versions.
+
+        Should be used for most migrations, but complex migrations might need to take
+        a more manual approach. For that reason, this context manager is optional.
+
+        If an error occurs during the migration process, staged changes will be unstaged
+        and dropped. If a subsequent error occurs during cleanup, it is logged with a
+        recommendation to restore the database.
+        """
+        try:
+            # copy indexes if needed (not implemented yet)
+            if copy_indexes:
+                raise NotImplementedError("Index copying is not yet implemented")
+            # Yield to run the actual migration
+            yield
+            await self.stage_new_collections(coll_names)
+
+            # Drop old collections. Don't do the index copy check unless we perform the
+            #  index copying via this method. Otherwise we can't be sure it wasn't
+            #  handled some other way
+            await self.drop_old_collections(enforce_indexes=copy_indexes)
+        except BaseException as exc:
+            try:
+                for staged in self._staged_collections:
+                    await self.unstage_collection(staged)
+                    await self._db.drop_collection(self.new_temp_name(staged))
+            except BaseException as exc_in_cleanup:
+                log.critical(
+                    "Error occurred while cleaning up migration failure. State cannot"
+                    + " be assured to be recoverable. Database restore recommended."
+                    + " Exception info: %s",
+                    str(exc_in_cleanup),
+                )
+                raise
+            log.critical(
+                "Migration failed but cleanup was successful. Error: %s", str(exc)
+            )
+            raise
+
+    @staticmethod
+    def _add_prefix(name: str, prefix: str) -> str:
+        """Adds a prefix to a string or returns the string unchanged."""
+        if name.startswith(prefix):
+            return name
+        return f"{prefix}_{name}"
+
+    def new_temp_name(self, coll_name: str) -> str:
+        """Add `self._new_prefix` to a plain collection name."""
+        return self._add_prefix(coll_name, self._new_prefix)
+
+    def old_temp_name(self, coll_name: str) -> str:
+        """Add `self._old_prefix` to plain collection name."""
+        return self._add_prefix(coll_name, self._old_prefix)
+
+    def get_new_temp_names(self, coll_name: list[str]) -> list[str]:
+        """Add `self._new_prefix` to a list of plain collection names."""
+        return [self.new_temp_name(name) for name in coll_name]
+
+    def get_old_temp_names(self, coll_name: list[str]) -> list[str]:
+        """Add `self._old_prefix` to a list of plain collection names."""
+        return [self.old_temp_name(name) for name in coll_name]
+
+    async def migrate_docs_in_collection(
+        self,
+        *,
+        coll_name: str,
+        change_function: Callable[[Document], Awaitable[Document]],
+        validation_model: type[BaseModel] | None = None,
+        id_field: str = "",
+        force_validate: bool = False,
+    ):
+        """Migrate a collection by calling `change_function` on each document within.
+
+        If `validation_model` is supplied, model will be used to cross-check the
+        resulting doc data when this is the last migration to be applied/unapplied OR
+        `always_validate` is True.
+        """
+        if coll_name in self._staged_collections:
+            raise RuntimeError("Collections already staged, changes shouldn't be made.")
+
+        old_collection = self._db[coll_name]
+        method = change_function
+
+        # Drop the temp collection first to make sure we're starting fresh.
+        temp_new_coll_name = self.new_temp_name(coll_name)
+        await self._db.drop_collection(temp_new_coll_name)
+        temp_new_collection = self._db[temp_new_coll_name]
+
+        # naive implementation - update to use batching and bulk inserts
+        async for doc in old_collection.find():
+            output_doc = await method(doc)
+
+            # do validation against model only if we're on the last migration because
+            # the model defined in code is not guaranteed to match until that time
+            if validation_model and (self._is_final_migration or force_validate):
+                validate_doc(output_doc, model=validation_model, id_field=id_field)
+
+            # insert into new collection
+            await temp_new_collection.insert_one(output_doc)
+        log.debug("Changes applied to collection '%s' %s", coll_name, self._log_blurb)
+
+    async def stage_collection(self, original_coll_name: str):
+        """Stage a single collection"""
+        # Don't do anything if it's already staged
+        if original_coll_name in self._staged_collections:
+            return
+
+        # Rename the old collection by giving it a prefix
+        # e.g. "users" -> "tmp_v7_old_users"
+        temp_old_coll_name = self.old_temp_name(original_coll_name)
+        old_collection = self._db[original_coll_name]
+        await old_collection.rename(temp_old_coll_name)
+
+        # Rename the new, temp collection by removing its prefix
+        # e.g. "tmp_v7_new_users" -> "users"
+        temp_new_coll_name = self.new_temp_name(original_coll_name)
+        new_collection = self._db[temp_new_coll_name]
+        await new_collection.rename(original_coll_name)
+
+        # Mark this collection as staged
+        self._staged_collections.add(original_coll_name)
+        log.debug("Staged changes for collection %s", original_coll_name)
+
+    async def unstage_collection(self, original_coll_name: str):
+        """Reverse steps from `stage_collection()`"""
+        # Add the prefix back to the new collection
+        # e.g. "users" -> "tmp_v7_new_users"
+        temp_new_coll_name = self.new_temp_name(original_coll_name)
+        new_collection = self._db[original_coll_name]
+        await new_collection.rename(temp_new_coll_name)
+
+        # Remove the prefix from the old collection
+        # e.g. "tmp_v7_old_users" -> "users"
+        temp_old_coll_name = self.old_temp_name(original_coll_name)
+        old_collection = self._db[temp_old_coll_name]
+        await old_collection.rename(temp_old_coll_name)
+
+        # Remove this collection from the "staged" tracking set
+        self._staged_collections.remove(original_coll_name)
+        log.debug("Unstaged changes for collection %s", original_coll_name)
+
+    async def stage_new_collections(self, original_coll_names: str | list[str]):
+        """Rename old collections to temporarily move them aside without dropping them,
+        then remove the temporary prefix from the migrated collections.
+
+        Assumes apply or unapply has completed.
+        """
+        if isinstance(original_coll_names, str):
+            original_coll_names = [original_coll_names]
+        for coll_name in original_coll_names:
+            await self.stage_collection(coll_name)
+        log.info("Temp collections staged %s", self._log_blurb)
+
+    async def copy_indexes(self, *, coll_names: str | list[str]):
+        """Copy the indexes from old collections to new."""
+        if isinstance(coll_names, str):
+            coll_names = [coll_names]
+        raise NotImplementedError()
+
+    async def drop_old_collections(self, *, enforce_indexes: bool):
+        """Drop the old, pre-migration version of all staged collections.
+
+        Args
+        - `enforce_indexes`: Raise an error if indexes haven't been copied over to the
+            replacement collections. This is not always useful, since the collections
+            might undergo changes that make old indexes obsolete. This should be set to
+            True for modifications that don't involve changes to the collections' indexes.
+        """
+        if enforce_indexes and not self._indexes_copied:
+            raise RuntimeError("Indexes have not been applied to staged collections")
+
+        for coll_to_drop in list(self._staged_collections):
+            old_temp_name = self.old_temp_name(coll_to_drop)
+            collection = self._db[old_temp_name]
+            await collection.drop()
+            log.debug(
+                "Dropped old collection for '%s' ('%s')", coll_to_drop, old_temp_name
+            )
+            self._staged_collections.remove(coll_to_drop)
+
+    @abstractmethod
+    async def apply(self):
+        """Make the changes required to move the DB version to `self.version`."""
+        ...
+
+    async def unapply(self):
+        """Placeholder for a method to reverse the migration changes.
+
+        To implement, additionally subclass Reversible:
+
+        ```
+        class MyMigration(MigrationDefinition, Reversible):
+            ...
+        ```
+        """
+        raise NotImplementedError()
+
+
+class Reversible(ABC):
+    """Mixin class to mark a migration class as reversible."""
+
+    @abstractmethod
+    async def unapply(self):
+        """Reverse changes made by `apply()`."""
+        ...

--- a/services/dcs/src/dcs/migration_logic/dcs_migrations.py
+++ b/services/dcs/src/dcs/migration_logic/dcs_migrations.py
@@ -1,0 +1,65 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Migration definitions for the DCS"""
+
+import math
+
+import crypt4gh.lib
+
+from dcs.core.models import AccessTimeDrsObject
+from dcs.migration_logic import Document, MigrationDefinition, Reversible
+
+DRS_OBJECT_COLLECTION = "drs_objects"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Adds `encrypted_size`"""
+
+    version = 2
+
+    async def add_encrypted_size(self, doc: Document) -> Document:
+        """Populate the `encrypted_size` field"""
+        decrypted_size = doc["decrypted_size"]
+
+        # this calculation comes from the ds kit
+        num_segments = math.ceil(decrypted_size / crypt4gh.lib.SEGMENT_SIZE)
+        encrypted_size = decrypted_size + num_segments * 28
+        doc["encrypted_size"] = encrypted_size
+        return doc
+
+    async def remove_encrypted_size(self, doc: Document) -> Document:
+        """Remove the `encrypted_size` field"""
+        doc.pop("encrypted_size", "")
+        return doc
+
+    async def apply(self):
+        """Populate `encrypted_size` field on docs in the drs_objects collection"""
+        async with self.auto_finalize(DRS_OBJECT_COLLECTION):
+            await self.migrate_docs_in_collection(
+                coll_name=DRS_OBJECT_COLLECTION,
+                change_function=self.add_encrypted_size,
+                validation_model=AccessTimeDrsObject,
+                id_field="file_id",
+            )
+
+    async def unapply(self):
+        """Remove `encrypted_size`"""
+        async with self.auto_finalize(DRS_OBJECT_COLLECTION):
+            await self.migrate_docs_in_collection(
+                coll_name=DRS_OBJECT_COLLECTION,
+                change_function=self.remove_encrypted_size,
+                validation_model=AccessTimeDrsObject,
+                id_field="file_id",
+            )

--- a/services/dcs/src/dcs/migrations.py
+++ b/services/dcs/src/dcs/migrations.py
@@ -1,0 +1,46 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database version checking & migration before startup"""
+
+from dcs.config import Config
+from dcs.migration_logic import MigrationManager, MigrationMap
+from dcs.migration_logic.dcs_migrations import V2Migration
+
+MIGRATION_MAP: MigrationMap = {2: V2Migration}
+DB_TARGET_VERSION = 2
+
+
+async def run_db_migrations(
+    *,
+    config: Config,
+    target_version: int = DB_TARGET_VERSION,
+):
+    """Check if the database is up to date and attempt to migrate the data if not.
+
+    The service must not start until this function is successful.
+
+    Args
+    - `config`: Config containing db connection str and lock/db versioning collections
+    - `target_version`: Which version the db needs to be at for this version of the service
+
+    `target_version` can be specified to aid in testing.
+    """
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/services/dcs/tests_dcs/fixtures/test_config.yaml
+++ b/services/dcs/tests_dcs/fixtures/test_config.yaml
@@ -34,5 +34,7 @@ unstaged_download_collection: unstagedDownloadRequested
 files_to_delete_topic: file-deletions
 file_deleted_event_topic: file-downloads
 file_deleted_event_type: file_deleted
+db_version_collection: dcsDbVersions
+migration_wait_sec: 2
 auth_key: "{}"
 log_level: INFO

--- a/services/dcs/tests_dcs/test_migrations.py
+++ b/services/dcs/tests_dcs/test_migrations.py
@@ -1,0 +1,132 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for database migrations"""
+
+import math
+from random import randint
+
+import crypt4gh.lib
+import pytest
+from ghga_service_commons.utils.utc_dates import UTCDatetime, now_as_utc
+from hexkit.providers.mongodb.provider import dto_to_document
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+from pydantic import BaseModel
+
+from dcs.core.models import AccessTimeDrsObject
+from dcs.migration_logic._manager import MigrationStepError
+from dcs.migrations import run_db_migrations
+from tests_dcs.fixtures.config import get_config
+
+
+def calc_encrypted_size(decrypted_size: int) -> int:
+    """Calculate the encrypted size given the decrypted object's size."""
+    num_segments = math.ceil(decrypted_size / crypt4gh.lib.SEGMENT_SIZE)
+    return decrypted_size + num_segments * 28
+
+
+@pytest.mark.asyncio
+async def test_v2_migration(
+    mongodb: MongoDbFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test the migration script for v2 where we add the size of the encrypted object
+    to the docs in the drs_objects collection.
+    """
+    # Patch the config
+    config = get_config(sources=[mongodb.config])
+    client = mongodb.client
+    coll = client[config.db_name]["drs_objects"]
+
+    # Set up test data - we want some random object sizes to verify we're not accidentally
+    #  reading some dummy value somewhere. Record the sizes so we can check later that
+    #  what we retrieve is correct.
+    test_data_sizes: dict[str, list[int]] = {}
+    base_model = AccessTimeDrsObject(
+        file_id="",
+        decryption_secret_id="",
+        decrypted_sha256="",
+        decrypted_size=0,
+        creation_date=now_as_utc().isoformat(),
+        s3_endpoint_alias="HD01",
+        object_id="",
+        last_accessed=now_as_utc(),
+        encrypted_size=0,
+    )
+
+    for n in range(1, 10):
+        drs_object = dto_to_document(base_model, id_field="file_id")
+        drs_object.pop("encrypted_size")
+        base_size = 10**7
+        multiplier = randint(1, 8000)
+        decrypted_size = base_size * multiplier
+        encrypted_size = calc_encrypted_size(decrypted_size)
+        drs_object["_id"] = f"examplefile00{n}"
+        test_data_sizes[drs_object["_id"]] = [decrypted_size, encrypted_size]
+        drs_object["object_id"] = f"objectid00{n}"
+        drs_object["decrypted_size"] = decrypted_size
+        coll.insert_one(drs_object)
+
+    post_insert = coll.find().to_list()
+    assert len(post_insert) == 9
+    for doc in post_insert:
+        assert doc["decrypted_size"] == test_data_sizes[doc["_id"]][0]
+        assert "encrypted_size" not in doc
+
+    # Run the database migrations, which should create the lock/versioning collection
+    #  and then update the 'file_metadata' collection.
+    await run_db_migrations(config=config)
+
+    # Make sure the docs from file_metadata were updated with the right size values
+    post_apply = coll.find().to_list()
+    assert len(post_apply) == 9
+    for doc in post_apply:
+        assert doc["decrypted_size"] == test_data_sizes[doc["_id"]][0]
+        assert "encrypted_size" in doc
+        assert doc["encrypted_size"] == test_data_sizes[doc["_id"]][1]
+
+    # Unapply the v2 migration, which will fail because the current model requires
+    #  the `encrypted_size` field.
+    with pytest.raises(MigrationStepError):
+        await run_db_migrations(config=config, target_version=1)
+
+    # Make sure the docs from file_metadata were updated with the right size values
+    post_failed_unapply = coll.find().to_list()
+    assert len(post_failed_unapply) == 9
+    for doc in post_failed_unapply:
+        assert "encrypted_size" in doc
+        assert doc["encrypted_size"] == test_data_sizes[doc["_id"]][1]
+
+    # Monkeypatch the pydantic model to resemble the old version so we can test reversal
+    class PatchedDrsModel(BaseModel):
+        """Does not contain the encrypted_size field"""
+
+        file_id: str
+        decryption_secret_id: str
+        decrypted_sha256: str
+        decrypted_size: int
+        creation_date: str
+        s3_endpoint_alias: str
+        object_id: str
+        last_accessed: UTCDatetime
+
+    monkeypatch.setattr(
+        "dcs.migration_logic.dcs_migrations.AccessTimeDrsObject", PatchedDrsModel
+    )
+    await run_db_migrations(config=config, target_version=1)
+
+    post_unapply = coll.find().to_list()
+    assert len(post_unapply) == 9
+    for doc in post_unapply:
+        assert "encrypted_size" not in doc


### PR DESCRIPTION
Copies over the same temporary migration framework from the IFRS. Migration manually calculates the encrypted object size using the [calculation found in the DS Kit ](https://github.com/ghga-de/ghga-datasteward-kit/blob/3da0419129393b48f116a086ad8c0a94815d7f7f/src/ghga_datasteward_kit/s3_upload/utils.py#L198). I did some preliminary verification of this approach beforehand by looking at what's in staging.

This will be part of the DCS v4 release