### PR TITLE
Only migrate found collections (GSI-1308)

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:4.0.0
+docker pull ghga/download-controller-service:4.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:4.0.0 .
+docker build -t ghga/download-controller-service:4.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:4.0.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:4.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 4.0.0
+  version: 4.0.1
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "4.0.0"
+version = "4.0.1"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/src/dcs/migration_logic/_utils.py
+++ b/services/dcs/src/dcs/migration_logic/_utils.py
@@ -193,6 +193,11 @@ class MigrationDefinition:
         if original_coll_name in self._staged_collections:
             return
 
+        # Don't do anything if the collection doesn't exist
+        if original_coll_name not in await self._db.list_collection_names():
+            log.warning("Collection '%s' not found, can't stage.", original_coll_name)
+            return
+
         # Rename the old collection by giving it a prefix
         # e.g. "users" -> "tmp_v7_old_users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
@@ -211,6 +216,11 @@ class MigrationDefinition:
 
     async def unstage_collection(self, original_coll_name: str):
         """Reverse steps from `stage_collection()`"""
+        # Don't do anything if the collection doesn't exist
+        if original_coll_name not in await self._db.list_collection_names():
+            log.warning("Collection '%s' not found, can't unstage.", original_coll_name)
+            return
+
         # Add the prefix back to the new collection
         # e.g. "users" -> "tmp_v7_new_users"
         temp_new_coll_name = self.new_temp_name(original_coll_name)

--- a/services/dcs/tests_dcs/test_migrations.py
+++ b/services/dcs/tests_dcs/test_migrations.py
@@ -130,3 +130,21 @@ async def test_v2_migration(
     assert len(post_unapply) == 9
     for doc in post_unapply:
         assert "encrypted_size" not in doc
+
+
+@pytest.mark.asyncio
+async def test_drop_or_rename_nonexistent_collection(mongodb: MongoDbFixture):
+    """Run migrations on a DB with no data in it.
+
+    The migrations should still complete and log the new DB version.
+    """
+    config = get_config(sources=[mongodb.config])
+    client = mongodb.client
+    version_coll = client[config.db_name][config.db_version_collection]
+    versions = version_coll.find().to_list()
+    assert not versions
+
+    await run_db_migrations(config=config)
+
+    versions = version_coll.find().to_list()
+    assert len(versions) == 2

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:3.0.0
+docker pull ghga/internal-file-registry-service:3.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:3.0.0 .
+docker build -t ghga/internal-file-registry-service:3.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:3.0.0 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:3.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "3.0.0"
+version = "3.0.1"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -193,6 +193,11 @@ class MigrationDefinition:
         if original_coll_name in self._staged_collections:
             return
 
+        # Don't do anything if the collection doesn't exist
+        if original_coll_name not in await self._db.list_collection_names():
+            log.warning("Collection '%s' not found, can't stage.", original_coll_name)
+            return
+
         # Rename the old collection by giving it a prefix
         # e.g. "users" -> "tmp_v7_old_users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
@@ -211,6 +216,11 @@ class MigrationDefinition:
 
     async def unstage_collection(self, original_coll_name: str):
         """Reverse steps from `stage_collection()`"""
+        # Don't do anything if the collection doesn't exist
+        if original_coll_name not in await self._db.list_collection_names():
+            log.warning("Collection '%s' not found, can't unstage.", original_coll_name)
+            return
+
         # Add the prefix back to the new collection
         # e.g. "users" -> "tmp_v7_new_users"
         temp_new_coll_name = self.new_temp_name(original_coll_name)

--- a/services/ifrs/tests_ifrs/test_migrations.py
+++ b/services/ifrs/tests_ifrs/test_migrations.py
@@ -116,3 +116,21 @@ async def test_v2_migration(
     assert len(post_unapply) == 9
     for doc in post_unapply:
         assert "object_size" not in doc
+
+
+@pytest.mark.asyncio
+async def test_drop_or_rename_nonexistent_collection(mongodb: MongoDbFixture):
+    """Run migrations on a DB with no data in it.
+
+    The migrations should still complete and log the new DB version.
+    """
+    config = get_config(sources=[mongodb.config])
+    client = mongodb.client
+    version_coll = client[config.db_name][config.db_version_collection]
+    versions = version_coll.find().to_list()
+    assert not versions
+
+    await run_db_migrations(config=config)
+
+    versions = version_coll.find().to_list()
+    assert len(versions) == 2


### PR DESCRIPTION
This PR fixes an issue found in testing where uninitialized collections crashed the migration process (can't rename a collection that doesn't exist). The migration process previously assumed the collections would exist, but now it will check before staging/unstaging and do nothing if they don't exist. This will allow migration-equipped services to start up in test environments that might not have test data already created. 

Of course, when testing the migrations specifically in those environments, we need to have test data present before starting the services. That's a team coordination thing though, imo and not an app/config problem.