### PR TITLE
DCS Hexkit v6 + Migrations (GSI-1780)

### DIFF
--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -482,6 +482,67 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
+- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
+
+    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  null
+  ```
+
+
+  ```json
+  300
+  ```
+
+
+  ```json
+  600
+  ```
+
+
+  ```json
+  3600
+  ```
+
+
 - <a id="properties/drs_server_uri"></a>**`drs_server_uri`** *(string, required)*: The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.
 
 

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:6.1.2
+docker pull ghga/download-controller-service:7.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:6.1.2 .
+docker build -t ghga/download-controller-service:7.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:6.1.2 --help
+docker run -p 8080:8080 ghga/download-controller-service:7.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -78,7 +78,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/otel_trace_sampling_rate"></a>**`otel_trace_sampling_rate`** *(number)*: Determines which proportion of spans should be sampled. A value of 1.0 means all and is equivalent to the previous behaviour. Setting this to 0 will result in no spans being sampled, but this does not automatically set `enable_opentelemetry` to False. Minimum: `0`. Maximum: `1`. Default: `1.0`.
 
-- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: `["grpc", "http/protobuf"]`. Default: `"http/protobuf"`.
+- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: "grpc" or "http/protobuf". Default: `"http/protobuf"`.
 
 - <a id="properties/otel_exporter_endpoint"></a>**`otel_exporter_endpoint`** *(string, format: uri, required)*: Base endpoint URL for the collector that receives content from the exporter. Length must be at least 1.
 
@@ -90,7 +90,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
+- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
 
 - <a id="properties/service_name"></a>**`service_name`** *(string)*: Default: `"dcs"`.
 
@@ -275,7 +275,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: `["PLAINTEXT", "SSL"]`. Default: `"PLAINTEXT"`.
+- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
 
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
 
@@ -319,7 +319,7 @@ The service requires the following configuration parameters:
 
   - **Any of**
 
-    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: `["gzip", "snappy", "lz4", "zstd"]`.
+    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
 
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 
@@ -691,7 +691,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests. Default: `null`.
+- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests. Default: `null`.
 
   - **Any of**
 
@@ -700,6 +700,24 @@ The service requires the following configuration parameters:
       - <a id="properties/cors_allowed_headers/anyOf/0/items"></a>**Items** *(string)*
 
     - <a id="properties/cors_allowed_headers/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  []
+  ```
+
+
+- <a id="properties/cors_exposed_headers"></a>**`cors_exposed_headers`**: A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/cors_exposed_headers/anyOf/0"></a>*array*
+
+      - <a id="properties/cors_exposed_headers/anyOf/0/items"></a>**Items** *(string)*
+
+    - <a id="properties/cors_exposed_headers/anyOf/1"></a>*null*
 
 
   Examples:
