### PR TITLE
PCS - use hexkit v6 (GSI-1787)

### DIFF
--- a/services/pcs/README.md
+++ b/services/pcs/README.md
@@ -355,6 +355,67 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
+- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
+
+    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  null
+  ```
+
+
+  ```json
+  300
+  ```
+
+
+  ```json
+  600
+  ```
+
+
+  ```json
+  3600
+  ```
+
+
 - <a id="properties/host"></a>**`host`** *(string)*: IP of the host. Default: `"127.0.0.1"`.
 
 - <a id="properties/port"></a>**`port`** *(integer)*: Port to expose the server on the specified host. Default: `8080`.

--- a/services/pcs/README.md
+++ b/services/pcs/README.md
@@ -26,13 +26,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/purge-controller-service):
 ```bash
-docker pull ghga/purge-controller-service:4.1.1
+docker pull ghga/purge-controller-service:5.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/purge-controller-service:4.1.1 .
+docker build -t ghga/purge-controller-service:5.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -40,7 +40,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/purge-controller-service:4.1.1 --help
+docker run -p 8080:8080 ghga/purge-controller-service:5.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -61,7 +61,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/otel_trace_sampling_rate"></a>**`otel_trace_sampling_rate`** *(number)*: Determines which proportion of spans should be sampled. A value of 1.0 means all and is equivalent to the previous behaviour. Setting this to 0 will result in no spans being sampled, but this does not automatically set `enable_opentelemetry` to False. Minimum: `0`. Maximum: `1`. Default: `1.0`.
 
-- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: `["grpc", "http/protobuf"]`. Default: `"http/protobuf"`.
+- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: "grpc" or "http/protobuf". Default: `"http/protobuf"`.
 
 - <a id="properties/otel_exporter_endpoint"></a>**`otel_exporter_endpoint`** *(string, format: uri, required)*: Base endpoint URL for the collector that receives content from the exporter. Length must be at least 1.
 
@@ -93,7 +93,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
+- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
 
 - <a id="properties/service_name"></a>**`service_name`** *(string)*: Default: `"pcs"`.
 
@@ -148,7 +148,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: `["PLAINTEXT", "SSL"]`. Default: `"PLAINTEXT"`.
+- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
 
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
 
@@ -192,7 +192,7 @@ The service requires the following configuration parameters:
 
   - **Any of**
 
-    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: `["gzip", "snappy", "lz4", "zstd"]`.
+    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
 
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 
@@ -429,7 +429,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests. Default: `null`.
+- <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests. Default: `null`.
 
   - **Any of**
 
@@ -438,6 +438,24 @@ The service requires the following configuration parameters:
       - <a id="properties/cors_allowed_headers/anyOf/0/items"></a>**Items** *(string)*
 
     - <a id="properties/cors_allowed_headers/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  []
