### PR TITLE
FIS - hexkit v6 + migration for persistent events

### DIFF
--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:8.1.1
+docker pull ghga/file-ingest-service:9.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:8.1.1 .
+docker build -t ghga/file-ingest-service:9.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:8.1.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:9.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -50,7 +50,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/otel_trace_sampling_rate"></a>**`otel_trace_sampling_rate`** *(number)*: Determines which proportion of spans should be sampled. A value of 1.0 means all and is equivalent to the previous behaviour. Setting this to 0 will result in no spans being sampled, but this does not automatically set `enable_opentelemetry` to False. Minimum: `0`. Maximum: `1`. Default: `1.0`.
 
-- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: `["grpc", "http/protobuf"]`. Default: `"http/protobuf"`.
+- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: "grpc" or "http/protobuf". Default: `"http/protobuf"`.
 
 - <a id="properties/otel_exporter_endpoint"></a>**`otel_exporter_endpoint`** *(string, format: uri, required)*: Base endpoint URL for the collector that receives content from the exporter. Length must be at least 1.
 
@@ -62,7 +62,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
+- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
 
 - <a id="properties/service_name"></a>**`service_name`** *(string)*: Default: `"fis"`.
 
@@ -321,7 +321,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests. Default: `null`.
+- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests. Default: `null`.
 
   - **Any of**
 