@@ -753,7 +771,7 @@ to talk to an S3 service in the backend.<br>  Args:
     ```
 
 
-  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required, write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
+  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required and write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
 
 
     Examples:
@@ -799,7 +817,7 @@ to talk to an S3 service in the backend.<br>  Args:
 
   - <a id="%24defs/S3ObjectStorageNodeConfig/properties/bucket"></a>**`bucket`** *(string, required)*
 
-  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`**: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
+  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`** *(required)*: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
 
 
 ### Usage:

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -466,6 +466,43 @@
       ],
       "title": "Mongo Timeout"
     },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
+    "migration_max_wait_sec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
+      "examples": [
+        null,
+        300,
+        600,
+        3600
+      ],
+      "title": "Migration Max Wait Sec"
+    },
     "drs_server_uri": {
       "description": "The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.",
       "examples": [
@@ -756,6 +793,8 @@
     "kafka_servers",
     "mongo_dsn",
     "db_name",
+    "db_version_collection",
+    "migration_wait_sec",
     "drs_server_uri",
     "ekss_base_url",
     "presigned_url_expires_after",

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -705,11 +705,30 @@
         }
       ],
       "default": null,
-      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests.",
+      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests.",
       "examples": [
         []
       ],
       "title": "Cors Allowed Headers"
+    },
+    "cors_exposed_headers": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses.",
+      "examples": [
+        []
+      ],
+      "title": "Cors Exposed Headers"
     },
     "api_route": {
       "default": "/ga4gh/drs/v1",

--- a/services/dcs/dev_config.yaml
+++ b/services/dcs/dev_config.yaml
@@ -45,3 +45,5 @@ auth_key: "{}"
 log_level: INFO
 
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 10
+db_version_collection: dcsDbVersions

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -20,6 +20,7 @@ cors_allowed_methods: []
 cors_allowed_origins: []
 cors_exposed_headers: null
 db_name: dev
+db_version_collection: dcsDbVersions
 docs_url: /docs
 download_served_topic: file-downloads
 download_served_type: download_served
@@ -55,6 +56,8 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_max_wait_sec: null
+migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 object_storages:

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -18,6 +18,7 @@ cors_allow_credentials: false
 cors_allowed_headers: []
 cors_allowed_methods: []
 cors_allowed_origins: []
+cors_exposed_headers: null
 db_name: dev
 docs_url: /docs
 download_served_topic: file-downloads

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -206,7 +206,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 6.1.2
+  version: 7.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "6.1.2"
+version = "7.0.0"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 
 

--- a/services/dcs/src/dcs/adapters/inbound/event_sub.py
+++ b/services/dcs/src/dcs/adapters/inbound/event_sub.py
@@ -26,6 +26,7 @@ from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.opentelemetry import start_span
 from hexkit.protocols.eventsub import EventSubscriberProtocol
+from pydantic import UUID4
 
 from dcs.core import models
 from dcs.ports.inbound.data_repository import DataRepositoryPort
@@ -95,7 +96,13 @@ class EventSubTranslator(EventSubscriberProtocol):
         await self._data_repository.delete_file(file_id=validated_payload.file_id)
 
     async def _consume_validated(
-        self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: str
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        topic: Ascii,
+        key: str,
+        event_id: UUID4,
     ) -> None:
         """Consume events from the topics of interest."""
         if type_ == self._config.file_internally_registered_type:

--- a/services/dcs/src/dcs/adapters/outbound/event_pub.py
+++ b/services/dcs/src/dcs/adapters/outbound/event_pub.py
@@ -15,8 +15,6 @@
 
 """Adapter for publishing events to other services."""
 
-import json
-
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.configs import (
     DownloadServedEventsConfig,
@@ -64,10 +62,9 @@ class EventPubTranslator(EventPublisherPort):
             target_bucket_id=bucket_id,
             decrypted_sha256=drs_object.decrypted_sha256,
         )
-        payload_dict = json.loads(payload.model_dump_json())
 
         await self._provider.publish(
-            payload=payload_dict,
+            payload=payload.model_dump(),
             topic=self._config.files_to_stage_topic,
             type_=self._config.files_to_stage_type,
             key=drs_object.file_id,
@@ -91,10 +88,9 @@ class EventPubTranslator(EventPublisherPort):
             decrypted_sha256=drs_object.decrypted_sha256,
             context="unknown",
         )
-        payload_dict = json.loads(payload.model_dump_json())
 
         await self._provider.publish(
-            payload=payload_dict,
+            payload=payload.model_dump(),
             type_=self._config.download_served_type,
             topic=self._config.download_served_topic,
             key=drs_object.file_id,
@@ -109,10 +105,9 @@ class EventPubTranslator(EventPublisherPort):
             upload_date=drs_object.creation_date,
             drs_uri=drs_object.self_uri,
         )
-        payload_dict = json.loads(payload.model_dump_json())
 
         await self._provider.publish(
-            payload=payload_dict,
+            payload=payload.model_dump(),
             type_=self._config.file_registered_for_download_type,
             topic=self._config.file_registered_for_download_topic,
             key=drs_object.file_id,
@@ -122,10 +117,9 @@ class EventPubTranslator(EventPublisherPort):
     async def file_deleted(self, *, file_id: str) -> None:
         """Communicates the event that a file has been successfully deleted."""
         payload = event_schemas.FileDeletionSuccess(file_id=file_id)
-        payload_dict = json.loads(payload.model_dump_json())
 
         await self._provider.publish(
-            payload=payload_dict,
+            payload=payload.model_dump(),
             type_=self._config.file_deleted_type,
             topic=self._config.file_deleted_topic,
             key=file_id,

--- a/services/dcs/src/dcs/config.py
+++ b/services/dcs/src/dcs/config.py
@@ -23,7 +23,7 @@ from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb import MongoDbConfig
+from hexkit.providers.mongodb.migrations import MigrationConfig
 from pydantic import Field
 
 from dcs.adapters.inbound.event_sub import EventSubTranslatorConfig
@@ -50,7 +50,7 @@ class Config(
     DrsApiConfig,
     WorkOrderTokenConfig,
     DataRepositoryConfig,
-    MongoDbConfig,
+    MigrationConfig,
     KafkaConfig,
     EventPubTranslatorConfig,
     EventSubTranslatorConfig,

--- a/services/dcs/src/dcs/core/models.py
+++ b/services/dcs/src/dcs/core/models.py
@@ -20,8 +20,8 @@ in the api.
 import re
 from typing import Literal
 
-from ghga_service_commons.utils import utc_dates
-from pydantic import BaseModel, field_validator
+from ghga_service_commons.utils.utc_dates import UTCDatetime
+from pydantic import UUID4, BaseModel, field_validator
 
 
 class AccessURL(BaseModel):
@@ -47,25 +47,25 @@ class Checksum(BaseModel):
 class DrsObjectBase(BaseModel):
     """A model containing the metadata needed to register a new DRS object."""
 
-    file_id: str
+    file_id: str  # the file accession
     decryption_secret_id: str
     decrypted_sha256: str
     decrypted_size: int
     encrypted_size: int
-    creation_date: str
+    creation_date: UTCDatetime
     s3_endpoint_alias: str
 
 
 class DrsObject(DrsObjectBase):
     """A DrsObjectBase with the object_id generated"""
 
-    object_id: str
+    object_id: UUID4  # the S3 object ID as uuid4
 
 
 class AccessTimeDrsObject(DrsObject):
     """DRS Model with information for outbox caching strategy"""
 
-    last_accessed: utc_dates.UTCDatetime
+    last_accessed: UTCDatetime
 
 
 class DrsObjectWithUri(DrsObject):
@@ -98,7 +98,7 @@ class DrsObjectWithAccess(DrsObjectWithUri):
         return DrsObjectResponseModel(
             access_methods=[access_method],
             checksums=[checksum],
-            created_time=self.creation_date,
+            created_time=self.creation_date.isoformat(),
             id=self.file_id,
             self_uri=self.self_uri,
             size=size,

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -26,6 +26,9 @@ from dcs.inject import (
     prepare_outbox_cleaner,
     prepare_rest_app,
 )
+from dcs.migrations import run_db_migrations
+
+DB_VERSION = 2
 
 
 async def run_rest_app():
@@ -33,6 +36,7 @@ async def run_rest_app():
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -43,6 +47,7 @@ async def consume_events(run_forever: bool = True):
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
@@ -53,6 +58,7 @@ async def run_outbox_cleanup():
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_outbox_cleaner(config=config) as cleanup_outbox:
         await cleanup_outbox
@@ -63,6 +69,7 @@ async def publish_events(*, all: bool = False):
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with get_persistent_publisher(config=config) as persistent_publisher:
         if all:

--- a/services/dcs/src/dcs/migrations/__init__.py
+++ b/services/dcs/src/dcs/migrations/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic"""
+
+from .definitions import V2Migration
+from .entry import run_db_migrations
+
+__all__ = ["V2Migration", "run_db_migrations"]

--- a/services/dcs/src/dcs/migrations/definitions.py
+++ b/services/dcs/src/dcs/migrations/definitions.py
@@ -1,0 +1,74 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic for DCS"""
+
+from hexkit.providers.mongodb.migrations import (
+    Document,
+    MigrationDefinition,
+    Reversible,
+)
+from hexkit.providers.mongodb.migrations.helpers import convert_uuids_and_datetimes_v6
+
+from dcs.core.models import AccessTimeDrsObject
+
+DRS_OBJECTS = "drs_objects"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Update the stored data to have native-typed UUIDs and datetimes.
+
+    This impacts the object_id, creation_date, and last_accessed fields on the
+    AccessTimeDrsObject model.
+
+    This can be reversed by converting the UUIDs and datetimes back to strings.
+    """
+
+    version = 2
+
+    _uuid_field: str = "object_id"
+    _date_fields: list[str] = ["creation_date", "last_accessed"]
+
+    async def apply(self):
+        """Perform the migration."""
+        convert_drs_objects = convert_uuids_and_datetimes_v6(
+            uuid_fields=[self._uuid_field], date_fields=self._date_fields
+        )
+
+        async with self.auto_finalize(coll_names=DRS_OBJECTS, copy_indexes=True):
+            await self.migrate_docs_in_collection(
+                coll_name=DRS_OBJECTS,
+                change_function=convert_drs_objects,
+                validation_model=AccessTimeDrsObject,
+                id_field="file_id",
+            )
+
+    async def unapply(self):
+        """Revert the migration."""
+
+        # define the change function
+        async def revert_drs_objects(doc: Document) -> Document:
+            """Convert the fields back into strings"""
+            doc[self._uuid_field] = str(doc[self._uuid_field])
+            for field in self._date_fields:
+                doc[field] = doc[field].isoformat()
+            return doc
+
+        async with self.auto_finalize(coll_names=DRS_OBJECTS, copy_indexes=True):
+            # Don't provide validation models here
+            await self.migrate_docs_in_collection(
+                coll_name=DRS_OBJECTS,
+                change_function=revert_drs_objects,
+            )

--- a/services/dcs/src/dcs/migrations/definitions.py
+++ b/services/dcs/src/dcs/migrations/definitions.py
@@ -15,44 +15,79 @@
 
 """Database migration logic for DCS"""
 
+from uuid import UUID
+
 from hexkit.providers.mongodb.migrations import (
     Document,
     MigrationDefinition,
     Reversible,
 )
-from hexkit.providers.mongodb.migrations.helpers import convert_uuids_and_datetimes_v6
+from hexkit.providers.mongodb.migrations.helpers import (
+    convert_persistent_event_v6,
+    convert_uuids_and_datetimes_v6,
+)
+from hexkit.providers.mongokafka.provider.persistent_pub import PersistentKafkaEvent
 
 from dcs.core.models import AccessTimeDrsObject
 
 DRS_OBJECTS = "drs_objects"
+DCS_PERSISTED_EVENTS = "dcsPersistedEvents"
 
 
 class V2Migration(MigrationDefinition, Reversible):
     """Update the stored data to have native-typed UUIDs and datetimes.
 
-    This impacts the object_id, creation_date, and last_accessed fields on the
-    AccessTimeDrsObject model.
+    Affected collections:
+    - drs_objects (AccessTimeDrsObject)
+        - object_id, creation_date, and last_accessed
+    - dcsPersistedEvents
 
     This can be reversed by converting the UUIDs and datetimes back to strings.
     """
 
     version = 2
 
-    _uuid_field: str = "object_id"
-    _date_fields: list[str] = ["creation_date", "last_accessed"]
+    _object_id: str = "object_id"
+    _drs_dates: list[str] = ["creation_date", "last_accessed"]
 
     async def apply(self):
         """Perform the migration."""
         convert_drs_objects = convert_uuids_and_datetimes_v6(
-            uuid_fields=[self._uuid_field], date_fields=self._date_fields
+            uuid_fields=[self._object_id], date_fields=self._drs_dates
         )
 
-        async with self.auto_finalize(coll_names=DRS_OBJECTS, copy_indexes=True):
+        convert_file_registered = convert_uuids_and_datetimes_v6(
+            date_fields=["upload_date"]
+        )
+
+        async def convert_persisted_events(doc: Document) -> Document:
+            # Convert the common event fields with hexkit's utility function
+            doc = await convert_persistent_event_v6(doc)
+
+            # convert the remaining fields inside the payload, treat payload as subdoc
+            if payload := doc["payload"]:  # the field should always exist, raise if not
+                if object_id := payload.get(self._object_id):
+                    payload[self._object_id] = UUID(object_id)
+                if "upload_date" in payload:
+                    payload = await convert_file_registered(payload)
+                doc["payload"] = payload
+            return doc
+
+        async with self.auto_finalize(
+            coll_names=[DRS_OBJECTS, DCS_PERSISTED_EVENTS], copy_indexes=True
+        ):
             await self.migrate_docs_in_collection(
                 coll_name=DRS_OBJECTS,
                 change_function=convert_drs_objects,
                 validation_model=AccessTimeDrsObject,
                 id_field="file_id",
+            )
+
+            await self.migrate_docs_in_collection(
+                coll_name=DCS_PERSISTED_EVENTS,
+                change_function=convert_persisted_events,
+                validation_model=PersistentKafkaEvent,
+                id_field="compaction_key",
             )
 
     async def unapply(self):
@@ -61,14 +96,34 @@ class V2Migration(MigrationDefinition, Reversible):
         # define the change function
         async def revert_drs_objects(doc: Document) -> Document:
             """Convert the fields back into strings"""
-            doc[self._uuid_field] = str(doc[self._uuid_field])
-            for field in self._date_fields:
+            doc[self._object_id] = str(doc[self._object_id])
+            for field in self._drs_dates:
                 doc[field] = doc[field].isoformat()
             return doc
 
-        async with self.auto_finalize(coll_names=DRS_OBJECTS, copy_indexes=True):
+        async def revert_persistent_event(doc: Document) -> Document:
+            """Convert the fields back into strings"""
+            doc.pop("event_id")
+            doc["correlation_id"] = str(doc["correlation_id"])
+            doc["created"] = doc["created"].isoformat()
+
+            if payload := doc["payload"]:
+                if object_id := payload.get(self._object_id):
+                    payload[self._object_id] = str(object_id)
+                if upload_date := payload.get("upload_date"):
+                    payload["upload_date"] = upload_date.isoformat()
+                doc["payload"] = payload
+            return doc
+
+        async with self.auto_finalize(
+            coll_names=[DRS_OBJECTS, DCS_PERSISTED_EVENTS], copy_indexes=True
+        ):
             # Don't provide validation models here
             await self.migrate_docs_in_collection(
                 coll_name=DRS_OBJECTS,
                 change_function=revert_drs_objects,
+            )
+            await self.migrate_docs_in_collection(
+                coll_name=DCS_PERSISTED_EVENTS,
+                change_function=revert_persistent_event,
             )

--- a/services/dcs/src/dcs/migrations/entry.py
+++ b/services/dcs/src/dcs/migrations/entry.py
@@ -1,0 +1,51 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing controller function for DB migrations"""
+
+from hexkit.providers.mongodb.migrations import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+)
+
+from dcs.migrations.definitions import V2Migration
+
+MIGRATION_MAP = {2: V2Migration}
+
+
+async def run_db_migrations(
+    *,
+    config: MigrationConfig,
+    target_version: int,
+    migration_map: MigrationMap | None = None,
+):
+    """Run all migrations.
+
+    Args
+    - `config`: Config containing mongo_dsn string and DB versioning collection name
+    - `target_version`: Which version the db needs to be at for this version of the service
+    - `migration_map`: Mapping of version to migration definition. Defaults to `MIGRATION_MAP`.
+
+    `migration_map` can be specified for testing, but may be left unspecified for production.
+    """
+    migration_map = migration_map or MIGRATION_MAP
+
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -18,6 +18,7 @@
 from abc import ABC, abstractmethod
 
 from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
+from pydantic import UUID4
 
 from dcs.core import models
 
@@ -38,7 +39,7 @@ class DataRepositoryPort(ABC):
         an underlying issue
         """
 
-        def __init__(self, *, object_id: str, from_error: Exception):
+        def __init__(self, *, object_id: UUID4, from_error: Exception):
             message = f"Could not remove object {object_id} from outbox bucket: {str(from_error)}"
             super().__init__(message)
 
@@ -52,7 +53,7 @@ class DataRepositoryPort(ABC):
     class EnvelopeNotFoundError(RuntimeError):
         """Raised when an envelope for a given download was not found"""
 
-        def __init__(self, *, object_id: str):
+        def __init__(self, *, object_id: UUID4):
             message = f"Envelope not found for object {object_id}"
             super().__init__(message)
 

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -28,6 +28,7 @@ import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from datetime import timedelta
+from uuid import UUID
 
 import httpx
 import pytest_asyncio
@@ -42,6 +43,7 @@ from hexkit.providers.akafka import KafkaEventSubscriber
 from hexkit.providers.akafka.testutils import KafkaFixture
 from hexkit.providers.mongodb.testutils import MongoDbFixture
 from hexkit.providers.s3.testutils import S3Fixture, temp_file_object
+from hexkit.utils import now_utc_ms_prec
 from jwcrypto.jwk import JWK
 from pydantic_settings import BaseSettings
 
@@ -63,16 +65,20 @@ from tests_dcs.fixtures.utils import (
 
 STORAGE_ALIAS = "test"
 
+EXAMPLE_OBJECT_ID = UUID("309b034b-9517-4adc-9e06-c77b09cecfea")
+CACHED_OBJECT_ID = UUID("038dfa61-19f6-4279-a894-4e8794013c44")
+EXPIRED_OBJECT_ID = UUID("9c8f2155-1fbe-418e-8159-274a4dfc6d8a")
+
 EXAMPLE_FILE = models.AccessTimeDrsObject(
     file_id="examplefile001",
-    object_id="object001",
+    object_id=EXAMPLE_OBJECT_ID,
     decrypted_sha256="0677de3685577a06862f226bb1bfa8f889e96e59439d915543929fb4f011d096",
-    creation_date=utc_dates.now_as_utc().isoformat(),
+    creation_date=now_utc_ms_prec(),
     decrypted_size=12345,
     decryption_secret_id="some-secret",
     encrypted_size=23456,
     s3_endpoint_alias=STORAGE_ALIAS,
-    last_accessed=utc_dates.now_as_utc(),
+    last_accessed=now_utc_ms_prec(),
 )
 
 
@@ -261,19 +267,17 @@ async def cleanup_fixture(
 
     # create AccessTimeDrsObjects for valid cached and expired cached file
     cached_file_id = file.file_id + "_cached"
-    cached_object_id = file.object_id + "-cached"
 
     test_file_cached = file.model_copy(deep=True)
     test_file_cached.file_id = cached_file_id
-    test_file_cached.object_id = cached_object_id
+    test_file_cached.object_id = CACHED_OBJECT_ID
     test_file_cached.last_accessed = utc_dates.now_as_utc()
 
     expired_file_id = file.file_id + "_expired"
-    expired_object_id = file.object_id + "-expired"
 
     test_file_expired = file.model_copy(deep=True)
     test_file_expired.file_id = expired_file_id
-    test_file_expired.object_id = expired_object_id
+    test_file_expired.object_id = EXPIRED_OBJECT_ID
     test_file_expired.last_accessed = utc_dates.now_as_utc() - timedelta(
         days=joint_fixture.config.outbox_cache_timeout
     )
@@ -285,11 +289,11 @@ async def cleanup_fixture(
     # populate storage
     with temp_file_object(
         bucket_id=joint_fixture.bucket_id,
-        object_id=test_file_cached.object_id,
+        object_id=str(test_file_cached.object_id),
     ) as cached_file:
         with temp_file_object(
             bucket_id=joint_fixture.bucket_id,
-            object_id=test_file_expired.object_id,
+            object_id=str(test_file_expired.object_id),
         ) as expired_file:
             await s3.populate_file_objects([cached_file, expired_file])
 

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -85,7 +85,7 @@ EXAMPLE_FILE = models.AccessTimeDrsObject(
 @dataclass
 class EndpointAliases:
     valid_node: str = STORAGE_ALIAS
-    fake: str = f"{STORAGE_ALIAS}_fake"
+    fake_node: str = f"{STORAGE_ALIAS}_fake"
 
 
 class EKSSBaseInjector(BaseSettings):

--- a/services/dcs/tests_dcs/fixtures/test_config.yaml
+++ b/services/dcs/tests_dcs/fixtures/test_config.yaml
@@ -39,3 +39,5 @@ file_deleted_type: file_deleted
 auth_key: "{}"
 log_level: INFO
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 2
+db_version_collection: dcsDbVersions

--- a/services/dcs/tests_dcs/test_dlq.py
+++ b/services/dcs/tests_dcs/test_dlq.py
@@ -15,6 +15,9 @@
 
 """Test to make sure that the DLQ is correctly set up for this service."""
 
+from datetime import datetime
+from uuid import uuid4
+
 import pytest
 from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.providers.akafka.testutils import KafkaFixture
@@ -58,13 +61,13 @@ async def test_consume_from_retry(joint_fixture: JointFixture):
     # Override the kafka test fixture's default for kafka_enable_dlq
     config = joint_fixture.config
     assert config.kafka_enable_dlq
-
     outbox_payload = event_schemas.FileDeletionRequested(file_id="123")
+    upload_date = datetime.fromisoformat("2025-02-25T16:15:28.148287+00:00")
     event_payload = event_schemas.FileInternallyRegistered(
         bucket_id="test",
-        upload_date="2025-02-25T16:15:28.148287+00:00",
+        upload_date=upload_date,
         file_id="",
-        object_id="",
+        object_id=uuid4(),
         s3_endpoint_alias="",
         decrypted_size=12345678,
         decrypted_sha256="fake-checksum",

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -49,12 +49,9 @@ class StorageUnavailableFixture:
 @pytest_asyncio.fixture
 async def storage_unavailable_fixture(joint_fixture: JointFixture):
     """Set up file with unavailable storage alias"""
-    alias = joint_fixture.endpoint_aliases.fake
-
     test_file = EXAMPLE_FILE.model_copy(deep=True)
-    test_file.file_id = alias
-    test_file.object_id = alias
-    test_file.s3_endpoint_alias = alias
+    test_file.file_id = "some_random_accession"
+    test_file.s3_endpoint_alias = joint_fixture.endpoint_aliases.fake_node
 
     # populate DB entry
     mongodb_dao = await joint_fixture.mongodb.dao_factory.get_dao(

--- a/services/dcs/tests_dcs/test_migrations.py
+++ b/services/dcs/tests_dcs/test_migrations.py
@@ -1,0 +1,119 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DCS database migrations"""
+
+from asyncio import sleep
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+
+from dcs.core.models import AccessTimeDrsObject
+from dcs.migrations import run_db_migrations
+from tests_dcs.fixtures.config import get_config
+
+pytestmark = pytest.mark.asyncio()
+
+
+async def test_migration_v2(mongodb: MongoDbFixture):
+    """Test the migration to DB version 2 and reversion to DB version 1."""
+    config = get_config(sources=[mongodb.config])
+
+    # Generate sample 'old' data that needs to be migrated
+    data: list[dict[str, Any]] = []
+
+    for i in range(3):
+        old_drs_object = AccessTimeDrsObject(
+            file_id=f"GHGAFile{i}",
+            decryption_secret_id="abc123",
+            decrypted_sha256="some-stuff",
+            decrypted_size=100,
+            encrypted_size=128,
+            creation_date=now_as_utc(),
+            s3_endpoint_alias="HD01",
+            object_id=uuid4(),
+            last_accessed=now_as_utc(),
+        ).model_dump()
+
+        # Convert data to the old format
+        old_drs_object["_id"] = old_drs_object.pop("file_id")
+        old_drs_object["object_id"] = str(old_drs_object["object_id"])
+        old_drs_object["creation_date"] = old_drs_object["creation_date"].isoformat()
+        old_drs_object["last_accessed"] = old_drs_object["last_accessed"].isoformat()
+        data.append(old_drs_object)
+        await sleep(0.1)  # sleep so timestamps are meaningfully different
+
+    # Clear out anything so we definitely start with an empty collection
+    db = mongodb.client[config.db_name]
+    collection = db["drs_objects"]
+    collection.delete_many({})
+
+    # Insert the test data
+    collection.insert_many(data)
+
+    # Run the migration
+    await run_db_migrations(config=config, target_version=2)
+
+    # Retrieve the migrated data and compare
+    migrated_data = collection.find().to_list()
+    migrated_data.sort(key=lambda x: x["_id"])
+
+    assert len(migrated_data) == len(data)
+    for old, new in zip(data, migrated_data, strict=True):
+        assert new["_id"] == old["_id"]
+
+        new_creation = new["creation_date"]
+        new_accessed = new["last_accessed"]
+
+        # Make sure the migrated data has the right types
+        assert isinstance(new["object_id"], UUID)
+        assert isinstance(new_creation, datetime)
+        assert isinstance(new_accessed, datetime)
+
+        # Make sure the actual ID of the object ID field still matches the old one
+        assert str(new["object_id"]) == old["object_id"]
+
+        # rather than calculating exact date mig results (tested in hexkit), just verify
+        #  that it's within half a millisecond
+        max_time_diff = timedelta(microseconds=500)
+        assert (
+            abs(new_creation - datetime.fromisoformat(old["creation_date"]))
+            < max_time_diff
+        )
+        assert (
+            abs(new_accessed - datetime.fromisoformat(old["last_accessed"]))
+            < max_time_diff
+        )
+
+        assert new_creation.microsecond % 1000 == 0
+        assert new_accessed.microsecond % 1000 == 0
+
+    # now unapply (dates will not have microseconds of course)
+    await run_db_migrations(config=config, target_version=1)
+    reverted_data = collection.find().to_list()
+    reverted_data.sort(key=lambda x: x["_id"])
+    assert len(reverted_data) == len(data)
+    for reverted, new in zip(reverted_data, migrated_data, strict=True):
+        assert isinstance(reverted["object_id"], str)
+        assert isinstance(reverted["creation_date"], str)
+        assert isinstance(reverted["last_accessed"], str)
+
+        assert reverted["_id"] == str(new["_id"])
+        assert reverted["creation_date"] == new["creation_date"].isoformat()
+        assert reverted["last_accessed"] == new["last_accessed"].isoformat()

--- a/services/dcs/tests_dcs/test_migrations.py
+++ b/services/dcs/tests_dcs/test_migrations.py
@@ -31,8 +31,11 @@ from tests_dcs.fixtures.config import get_config
 pytestmark = pytest.mark.asyncio()
 
 
-async def test_migration_v2(mongodb: MongoDbFixture):
-    """Test the migration to DB version 2 and reversion to DB version 1."""
+async def test_migration_v2_drs_objects(mongodb: MongoDbFixture):
+    """Test the migration to DB version 2 and reversion to DB version 1.
+
+    This test is only for the DRS objects, which are the main domain object.
+    """
     config = get_config(sources=[mongodb.config])
 
     # Generate sample 'old' data that needs to be migrated
@@ -117,3 +120,106 @@ async def test_migration_v2(mongodb: MongoDbFixture):
         assert reverted["_id"] == str(new["_id"])
         assert reverted["creation_date"] == new["creation_date"].isoformat()
         assert reverted["last_accessed"] == new["last_accessed"].isoformat()
+
+
+async def test_migration_v2_persisted_events(mongodb: MongoDbFixture):
+    """Test the migration to DB version 2 and reversion to DB version 1.
+
+    This test is only for persisted events.
+    """
+    config = get_config(sources=[mongodb.config])
+
+    download_served_topic = config.download_served_topic
+    file_registered_topic = config.file_registered_for_download_topic
+    file_deleted_topic = config.file_deleted_topic
+
+    new_object_id = uuid4()
+    new_upload_date = now_as_utc()
+
+    # Make one test event for each of the three stored topics
+    old_events: list[dict[str, Any]] = []
+    topics = [download_served_topic, file_registered_topic, file_deleted_topic]
+    for i, topic in enumerate(topics):
+        await sleep(0.1)
+        reverted_payload = {}
+        if topic == download_served_topic:
+            reverted_payload = {"object_id": str(new_object_id)}
+        elif topic == file_registered_topic:
+            reverted_payload = {"upload_date": new_upload_date.isoformat()}
+        event = {
+            "_id": f"{topic}:key{i}",
+            "topic": topic,
+            "payload": reverted_payload,
+            "key": f"key{i}",
+            "type_": "some-type",
+            "headers": {},
+            "correlation_id": str(uuid4()),
+            "created": now_as_utc().isoformat(),
+            "published": True,
+        }
+        old_events.append(event)
+
+    # Insert the test data
+    # Clear out anything so we definitely start with an empty collection
+    db = mongodb.client[config.db_name]
+    collection = db["dcsPersistedEvents"]
+    collection.delete_many({})
+
+    # Insert the test data
+    collection.insert_many(old_events)
+
+    # Run the migration
+    await run_db_migrations(config=config, target_version=2)
+
+    # Retrieve the migrated data and compare
+    migrated_events = collection.find().to_list()
+    migrated_events.sort(key=lambda x: x["_id"])
+
+    assert len(migrated_events) == 3
+    # Compare old and new data
+    max_time_diff = timedelta(microseconds=500)
+    for migrated, old in zip(migrated_events, old_events, strict=True):
+        assert isinstance(migrated["created"], datetime)
+        assert isinstance(migrated["correlation_id"], UUID)
+        assert (
+            abs(migrated["created"] - datetime.fromisoformat(old["created"]))
+            < max_time_diff
+        )
+        assert str(migrated["correlation_id"]) == old["correlation_id"]
+
+        # check the migrated payload fields and make sure the types/content are right
+        migrated_payload = migrated["payload"]
+        if migrated_object_id := migrated_payload.get("object_id"):
+            assert isinstance(migrated_object_id, UUID)
+            assert str(migrated_object_id) == old["payload"]["object_id"]
+        if migrated_upload_date := migrated_payload.get("upload_date"):
+            assert isinstance(migrated_upload_date, datetime)
+            assert (
+                abs(
+                    migrated_upload_date
+                    - datetime.fromisoformat(old["payload"]["upload_date"])
+                )
+                < max_time_diff
+            )
+
+    # Now reverse the migration and verify that part:
+    await run_db_migrations(config=config, target_version=1)
+    reverted_events = collection.find().to_list()
+    reverted_events.sort(key=lambda x: x["_id"])
+
+    for reverted, migrated in zip(reverted_events, migrated_events, strict=True):
+        assert isinstance(reverted["created"], str)
+        assert isinstance(reverted["correlation_id"], str)
+        assert reverted["created"] == migrated["created"].isoformat()
+        assert reverted["correlation_id"] == str(migrated["correlation_id"])
+
+        # check the payload fields
+        reverted_payload = reverted["payload"]
+        if reverted_object_id := reverted_payload.get("object_id"):
+            assert isinstance(reverted_object_id, str)
+            assert reverted_object_id == str(migrated["payload"]["object_id"])
+        if reverted_upload_date := reverted_payload.get("upload_date"):
+            assert isinstance(reverted_upload_date, str)
+            assert (
+                reverted_upload_date == migrated["payload"]["upload_date"].isoformat()
+            )

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -111,7 +111,7 @@ async def test_happy_journey(
     file_object = tmp_file.model_copy(
         update={
             "bucket_id": joint_fixture.bucket_id,
-            "object_id": object_id,
+            "object_id": str(object_id),
         }
     )
 
@@ -190,7 +190,7 @@ async def test_happy_deletion(
 
     drs_id = populated_fixture.example_file.file_id
     drs_object = await populated_fixture.mongodb_dao.get_by_id(drs_id)
-    object_id = drs_object.object_id
+    object_id = str(drs_object.object_id)
 
     # place example content in the outbox bucket:
     file_object = tmp_file.model_copy(
@@ -237,14 +237,14 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
     cached_object = await cleanup_fixture.mongodb_dao.get_by_id(cached_id)
     assert await s3.storage.does_object_exist(
         bucket_id=cleanup_fixture.joint.bucket_id,
-        object_id=cached_object.object_id,
+        object_id=str(cached_object.object_id),
     )
 
     # check if expired object has been removed from outbox
     expired_object = await cleanup_fixture.mongodb_dao.get_by_id(expired_id)
     assert not await s3.storage.does_object_exist(
         bucket_id=cleanup_fixture.joint.bucket_id,
-        object_id=expired_object.object_id,
+        object_id=str(expired_object.object_id),
     )
 
     with caplog.at_level(logging.ERROR):

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -249,12 +249,12 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
 
     with caplog.at_level(logging.ERROR):
         await data_repository.cleanup_outbox(
-            storage_alias=cleanup_fixture.joint.endpoint_aliases.fake
+            storage_alias=cleanup_fixture.joint.endpoint_aliases.fake_node
         )
 
     expected_message = str(
         data_repository.StorageAliasNotConfiguredError(
-            alias=cleanup_fixture.joint.endpoint_aliases.fake
+            alias=cleanup_fixture.joint.endpoint_aliases.fake_node
         )
     )
 


### PR DESCRIPTION
Ignore the failed mypy check because it's only flagging errors in other services. This will occur for all the PRs until they are merged into one.

### DCS Changes:
- V2 migration that covers two collections: `drs_objects` and `dcsPersistedEvents`.
- Models updated to use UUID4 and UTCDatetime where appropriate
- Use of `now_as_utc` replaced with less precise `now_utc_ms_prec`
- `MongoDbDaoFactory` is now used as a context manager