+  ```
+
+
+- <a id="properties/cors_exposed_headers"></a>**`cors_exposed_headers`**: A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/cors_exposed_headers/anyOf/0"></a>*array*
+
+      - <a id="properties/cors_exposed_headers/anyOf/0/items"></a>**Items** *(string)*
+
+    - <a id="properties/cors_exposed_headers/anyOf/1"></a>*null*
 
 
   Examples:

--- a/services/pcs/config_schema.json
+++ b/services/pcs/config_schema.json
@@ -290,6 +290,43 @@
       ],
       "title": "Mongo Timeout"
     },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
+    "migration_max_wait_sec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
+      "examples": [
+        null,
+        300,
+        600,
+        3600
+      ],
+      "title": "Migration Max Wait Sec"
+    },
     "host": {
       "default": "127.0.0.1",
       "description": "IP of the host.",
@@ -441,7 +478,9 @@
     "token_hashes",
     "kafka_servers",
     "mongo_dsn",
-    "db_name"
+    "db_name",
+    "db_version_collection",
+    "migration_wait_sec"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/pcs/config_schema.json
+++ b/services/pcs/config_schema.json
@@ -407,11 +407,30 @@
         }
       ],
       "default": null,
-      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests.",
+      "description": "A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests.",
       "examples": [
         []
       ],
       "title": "Cors Allowed Headers"
+    },
+    "cors_exposed_headers": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses.",
+      "examples": [
+        []
+      ],
+      "title": "Cors Exposed Headers"
     }
   },
   "required": [

--- a/services/pcs/dev_config.yaml
+++ b/services/pcs/dev_config.yaml
@@ -21,3 +21,5 @@ mongo_dsn: "mongodb://mongodb:27017"
 db_name: "dev"
 
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 10
+db_version_collection: pcsDbVersions

--- a/services/pcs/example_config.yaml
+++ b/services/pcs/example_config.yaml
@@ -4,6 +4,7 @@ cors_allow_credentials: null
 cors_allowed_headers: null
 cors_allowed_methods: null
 cors_allowed_origins: null
+cors_exposed_headers: null
 db_name: dev
 docs_url: /docs
 enable_opentelemetry: false

--- a/services/pcs/example_config.yaml
+++ b/services/pcs/example_config.yaml
@@ -6,6 +6,7 @@ cors_allowed_methods: null
 cors_allowed_origins: null
 cors_exposed_headers: null
 db_name: dev
+db_version_collection: pcsDbVersions
 docs_url: /docs
 enable_opentelemetry: false
 file_deletion_request_topic: file-deletion-requests
@@ -28,6 +29,8 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_max_wait_sec: null
+migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 openapi_url: /openapi.json

--- a/services/pcs/openapi.yaml
+++ b/services/pcs/openapi.yaml
@@ -38,7 +38,7 @@ info:
   description: A service exposing an external API to commission file deletionsfrom
     the wholefile backend.
   title: Purge Controller Service
-  version: 4.1.1
+  version: 5.0.0
 openapi: 3.1.0
 paths:
   /files/{file_id}:

--- a/services/pcs/pyproject.toml
+++ b/services/pcs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pcs"
-version = "4.1.1"
+version = "5.0.0"
 description = "Purge Controller Service - a service to commission file deletions"
 readme = "README.md"
 authors = [

--- a/services/pcs/src/pcs/config.py
+++ b/services/pcs/src/pcs/config.py
@@ -20,7 +20,7 @@ from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongokafka import MongoKafkaConfig
+from hexkit.providers.mongodb.migrations import MigrationConfig
 
 from pcs.adapters.inbound.fastapi_.config import TokenHashConfig
 from pcs.adapters.outbound.event_pub import EventPubTranslatorConfig
@@ -31,7 +31,7 @@ SERVICE_NAME = "pcs"
 @config_from_yaml(prefix=SERVICE_NAME)
 class Config(
     ApiConfigBase,
-    MongoKafkaConfig,
+    MigrationConfig,
     KafkaConfig,
     TokenHashConfig,
     LoggingConfig,

--- a/services/pcs/src/pcs/inject.py
+++ b/services/pcs/src/pcs/inject.py
@@ -16,10 +16,9 @@
 """Module hosting the dependency injection container."""
 
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 
 from fastapi import FastAPI
-from ghga_service_commons.utils.context import asyncnullcontext
 from hexkit.providers.mongodb import MongoDbDaoFactory
 from hexkit.providers.mongokafka import PersistentKafkaPublisher
 
@@ -36,23 +35,26 @@ async def get_persistent_publisher(
     config: Config, dao_factory: MongoDbDaoFactory | None = None
 ) -> AsyncGenerator[PersistentKafkaPublisher, None]:
     """Construct and return a PersistentKafkaPublisher."""
-    dao_factory = dao_factory or MongoDbDaoFactory(config=config)
-    async with PersistentKafkaPublisher.construct(
-        config=config,
-        dao_factory=dao_factory,
-        compacted_topics={config.file_deletion_request_topic},
-        collection_name="pcsPersistedEvents",
-    ) as persistent_publisher:
+    async with (
+        (
+            nullcontext(dao_factory)
+            if dao_factory
+            else MongoDbDaoFactory.construct(config=config)
+        ) as _dao_factory,
+        PersistentKafkaPublisher.construct(
+            config=config,
+            dao_factory=_dao_factory,
+            compacted_topics={config.file_deletion_request_topic},
+            collection_name="pcsPersistedEvents",
+        ) as persistent_publisher,
+    ):
         yield persistent_publisher
 
 
 @asynccontextmanager
 async def prepare_core(*, config: Config) -> AsyncGenerator[FileDeletionPort, None]:
     """Construct and initialize the core component and its outbound dependencies."""
-    dao_factory = MongoDbDaoFactory(config=config)
-    async with get_persistent_publisher(
-        config=config, dao_factory=dao_factory
-    ) as persistent_publisher:
+    async with get_persistent_publisher(config=config) as persistent_publisher:
         event_pub_translator = EventPubTranslator(
             config=config, provider=persistent_publisher
         )
@@ -68,11 +70,7 @@ def prepare_core_with_override(
     """Return a context manager for preparing the core that can be overwritten
     with the given value.
     """
-    return (
-        asyncnullcontext(core_override)
-        if core_override
-        else prepare_core(config=config)
-    )
+    return nullcontext(core_override) if core_override else prepare_core(config=config)
 
 
 @asynccontextmanager

--- a/services/pcs/src/pcs/main.py
+++ b/services/pcs/src/pcs/main.py
@@ -21,6 +21,9 @@ from hexkit.opentelemetry import configure_opentelemetry
 
 from pcs.config import Config
 from pcs.inject import get_persistent_publisher, prepare_rest_app
+from pcs.migrations import run_db_migrations
+
+DB_VERSION = 2
 
 
 async def run_rest_app():
@@ -28,6 +31,8 @@ async def run_rest_app():
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -38,6 +43,8 @@ async def publish_events(*, all: bool = False):
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with get_persistent_publisher(config=config) as persistent_publisher:
         if all:

--- a/services/pcs/src/pcs/migrations/__init__.py
+++ b/services/pcs/src/pcs/migrations/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DB Migration logic"""
+
+from .definitions import V2Migration
+from .entry import run_db_migrations
+
+__all__ = ["V2Migration", "run_db_migrations"]

--- a/services/pcs/src/pcs/migrations/definitions.py
+++ b/services/pcs/src/pcs/migrations/definitions.py
@@ -1,0 +1,74 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic for PCS"""
+
+from hexkit.providers.mongodb.migrations import (
+    Document,
+    MigrationDefinition,
+    Reversible,
+)
+from hexkit.providers.mongodb.migrations.helpers import convert_persistent_event_v6
+from hexkit.providers.mongokafka.provider.persistent_pub import PersistentKafkaEvent
+
+# Collection names defined as constants
+PCS_PERSISTED_EVENTS = "pcsPersistedEvents"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Migrate select fields in the `pcsPersistedEvents` collection for hexkit v6.
+
+    Fields affected:
+    - `created`: *str* -> *datetime*
+    - `correlation_id`: *str* -> *UUID4*
+    - `event_id`: new, *UUID4*
+
+    No changes to payload, which only contains a string field.
+
+    This can be reversed by converting the UUIDs and datetimes back to strings.
+    """
+
+    version = 2
+
+    async def apply(self):
+        """Perform the migration"""
+        async with self.auto_finalize(
+            coll_names=PCS_PERSISTED_EVENTS, copy_indexes=True
+        ):
+            await self.migrate_docs_in_collection(
+                coll_name=PCS_PERSISTED_EVENTS,
+                change_function=convert_persistent_event_v6,
+                validation_model=PersistentKafkaEvent,
+                id_field="compaction_key",
+            )
+
+    async def unapply(self):
+        """Reverse the migration"""
+
+        async def revert_persistent_event(doc: Document) -> Document:
+            """Convert the fields back into strings"""
+            doc.pop("event_id")
+            doc["correlation_id"] = str(doc["correlation_id"])
+            doc["created"] = doc["created"].isoformat()
+            return doc
+
+        async with self.auto_finalize(
+            coll_names=PCS_PERSISTED_EVENTS, copy_indexes=True
+        ):
+            # Don't provide validation models here
+            await self.migrate_docs_in_collection(
+                coll_name=PCS_PERSISTED_EVENTS,
+                change_function=revert_persistent_event,
+            )

--- a/services/pcs/src/pcs/migrations/entry.py
+++ b/services/pcs/src/pcs/migrations/entry.py
@@ -1,0 +1,50 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing controller function for DB migrations"""
+
+from hexkit.providers.mongodb.migrations import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+)
+
+from pcs.migrations.definitions import V2Migration
+
+MIGRATION_MAP = {2: V2Migration}
+
+
+async def run_db_migrations(
+    *,
+    config: MigrationConfig,
+    target_version: int,
+    migration_map: MigrationMap | None = None,
+):
+    """Run all migrations.
+
+    Args
+    - `config`: Config containing mongo_dsn string and DB versioning collection name
+    - `target_version`: Which version the db needs to be at for this version of the service
+    - `migration_map`: Mapping of version to migration definition. Defaults to `MIGRATION_MAP`.
+
+    `migration_map` can be specified for testing, but may be left unspecified for production.
+    """
+    migration_map = migration_map or MIGRATION_MAP
+
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/services/pcs/tests_pcs/fixtures/test_config.yaml
+++ b/services/pcs/tests_pcs/fixtures/test_config.yaml
@@ -21,3 +21,5 @@ token_hashes: [abcdef, ghijkl]
 mongo_dsn: "mongodb://mongodb:27017"
 db_name: "dev"
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 2
+db_version_collection: fisDbVersions

--- a/services/pcs/tests_pcs/test_migrations.py
+++ b/services/pcs/tests_pcs/test_migrations.py
@@ -28,8 +28,8 @@ from tests_pcs.fixtures.config import get_config
 pytestmark = pytest.mark.asyncio()
 
 
-async def test_v3_migration(mongodb: MongoDbFixture):
-    """Test the v3 migration, which should update the persistent event collection
+async def test_v2_migration(mongodb: MongoDbFixture):
+    """Test the v2 migration, which should update the persistent event collection
     so the fields use actual UUID and datetime field types.
     """
     config = get_config(sources=[mongodb.config])

--- a/services/pcs/tests_pcs/test_migrations.py
+++ b/services/pcs/tests_pcs/test_migrations.py
@@ -1,0 +1,95 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test for migration logic."""
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import pytest
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+
+from pcs.migrations import run_db_migrations
+from tests_pcs.fixtures.config import get_config
+
+pytestmark = pytest.mark.asyncio()
+
+
+async def test_v3_migration(mongodb: MongoDbFixture):
+    """Test the v3 migration, which should update the persistent event collection
+    so the fields use actual UUID and datetime field types.
+    """
+    config = get_config(sources=[mongodb.config])
+    db = mongodb.client[config.db_name]
+    collection = db["pcsPersistedEvents"]
+
+    # affected fields - share value for fields of same type to simplify test
+    date = datetime(2025, 4, 9, 15, 10, 2, 284123, tzinfo=UTC)
+    migrated_date = date.replace(microsecond=284000)
+    reverted_date = migrated_date.isoformat()
+
+    old_uuid = "794fa7ab-fa80-493b-a08d-a6be41a07cde"
+    migrated_uuid = UUID(old_uuid)
+
+    # Prepare the old, migrated, and reverted data ahead of time
+    old_events: list[dict[str, Any]] = []
+    expected_migrated_events: list[dict[str, Any]] = []
+    expected_reverted_events: list[dict[str, Any]] = []
+
+    for i in range(1, 3):
+        old_event = {
+            "_id": f"test-topic:key{i}",
+            "topic": "test-topic",
+            "payload": {"file_id": "the-best-file-id"},
+            "key": f"key{i}",
+            "type_": "some-type",
+            "headers": {},
+            "correlation_id": old_uuid,
+            "created": date.isoformat(),
+            "published": True,
+        }
+
+        migrated_event = old_event.copy()
+        migrated_event.update(
+            {"correlation_id": migrated_uuid, "created": migrated_date}
+        )
+        reverted_event = old_event.copy()
+        reverted_event.update({"created": reverted_date})
+
+        old_events.append(old_event)
+        expected_migrated_events.append(migrated_event)
+        expected_reverted_events.append(reverted_event)
+
+    # Clear DB and insert test data
+    collection.delete_many({})
+    collection.insert_many(old_events)
+
+    # Run the migration
+    await run_db_migrations(config=config, target_version=2)
+
+    # Compare migrated data against expected migrated data
+    migrated_events = sorted(collection.find({}).to_list(), key=lambda d: d["_id"])
+
+    # Verify event_id is there and that it is a UUID, removing it in the process
+    assert all(isinstance(doc.pop("event_id"), UUID) for doc in migrated_events)
+    assert migrated_events == expected_migrated_events  # without event_id, should match
+
+    # Run reverse migration
+    await run_db_migrations(config=config, target_version=1)
+
+    # Compare reversal with expected data
+    reverted_events = sorted(collection.find({}).to_list(), key=lambda d: d["_id"])
+    assert reverted_events == expected_reverted_events


### PR DESCRIPTION
Migrate the PCS's persistent event store for hexkit v6. The persistent events consist only of "FileDeletionRequested" events, so the payload field doesn't need to be checked. Thus, the migration is straightforward.

Bumps the PCS to version `7.0.0`.
