### PR TITLE
[patch] Migration staging/unstaging fix (GSI-1329)

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:4.0.1
+docker pull ghga/download-controller-service:4.0.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:4.0.1 .
+docker build -t ghga/download-controller-service:4.0.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:4.0.1 --help
+docker run -p 8080:8080 ghga/download-controller-service:4.0.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 4.0.1
+  version: 4.0.2
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "4.0.1"
+version = "4.0.2"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/src/dcs/migration_logic/_utils.py
+++ b/services/dcs/src/dcs/migration_logic/_utils.py
@@ -202,7 +202,7 @@ class MigrationDefinition:
         # e.g. "users" -> "tmp_v7_old_users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
         old_collection = self._db[original_coll_name]
-        await old_collection.rename(temp_old_coll_name)
+        await old_collection.rename(temp_old_coll_name, dropTarget=True)
 
         # Rename the new, temp collection by removing its prefix
         # e.g. "tmp_v7_new_users" -> "users"
@@ -225,7 +225,7 @@ class MigrationDefinition:
         # e.g. "users" -> "tmp_v7_new_users"
         temp_new_coll_name = self.new_temp_name(original_coll_name)
         new_collection = self._db[original_coll_name]
-        await new_collection.rename(temp_new_coll_name)
+        await new_collection.rename(temp_new_coll_name, dropTarget=True)
 
         # Remove the prefix from the old collection
         # e.g. "tmp_v7_old_users" -> "users"

--- a/services/dcs/src/dcs/migration_logic/_utils.py
+++ b/services/dcs/src/dcs/migration_logic/_utils.py
@@ -231,7 +231,7 @@ class MigrationDefinition:
         # e.g. "tmp_v7_old_users" -> "users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
         old_collection = self._db[temp_old_coll_name]
-        await old_collection.rename(temp_old_coll_name)
+        await old_collection.rename(original_coll_name)
 
         # Remove this collection from the "staged" tracking set
         self._staged_collections.remove(original_coll_name)

--- a/services/dcs/tests_dcs/test_migrations.py
+++ b/services/dcs/tests_dcs/test_migrations.py
@@ -154,20 +154,20 @@ async def test_drop_or_rename_nonexistent_collection(mongodb: MongoDbFixture):
 
 @pytest.mark.asyncio
 async def test_stage_unstage(mongodb: MongoDbFixture):
-    """Stage and immediately unstage a collection."""
+    """Stage and immediately unstage a collection with collection name collisions."""
     config = get_config(sources=[mongodb.config])
-    client = AsyncIOMotorClient(config.db_connection_str.get_secret_value())
+    client: AsyncIOMotorClient = AsyncIOMotorClient(
+        config.db_connection_str.get_secret_value()
+    )
     db = client.get_database(config.db_name)
-    og_name = "coll1"
-    coll = client[config.db_name][og_name]
+    coll_name = "coll1"
+    collection = client[config.db_name][coll_name]
 
-    class Model(BaseModel):
-        field: str
-
-    doc = Model(field="test")
-    await coll.insert_one(doc.model_dump())
+    # Insert a dummy doc so our migration has something to do
+    await collection.insert_one({"field": "test"})
 
     async def change_function(doc):
+        """Dummy change function for running `migration_docs_in_collection`"""
         return doc
 
     class TestMig(MigrationDefinition):
@@ -175,11 +175,19 @@ async def test_stage_unstage(mongodb: MongoDbFixture):
 
         async def apply(self):
             await self.migrate_docs_in_collection(
-                coll_name=og_name,
+                coll_name=coll_name,
                 change_function=change_function,
             )
-            await self.stage_collection(og_name)
-            await self.unstage_collection(og_name)
+            # Create tmp_v2_old_coll1 for name collision upon staging 'coll1'
+            # The correct behavior is to drop the collection upon rename if it exists
+            temp_coll = client[config.db_name][f"tmp_v2_old_{coll_name}"]
+            await temp_coll.insert_one({"some": "document"})
+            await self.stage_collection(coll_name)
+
+            # Create tmp_v2_new_coll1 for name collision upon unstaging 'coll1'
+            temp_coll = client[config.db_name][f"tmp_v2_new_{coll_name}"]
+            await temp_coll.insert_one({"some": "document"})
+            await self.unstage_collection(coll_name)
 
     migdef = TestMig(db=db, is_final_migration=False, unapplying=False)
     await migdef.apply()

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:3.0.1
+docker pull ghga/internal-file-registry-service:3.0.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:3.0.1 .
+docker build -t ghga/internal-file-registry-service:3.0.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:3.0.1 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:3.0.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "3.0.1"
+version = "3.0.2"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -202,7 +202,7 @@ class MigrationDefinition:
         # e.g. "users" -> "tmp_v7_old_users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
         old_collection = self._db[original_coll_name]
