### PR TITLE
IRS: Hexkit v6 (GSI-1788)

### DIFF
--- a/services/irs/README.md
+++ b/services/irs/README.md
@@ -14,13 +14,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/interrogation-room-service):
 ```bash
-docker pull ghga/interrogation-room-service:6.1.1
+docker pull ghga/interrogation-room-service:7.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/interrogation-room-service:6.1.1 .
+docker build -t ghga/interrogation-room-service:7.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -28,7 +28,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/interrogation-room-service:6.1.1 --help
+docker run -p 8080:8080 ghga/interrogation-room-service:7.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -49,7 +49,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/otel_trace_sampling_rate"></a>**`otel_trace_sampling_rate`** *(number)*: Determines which proportion of spans should be sampled. A value of 1.0 means all and is equivalent to the previous behaviour. Setting this to 0 will result in no spans being sampled, but this does not automatically set `enable_opentelemetry` to False. Minimum: `0`. Maximum: `1`. Default: `1.0`.
 
-- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: `["grpc", "http/protobuf"]`. Default: `"http/protobuf"`.
+- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: "grpc" or "http/protobuf". Default: `"http/protobuf"`.
 
 - <a id="properties/otel_exporter_endpoint"></a>**`otel_exporter_endpoint`** *(string, format: uri, required)*: Base endpoint URL for the collector that receives content from the exporter. Length must be at least 1.
 
@@ -63,7 +63,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/object_stale_after_minutes"></a>**`object_stale_after_minutes`** *(integer, required)*: Amount of time in minutes after which an object in the staging bucket is considered stale. If an object continues existing after this point in time, this is an indication, that something might have gone wrong downstream.
 
-- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
+- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
 
 - <a id="properties/service_name"></a>**`service_name`** *(string)*: Default: `"irs"`.
 
@@ -193,7 +193,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: `["PLAINTEXT", "SSL"]`. Default: `"PLAINTEXT"`.
+- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
 
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
 
@@ -203,7 +203,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/kafka_ssl_password"></a>**`kafka_ssl_password`** *(string, format: password, write-only)*: Optional password to be used for the client private key. Default: `""`.
 
-- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header. Default: `true`.
+- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header. Default: `true`.
 
 
   Examples:
@@ -237,7 +237,7 @@ The service requires the following configuration parameters:
 
   - **Any of**
 
-    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: `["gzip", "snappy", "lz4", "zstd"]`.
+    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
 
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 
@@ -452,7 +452,7 @@ to talk to an S3 service in the backend.<br>  Args:
     ```
 
 
-  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required, write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
+  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required and write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
 
 
     Examples:
@@ -498,7 +498,7 @@ to talk to an S3 service in the backend.<br>  Args:
 
   - <a id="%24defs/S3ObjectStorageNodeConfig/properties/bucket"></a>**`bucket`** *(string, required)*
 
-  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`**: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
+  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`** *(required)*: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
 
 
 ### Usage:

