### PR TITLE
[patch] UCS: Remove migration config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: [--check]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '.*\.md'

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:5.0.0
+docker pull ghga/upload-controller-service:5.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:5.0.0 .
+docker build -t ghga/upload-controller-service:5.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:5.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:5.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -394,67 +394,6 @@ The service requires the following configuration parameters:
 
   ```json
   null
-  ```
-
-
-- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
-
-
-  Examples:
-
-  ```json
-  "ifrsDbVersions"
-  ```
-
-
-- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
-
-
-  Examples:
-
-  ```json
-  5
-  ```
-
-
-  ```json
-  30
-  ```
-
-
-  ```json
-  180
-  ```
-
-
-- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
-
-  - **Any of**
-
-    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
-
-    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
-
-
-  Examples:
-
-  ```json
-  null
-  ```
-
-
-  ```json
-  300
-  ```
-
-
-  ```json
-  600
-  ```
-
-
-  ```json
-  3600
   ```
 
 

--- a/services/ucs/config_schema.json
+++ b/services/ucs/config_schema.json
@@ -405,43 +405,6 @@
       ],
       "title": "Mongo Timeout"
     },
-    "db_version_collection": {
-      "description": "The name of the collection containing DB version information for this service",
-      "examples": [
-        "ifrsDbVersions"
-      ],
-      "title": "Db Version Collection",
-      "type": "string"
-    },
-    "migration_wait_sec": {
-      "description": "The number of seconds to wait before checking the DB version again",
-      "examples": [
-        5,
-        30,
-        180
-      ],
-      "title": "Migration Wait Sec",
-      "type": "integer"
-    },
-    "migration_max_wait_sec": {
-      "anyOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
-      "examples": [
-        null,
-        300,
-        600,
-        3600
-      ],
-      "title": "Migration Max Wait Sec"
-    },
     "host": {
       "default": "127.0.0.1",
       "description": "IP of the host.",
@@ -583,9 +546,7 @@
     "kafka_servers",
     "object_storages",
     "mongo_dsn",
-    "db_name",
-    "db_version_collection",
-    "migration_wait_sec"
+    "db_name"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/ucs/dev_config.yaml
+++ b/services/ucs/dev_config.yaml
@@ -22,5 +22,3 @@ file_upload_received_type: file_uploaded
 service_instance_id: "001"
 kafka_servers: ["kafka:9092"]
 kafka_enable_dlq: True
-migration_wait_sec: 10
-db_version_collection: ucsDbVersions

--- a/services/ucs/example_config.yaml
+++ b/services/ucs/example_config.yaml
@@ -5,7 +5,6 @@ cors_allowed_headers: null
 cors_allowed_methods: null
 cors_allowed_origins: null
 db_name: dev
-db_version_collection: ucsDbVersions
 docs_url: /docs
 file_deleted_topic: file-downloads
 file_deleted_type: file_deleted
@@ -36,8 +35,6 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
-migration_max_wait_sec: null
-migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 object_storages:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -417,7 +417,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 5.0.0
+  version: 5.0.1
 openapi: 3.1.0
 paths:
   /files/{file_id}:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "5.0.0"
+version = "5.0.1"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/config.py
+++ b/services/ucs/src/ucs/config.py
@@ -20,7 +20,6 @@ from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb.migrations import MigrationConfig
 from hexkit.providers.mongokafka import MongoKafkaConfig
 
 from ucs.adapters.inbound.event_sub import EventSubTranslatorConfig
@@ -33,7 +32,6 @@ SERVICE_NAME = "ucs"
 class Config(
     ApiConfigBase,
     MongoKafkaConfig,
-    MigrationConfig,
     S3ObjectStoragesConfig,
     KafkaConfig,
     LoggingConfig,

--- a/services/ucs/tests_ucs/fixtures/test_config.yaml
+++ b/services/ucs/tests_ucs/fixtures/test_config.yaml
@@ -22,5 +22,3 @@ file_upload_received_type: file_uploaded
 service_instance_id: "001"
 kafka_servers: ["kafka:9092"]
 kafka_enable_dlq: True
-migration_wait_sec: 10
-db_version_collection: ucsDbVersions


### PR DESCRIPTION
~During the last big PR for the monorepo I accidentally added the migration config to the UCS. This PR removes it and bumps the patch version number~