@@ -339,7 +339,25 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header. Default: `true`.
+- <a id="properties/cors_exposed_headers"></a>**`cors_exposed_headers`**: A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/cors_exposed_headers/anyOf/0"></a>*array*
+
+      - <a id="properties/cors_exposed_headers/anyOf/0/items"></a>**Items** *(string)*
+
+    - <a id="properties/cors_exposed_headers/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  []
+  ```
+
+
+- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header. Default: `true`.
 
 
   Examples:
@@ -368,7 +386,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: `["PLAINTEXT", "SSL"]`. Default: `"PLAINTEXT"`.
+- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
 
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
 
@@ -397,7 +415,7 @@ The service requires the following configuration parameters:
 
   - **Any of**
 
-    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: `["gzip", "snappy", "lz4", "zstd"]`.
+    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
 
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 

--- a/services/fis/config_schema.json
+++ b/services/fis/config_schema.json
@@ -361,15 +361,34 @@
         }
       ],
       "default": null,
-      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests.",
+      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests.",
       "examples": [
         []
       ],
       "title": "Cors Allowed Headers"
     },
+    "cors_exposed_headers": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses.",
+      "examples": [
+        []
+      ],
+      "title": "Cors Exposed Headers"
+    },
     "generate_correlation_id": {
       "default": true,
-      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header.",
+      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header.",
       "examples": [
         true,
         false

--- a/services/fis/example_config.yaml
+++ b/services/fis/example_config.yaml
@@ -4,6 +4,7 @@ cors_allow_credentials: null
 cors_allowed_headers: null
 cors_allowed_methods: null
 cors_allowed_origins: null
+cors_exposed_headers: null
 db_name: dev
 db_version_collection: fisDbVersions
 docs_url: /docs

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -48,6 +48,7 @@ components:
           title: File Id
           type: string
         object_id:
+          format: uuid4
           title: Object Id
           type: string
         part_size:
@@ -108,7 +109,7 @@ info:
   description: A service to ingest s3 file upload metadata produced by the data-steward-kit
     upload command
   title: File Ingest Service
-  version: 8.1.1
+  version: 9.0.0
 openapi: 3.1.0
 paths:
   /federated/ingest_metadata:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "8.1.1"
+version = "9.0.0"
 description = "File Ingest Service - A lightweight service to propagate file upload metadata to the GHGA file backend services"
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/adapters/outbound/event_pub.py
+++ b/services/fis/src/fis/adapters/outbound/event_pub.py
@@ -16,8 +16,8 @@
 
 from ghga_event_schemas.configs import FileInterrogationSuccessEventsConfig
 from ghga_event_schemas.pydantic_ import FileUploadValidationSuccess
-from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.protocols.eventpub import EventPublisherProtocol
+from hexkit.utils import now_utc_ms_prec
 
 from fis.core import models
 from fis.ports.outbound.event_pub import EventPubTranslatorPort
@@ -48,7 +48,7 @@ class EventPubTranslator(EventPubTranslatorPort):
     ):
         """Send FileUploadValidationSuccess event to downstream services"""
         payload = FileUploadValidationSuccess(
-            upload_date=now_as_utc().isoformat(),
+            upload_date=now_utc_ms_prec(),
             file_id=upload_metadata.file_id,
             object_id=upload_metadata.object_id,
             bucket_id=upload_metadata.bucket_id,

--- a/services/fis/src/fis/core/ingest.py
+++ b/services/fis/src/fis/core/ingest.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+from contextlib import suppress
 from pathlib import Path
 
 from crypt4gh.keys import get_private_key
@@ -104,11 +105,10 @@ class LegacyUploadMetadataProcessor(LegacyUploadMetadataProcessorPort):
 
     async def has_already_been_processed(self, *, file_id: str):
         """Check if file metadata has already been seen and successfully processed."""
-        try:
+        with suppress(ResourceNotFoundError):
             await self._file_dao.get_by_id(file_id)
-        except ResourceNotFoundError:
-            return False
-        return True
+            return True
+        return False
 
     async def populate_by_event(
         self, *, upload_metadata: models.LegacyUploadMetadata, secret_id: str

--- a/services/fis/src/fis/core/models.py
+++ b/services/fis/src/fis/core/models.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Models for internal representation"""
 
-from pydantic import BaseModel, SecretStr
+from pydantic import UUID4, BaseModel, SecretStr
 
 
 class EncryptedPayload(BaseModel):
@@ -37,7 +37,7 @@ class UploadMetadataBase(FileIdModel):
     representing the S3 upload script output
     """
 
-    object_id: str
+    object_id: UUID4
     bucket_id: str
     part_size: int
     unencrypted_size: int

--- a/services/fis/src/fis/main.py
+++ b/services/fis/src/fis/main.py
@@ -22,7 +22,7 @@ from fis.config import Config
 from fis.inject import get_persistent_publisher, prepare_rest_app
 from fis.migrations import run_db_migrations
 
-DB_VERSION = 2
+DB_VERSION = 3
 
 
 async def run_rest():

--- a/services/fis/src/fis/migrations/entry.py
+++ b/services/fis/src/fis/migrations/entry.py
@@ -20,9 +20,9 @@ from hexkit.providers.mongodb.migrations import (
     MigrationMap,
 )
 
-from fis.migrations.definitions import V2Migration
+from fis.migrations.definitions import V2Migration, V3Migration
 
-MIGRATION_MAP = {2: V2Migration}
+MIGRATION_MAP = {2: V2Migration, 3: V3Migration}
 
 
 async def run_db_migrations(

--- a/services/fis/tests_fis/fixtures/joint.py
+++ b/services/fis/tests_fis/fixtures/joint.py
@@ -20,6 +20,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkstemp
+from uuid import UUID
 
 import httpx
 import pytest_asyncio
@@ -42,10 +43,12 @@ from tests_fis.fixtures.config import get_config
 
 __all__ = ["TEST_PAYLOAD", "JointFixture", "joint_fixture"]
 
+TEST_OBJECT_ID = UUID("794fa7ab-fa80-493b-a08d-a6be41a07cde")
+
 TEST_PAYLOAD = UploadMetadataBase(
     file_id="abc",
     bucket_id="staging",
-    object_id="happy_little_object",
+    object_id=TEST_OBJECT_ID,
     part_size=16 * 1024**2,
     unencrypted_size=50 * 1024**2,
     encrypted_size=50 * 1024**2 + 128,

--- a/services/fis/tests_fis/test_api_call.py
+++ b/services/fis/tests_fis/test_api_call.py
@@ -113,7 +113,7 @@ async def test_api_calls(monkeypatch, joint_fixture: JointFixture):
     # can't get exact event time for equality comparison, don't check but get directly
     # from the recorded event instead
     expected_upload_date = datetime.fromisoformat(
-        event_recorder.recorded_events[0].payload["upload_date"]
+        event_recorder.recorded_events[0].payload["upload_date"]  # type: ignore
     )
 
     expected_payload = FileUploadValidationSuccess(
@@ -218,7 +218,7 @@ async def test_legacy_api_calls(monkeypatch, joint_fixture: JointFixture):
     # can't get exact event time for equality comparison, don't check but get directly
     # from the recorded event instead
     expected_upload_date = datetime.fromisoformat(
-        event_recorder.recorded_events[0].payload["upload_date"]
+        event_recorder.recorded_events[0].payload["upload_date"]  # type: ignore
     )
 
     expected_payload = FileUploadValidationSuccess(

--- a/services/fis/tests_fis/test_api_call.py
+++ b/services/fis/tests_fis/test_api_call.py
@@ -93,7 +93,7 @@ async def test_api_calls(monkeypatch, joint_fixture: JointFixture):
         **TEST_PAYLOAD.model_dump(),
         secret_id=secret_id,
     )
-    json_payload = json.loads(payload.model_dump_json())
+    json_payload = payload.model_dump(mode="json")
 
     event_recorder = EventRecorder(
         kafka_servers=joint_fixture.kafka.config.kafka_servers,
@@ -167,10 +167,9 @@ async def test_api_calls(monkeypatch, joint_fixture: JointFixture):
     assert response.status_code == 403
 
     # test malformed payload
-    nonsense_payload = json.loads(expected_payload.model_dump_json())
     response = await joint_fixture.rest_client.post(
         "/federated/ingest_metadata",
-        json=nonsense_payload,
+        json=expected_payload.model_dump(mode="json"),
         headers=headers,
     )
     assert response.status_code == 422
@@ -256,7 +255,7 @@ async def test_legacy_api_calls(monkeypatch, joint_fixture: JointFixture):
     async with event_recorder:
         response = await joint_fixture.rest_client.post(
             "/legacy/ingest",
-            json=json.loads(encrypted_payload.model_dump_json()),
+            json=encrypted_payload.model_dump(mode="json"),
             headers=headers,
         )
     assert response.status_code == 409

--- a/services/fis/tests_fis/test_ingest.py
+++ b/services/fis/tests_fis/test_ingest.py
@@ -41,7 +41,7 @@ async def test_legacy_decryption_happy(joint_fixture: JointFixture):
 
     encrypted_payload = EncryptedPayload(
         payload=encrypt(
-            data=json.dumps(payload),
+            data=json.dumps(payload, default=str),
             key=joint_fixture.keypair.public,
         )
     )

--- a/services/fis/tests_fis/test_migrations.py
+++ b/services/fis/tests_fis/test_migrations.py
@@ -14,11 +14,16 @@
 # limitations under the License.
 """Verify the functionality of the migrations module."""
 
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
 import pytest
 from ghga_event_schemas.pydantic_ import FileUploadValidationSuccess
-from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.providers.mongodb.testutils import MongoDbFixture
+from hexkit.utils import now_utc_ms_prec
 
+from fis.main import DB_VERSION
 from fis.migrations import run_db_migrations
 from tests_fis.fixtures.config import get_config
 from tests_fis.fixtures.joint import TEST_PAYLOAD
@@ -31,7 +36,7 @@ TEST_CORRELATION_ID = "9b2af78e-2f36-49da-ab78-f0142d433038"
 def make_test_event(file_id: str) -> FileUploadValidationSuccess:
     """Make a copy of the test event with the given file_id."""
     event = FileUploadValidationSuccess(
-        upload_date=now_as_utc().isoformat(),
+        upload_date=now_utc_ms_prec(),
         file_id=file_id,
         object_id=TEST_PAYLOAD.object_id,
         bucket_id=TEST_PAYLOAD.bucket_id,
@@ -47,6 +52,7 @@ def make_test_event(file_id: str) -> FileUploadValidationSuccess:
     return event
 
 
+@pytest.mark.skipif(DB_VERSION != 2, reason="Don't run tests for old migrations")
 async def test_v2_migration(mongodb: MongoDbFixture):
     """Test the v2 migration, which should move existing outbox events to
     the new persisted events collection.
@@ -90,3 +96,99 @@ async def test_v2_migration(mongodb: MongoDbFixture):
         index = int(doc["key"][-1])
         assert doc["payload"] == events[index].model_dump()
     assert outbox_name not in db.list_collection_names()
+
+
+@pytest.mark.skipif(DB_VERSION != 3, reason="Don't run tests for old migrations")
+async def test_v3_migration(mongodb: MongoDbFixture):
+    """Test the v3 migration, which should update the persistent event collection
+    so the fields use actual UUID and datetime field types.
+    """
+    config = get_config(sources=[mongodb.config])
+    db = mongodb.client[config.db_name]
+    collection = db["fisPersistedEvents"]
+
+    # affected fields - share value for fields of same type to simplify test
+    date = datetime(2025, 4, 9, 15, 10, 2, 284123, tzinfo=UTC)
+    migrated_date = date.replace(microsecond=284000)
+    reverted_date = migrated_date.isoformat()
+
+    old_uuid = "794fa7ab-fa80-493b-a08d-a6be41a07cde"
+    migrated_uuid = UUID(old_uuid)
+
+    # Prepare the old, migrated, and reverted data ahead of time
+    old_events: list[dict[str, Any]] = []
+    expected_migrated_events: list[dict[str, Any]] = []
+    expected_reverted_events: list[dict[str, Any]] = []
+
+    for i in range(1, 3):
+        # Form the payloads within the persisted events separately, then hydrate
+        old_payload = {
+            "bucket_id": "staging",
+            "content_offset": 0,
+            "decrypted_sha256": "def",
+            "decrypted_size": 52428800,
+            "decryption_secret_id": "",
+            "encrypted_part_size": 16777216,
+            "encrypted_parts_md5": ["a", "b", "c"],
+            "encrypted_parts_sha256": ["a", "b", "c"],
+            "file_id": f"test_id{i}",
+            "object_id": old_uuid,
+            "s3_endpoint_alias": "staging",
+            "upload_date": date.isoformat(),
+        }
+
+        migrated_payload = old_payload.copy()
+        migrated_payload.update(
+            {"object_id": migrated_uuid, "upload_date": migrated_date}
+        )
+        reverted_payload = old_payload.copy()
+        reverted_payload.update({"upload_date": reverted_date})
+
+        # Now form the top-level document data and inject the payloads
+        old_event = {
+            "_id": f"test-topic:key{i}",
+            "topic": "test-topic",
+            "payload": old_payload,
+            "key": f"key{i}",
+            "type_": "some-type",
+            "headers": {},
+            "correlation_id": old_uuid,
+            "created": date.isoformat(),
+            "published": True,
+        }
+
+        migrated_event = old_event.copy()
+        migrated_event.update(
+            {
+                "payload": migrated_payload,
+                "correlation_id": migrated_uuid,
+                "created": migrated_date,
+            }
+        )
+        reverted_event = old_event.copy()
+        reverted_event.update({"payload": reverted_payload, "created": reverted_date})
+
+        old_events.append(old_event)
+        expected_migrated_events.append(migrated_event)
+        expected_reverted_events.append(reverted_event)
+
+    # Clear DB and insert test data
+    collection.delete_many({})
+    collection.insert_many(old_events)
+
+    # Run the migration
+    await run_db_migrations(config=config, target_version=3)
+
+    # Compare migrated data against expected migrated data
+    migrated_events = sorted(collection.find({}).to_list(), key=lambda d: d["_id"])
+
+    # Verify event_id is there and that it is a UUID, removing it in the process
+    assert all(isinstance(doc.pop("event_id"), UUID) for doc in migrated_events)
+    assert migrated_events == expected_migrated_events  # without event_id, should match
+
+    # Run reverse migration
+    await run_db_migrations(config=config, target_version=2)
+
+    # Compare reversal with expected data
+    reverted_events = sorted(collection.find({}).to_list(), key=lambda d: d["_id"])
+    assert reverted_events == expected_reverted_events


### PR DESCRIPTION
Ignore the failed mypy check because it's only flagging errors in other services. This will occur for all the PRs until they are merged into one.

### FIS Changes:
- V3 migration that covers just the `fisPersistedEvents` collection
- Models updated to use UUID4 and UTCDatetime where appropriate
- Use of `now_as_utc` replaced with less precise `now_utc_ms_prec`
- `MongoDbDaoFactory` is now used as a context manager

I left otel & `@start_span()` in there because it is still hexkit v6 

Went for a slightly different approach for the migration test than in the last few PRs. I created the original, migrated, and reverted expected outputs upfront and tried to directly equate the output. 