--- a/services/irs/config_schema.json
+++ b/services/irs/config_schema.json
@@ -301,7 +301,7 @@
     },
     "generate_correlation_id": {
       "default": true,
-      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header.",
+      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header.",
       "examples": [
         true,
         false

--- a/services/irs/pyproject.toml
+++ b/services/irs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "irs"
-version = "6.1.1"
+version = "7.0.0"
 description = "Interrogation Room Service"
 readme = "README.md"
 authors = [

--- a/services/irs/src/irs/adapters/inbound/event_sub.py
+++ b/services/irs/src/irs/adapters/inbound/event_sub.py
@@ -24,6 +24,7 @@ from ghga_event_schemas.configs import (
 from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.protocols.eventsub import EventSubscriberProtocol
+from pydantic import UUID4
 
 from irs.core.models import InterrogationSubject
 from irs.ports.inbound.interrogator import InterrogatorPort
@@ -61,7 +62,13 @@ class EventSubTranslator(EventSubscriberProtocol):
         ]
 
     async def _consume_validated(
-        self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: str
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        topic: Ascii,
+        key: str,
+        event_id: UUID4,
     ) -> None:
         """
         Receive and process an event with already validated topic and type.
@@ -71,6 +78,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             type_ (str): The type of the event.
             topic (str): Name of the topic the event was published to.
             key (str): The key associated with the event.
+            event_id (UUID4): The unique identifier for the event.
         """
         if type_ == self._config.file_internally_registered_type:
             await self._consume_file_internally_registered(payload=payload)
@@ -104,7 +112,7 @@ class EventSubTranslator(EventSubscriberProtocol):
         subject = InterrogationSubject(
             file_id=validated_payload.file_id,
             inbox_bucket_id=validated_payload.bucket_id,
-            inbox_object_id=validated_payload.object_id,
+            inbox_object_id=str(validated_payload.object_id),
             storage_alias=validated_payload.s3_endpoint_alias,
             decrypted_size=validated_payload.decrypted_size,
             expected_decrypted_sha256=validated_payload.expected_decrypted_sha256,

--- a/services/irs/src/irs/adapters/outbound/event_pub.py
+++ b/services/irs/src/irs/adapters/outbound/event_pub.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """KafkaEventPublisher for file upload validation success/failure event details"""
 
-import json
+from uuid import UUID
 
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.configs import (
@@ -55,13 +55,13 @@ class EventPublisher(EventPublisherPort):
         event_payload = event_schemas.FileUploadValidationFailure(
             s3_endpoint_alias=subject.storage_alias,
             file_id=subject.file_id,
-            object_id=staging_handler.staging.object_id,
+            object_id=UUID(staging_handler.staging.object_id),
             bucket_id=staging_handler.staging.bucket_id,
             upload_date=subject.upload_date,
             reason=cause,
         )
         await self._provider.publish(
-            payload=json.loads(event_payload.model_dump_json()),
+            payload=event_payload.model_dump(),
             type_=self._config.interrogation_failure_type,
             topic=self._config.file_interrogations_topic,
             key=subject.file_id,
@@ -78,7 +78,7 @@ class EventPublisher(EventPublisherPort):
         event_payload = event_schemas.FileUploadValidationSuccess(
             s3_endpoint_alias=subject.storage_alias,
             file_id=subject.file_id,
-            object_id=staging_handler.staging.object_id,
+            object_id=UUID(staging_handler.staging.object_id),
             bucket_id=staging_handler.staging.bucket_id,
             upload_date=subject.upload_date,
             decrypted_size=subject.decrypted_size,
@@ -90,7 +90,7 @@ class EventPublisher(EventPublisherPort):
             decrypted_sha256=processing_result.checksums.content_checksum_sha256,
         )
         await self._provider.publish(
-            payload=json.loads(event_payload.model_dump_json()),
+            payload=event_payload.model_dump(),
             type_=self._config.interrogation_success_type,
             topic=self._config.file_interrogations_topic,
             key=subject.file_id,

--- a/services/irs/src/irs/core/interrogator.py
+++ b/services/irs/src/irs/core/interrogator.py
@@ -165,7 +165,7 @@ class Interrogator(InterrogatorPort):
         except (CryptoError, EnvelopeError, ValueError) as error:
             # These should be systemic issues with the file submitted, i.e. there's no
             # way to recover without resubmitting in the upstream service
-            log.error(error)
+            log.error(error, exc_info=True)
             await staging_handler.abort_staging()
             await self._event_publisher.publish_validation_failure(
                 staging_handler=staging_handler, subject=subject, cause=str(error)
@@ -241,7 +241,7 @@ class Interrogator(InterrogatorPort):
                 f"Object '{staging_object.object_id}' unexpectedly not in staging bucket"
                 + f" '{staging_bucket_id}' of storage '{storage_alias}'."
             )
-            log.critical(out_of_sync_error)
+            log.critical(out_of_sync_error, exc_info=True)
             raise out_of_sync_error
 
         # these have been checked before, i.e. should not raise

--- a/services/irs/src/irs/core/models.py
+++ b/services/irs/src/irs/core/models.py
@@ -18,7 +18,8 @@
 
 import hashlib
 
-from ghga_service_commons.utils.utc_dates import UTCDatetime, now_as_utc
+from ghga_service_commons.utils.utc_dates import UTCDatetime
+from hexkit.utils import now_utc_ms_prec
 from pydantic import BaseModel, Field
 
 
@@ -37,7 +38,7 @@ class StagingObject(BaseModel):
     file_id: str
     object_id: str
     storage_alias: str
-    creation_date: UTCDatetime = Field(default_factory=now_as_utc)
+    creation_date: UTCDatetime = Field(default_factory=now_utc_ms_prec)
 
 
 class InterrogationSubject(BaseModel):
@@ -49,7 +50,7 @@ class InterrogationSubject(BaseModel):
     storage_alias: str
     decrypted_size: int
     expected_decrypted_sha256: str
-    upload_date: str
+    upload_date: UTCDatetime
     submitter_public_key: str
 
 
@@ -61,7 +62,7 @@ class UploadReceivedFingerprint(BaseModel):
     """
 
     checksum: str
-    creation_date: UTCDatetime = Field(default_factory=now_as_utc)
+    creation_date: UTCDatetime = Field(default_factory=now_utc_ms_prec)
 
     @staticmethod
     def generate(

--- a/services/irs/src/irs/core/storage_inspector.py
+++ b/services/irs/src/irs/core/storage_inspector.py
@@ -19,8 +19,8 @@ import logging
 from datetime import timedelta
 
 from ghga_service_commons.utils.multinode_storage import S3ObjectStorages
-from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.protocols.dao import MultipleHitsFoundError, NoHitsFoundError
+from hexkit.utils import now_utc_ms_prec
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
@@ -85,10 +85,11 @@ class StagingInspector(StorageInspectorPort):
             log.critical(
                 error,
                 extra=extra,
+                exc_info=True,
             )
             return
 
-        stale_as_of = now_as_utc() - timedelta(
+        stale_as_of = now_utc_ms_prec() - timedelta(
             minutes=self._config.object_stale_after_minutes
         )
         if staging_object.creation_date <= stale_as_of:

--- a/services/irs/tests_irs/test_cli.py
+++ b/services/irs/tests_irs/test_cli.py
@@ -18,7 +18,7 @@
 from datetime import timedelta
 
 import pytest
-from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.utils import now_utc_ms_prec
 
 from irs.adapters.outbound.dao import get_staging_object_dao
 from irs.core.models import StagingObject
@@ -64,7 +64,7 @@ async def test_staging_inspector(caplog, joint_fixture: JointFixture):
     )
 
     # modify second object to be recognized as stale
-    staging_object_2.creation_date = now_as_utc() - timedelta(
+    staging_object_2.creation_date = now_utc_ms_prec() - timedelta(
         minutes=joint_fixture.config.object_stale_after_minutes
     )
 

--- a/services/irs/tests_irs/test_dlq.py
+++ b/services/irs/tests_irs/test_dlq.py
@@ -15,6 +15,9 @@
 
 """Test to make sure that the DLQ is correctly set up for this service."""
 
+from datetime import datetime
+from uuid import uuid4
+
 import pytest
 from ghga_event_schemas import pydantic_ as event_schemas
 
@@ -54,9 +57,9 @@ async def test_consume_from_retry(joint_fixture: JointFixture):
 
     event_payload = event_schemas.FileInternallyRegistered(
         bucket_id="test",
-        upload_date="2025-02-25T16:15:28.148287+00:00",
+        upload_date=datetime.fromisoformat("2025-02-25T16:15:28.148287+00:00"),
         file_id="",
-        object_id="",
+        object_id=uuid4(),
         s3_endpoint_alias="",
         decrypted_size=12345678,
         decrypted_sha256="fake-checksum",

--- a/services/irs/tests_irs/test_event_handling.py
+++ b/services/irs/tests_irs/test_event_handling.py
@@ -22,10 +22,9 @@ from functools import partial
 from typing import Any
 
 import pytest
-from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.protocols.dao import ResourceNotFoundError
 from hexkit.providers.akafka.testutils import ExpectedEvent
-from hexkit.utils import calc_part_size
+from hexkit.utils import calc_part_size, now_utc_ms_prec
 
 from irs.adapters.outbound.dao import get_fingerprint_dao, get_staging_object_dao
 from irs.core.models import InterrogationSubject, UploadReceivedFingerprint
@@ -277,7 +276,7 @@ async def test_success_event(monkeypatch, joint_fixture: JointFixture):
         "encrypted_parts_md5": encrypted_parts_md5,
         "encrypted_parts_sha256": encrypted_parts_sha256,
         "decrypted_sha256": data.checksum,
-        "upload_date": now_as_utc().isoformat(),
+        "upload_date": now_utc_ms_prec().isoformat(),
     }
 
     remove_event = _incoming_event_file_registered(


### PR DESCRIPTION
Bump irs to version 7 and use hexkit v6.

I left the IRS-specific definitions of `object_id` here as strings because of the blind way the IRS queries S3 for stale objects, some annoying test inconsistencies that would result, and because it really just doesn't need to change right now (not deployed). There's also no migration.