-        await old_collection.rename(temp_old_coll_name)
+        await old_collection.rename(temp_old_coll_name, dropTarget=True)
 
         # Rename the new, temp collection by removing its prefix
         # e.g. "tmp_v7_new_users" -> "users"
@@ -225,7 +225,7 @@ class MigrationDefinition:
         # e.g. "users" -> "tmp_v7_new_users"
         temp_new_coll_name = self.new_temp_name(original_coll_name)
         new_collection = self._db[original_coll_name]
-        await new_collection.rename(temp_new_coll_name)
+        await new_collection.rename(temp_new_coll_name, dropTarget=True)
 
         # Remove the prefix from the old collection
         # e.g. "tmp_v7_old_users" -> "users"

--- a/services/ifrs/src/ifrs/migration_logic/_utils.py
+++ b/services/ifrs/src/ifrs/migration_logic/_utils.py
@@ -231,7 +231,7 @@ class MigrationDefinition:
         # e.g. "tmp_v7_old_users" -> "users"
         temp_old_coll_name = self.old_temp_name(original_coll_name)
         old_collection = self._db[temp_old_coll_name]
-        await old_collection.rename(temp_old_coll_name)
+        await old_collection.rename(original_coll_name)
 
         # Remove this collection from the "staged" tracking set
         self._staged_collections.remove(original_coll_name)

--- a/services/ifrs/tests_ifrs/test_migrations.py
+++ b/services/ifrs/tests_ifrs/test_migrations.py
@@ -23,9 +23,12 @@ from ghga_service_commons.utils.multinode_storage import (
 )
 from hexkit.providers.mongodb.testutils import MongoDbFixture
 from hexkit.providers.s3.testutils import S3Fixture, temp_file_object
+from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import BaseModel
 
 from ifrs.core.models import FileMetadataBase
 from ifrs.migration_logic._manager import MigrationStepError
+from ifrs.migration_logic._utils import MigrationDefinition
 from ifrs.migrations import run_db_migrations
 from tests_ifrs.fixtures.config import get_config
 from tests_ifrs.fixtures.example_data import EXAMPLE_METADATA_BASE
@@ -134,3 +137,36 @@ async def test_drop_or_rename_nonexistent_collection(mongodb: MongoDbFixture):
 
     versions = version_coll.find().to_list()
     assert len(versions) == 2
+
+
+@pytest.mark.asyncio
+async def test_stage_unstage(mongodb: MongoDbFixture):
+    """Stage and immediately unstage a collection."""
+    config = get_config(sources=[mongodb.config])
+    client = AsyncIOMotorClient(config.db_connection_str.get_secret_value())
+    db = client.get_database(config.db_name)
+    og_name = "coll1"
+    coll = client[config.db_name][og_name]
+
+    class Model(BaseModel):
+        field: str
+
+    doc = Model(field="test")
+    await coll.insert_one(doc.model_dump())
+
+    async def change_function(doc):
+        return doc
+
+    class TestMig(MigrationDefinition):
+        version = 2
+
+        async def apply(self):
+            await self.migrate_docs_in_collection(
+                coll_name=og_name,
+                change_function=change_function,
+            )
+            await self.stage_collection(og_name)
+            await self.unstage_collection(og_name)
+
+    migdef = TestMig(db=db, is_final_migration=False, unapplying=False)
+    await migdef.apply()


### PR DESCRIPTION
Fixes an issue in the DCS/IFRS migration tools where we could potentially encounter errors during staging if a `tmp_vN_old_collname` exists, or during unstaging if `tmp_vN_new_collname` exists. These are unlikely to occur in production, but might be encountered in staging or local testing if the DB state is not properly managed.

Additionally, this PR fixes a problem in the `unstage` method where the collection `tmp_vN_old_collname` would be renamed to itself instead of `collname`, resulting in a MongoDB error.

Both IFRS and DCS version patch numbers have been bumped.