### PR TITLE
IFRS - hexkit v6 (GSI-1785)

### DIFF
--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:5.1.1
+docker pull ghga/internal-file-registry-service:6.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:5.1.1 .
+docker build -t ghga/internal-file-registry-service:6.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:5.1.1 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:6.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -71,7 +71,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/otel_trace_sampling_rate"></a>**`otel_trace_sampling_rate`** *(number)*: Determines which proportion of spans should be sampled. A value of 1.0 means all and is equivalent to the previous behaviour. Setting this to 0 will result in no spans being sampled, but this does not automatically set `enable_opentelemetry` to False. Minimum: `0`. Maximum: `1`. Default: `1.0`.
 
-- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: `["grpc", "http/protobuf"]`. Default: `"http/protobuf"`.
+- <a id="properties/otel_exporter_protocol"></a>**`otel_exporter_protocol`** *(string)*: Specifies which protocol should be used by exporters. Must be one of: "grpc" or "http/protobuf". Default: `"http/protobuf"`.
 
 - <a id="properties/otel_exporter_endpoint"></a>**`otel_exporter_endpoint`** *(string, format: uri, required)*: Base endpoint URL for the collector that receives content from the exporter. Length must be at least 1.
 
@@ -83,7 +83,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
+- <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
 
 - <a id="properties/service_name"></a>**`service_name`** *(string)*: Default: `"ifrs"`.
 
@@ -263,7 +263,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: `["PLAINTEXT", "SSL"]`. Default: `"PLAINTEXT"`.
+- <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
 
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
 
@@ -273,7 +273,7 @@ The service requires the following configuration parameters:
 
 - <a id="properties/kafka_ssl_password"></a>**`kafka_ssl_password`** *(string, format: password, write-only)*: Optional password to be used for the client private key. Default: `""`.
 
-- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header. Default: `true`.
+- <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header. Default: `true`.
 
 
   Examples:
@@ -307,7 +307,7 @@ The service requires the following configuration parameters:
 
   - **Any of**
 
-    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: `["gzip", "snappy", "lz4", "zstd"]`.
+    - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
 
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 
@@ -470,6 +470,67 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
+- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
+
+    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  null
+  ```
+
+
+  ```json
+  300
+  ```
+
+
+  ```json
+  600
+  ```
+
+
+  ```json
+  3600
+  ```
+
+
 ## Definitions
 
 
@@ -512,7 +573,7 @@ to talk to an S3 service in the backend.<br>  Args:
     ```
 
 
-  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required, write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
+  - <a id="%24defs/S3Config/properties/s3_secret_access_key"></a>**`s3_secret_access_key`** *(string, format: password, required and write-only)*: Part of credentials for login into the S3 service. See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html.
 
 
     Examples:
@@ -558,7 +619,7 @@ to talk to an S3 service in the backend.<br>  Args:
 
   - <a id="%24defs/S3ObjectStorageNodeConfig/properties/bucket"></a>**`bucket`** *(string, required)*
 
-  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`**: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
+  - <a id="%24defs/S3ObjectStorageNodeConfig/properties/credentials"></a>**`credentials`** *(required)*: Refer to *[#/$defs/S3Config](#%24defs/S3Config)*.
 
 
 ### Usage:

--- a/services/ifrs/config_schema.json
+++ b/services/ifrs/config_schema.json
@@ -336,7 +336,7 @@
     },
     "generate_correlation_id": {
       "default": true,
-      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, the a newly correlation ID will be generated and used in the event header.",
+      "description": "A flag, which, if False, will result in an error when trying to publish an event without a valid correlation ID set for the context. If True, a new correlation ID will be generated and used in the event header.",
       "examples": [
         true,
         false
@@ -464,6 +464,43 @@
         null
       ],
       "title": "Mongo Timeout"
+    },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
+    "migration_max_wait_sec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
+      "examples": [
+        null,
+        300,
+        600,
+        3600
+      ],
+      "title": "Migration Max Wait Sec"
     }
   },
   "required": [
@@ -484,7 +521,9 @@
     "files_to_stage_type",
     "kafka_servers",
     "mongo_dsn",
-    "db_name"
+    "db_name",
+    "db_version_collection",
+    "migration_wait_sec"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/ifrs/dev_config.yaml
+++ b/services/ifrs/dev_config.yaml
@@ -23,3 +23,5 @@ file_staged_type: file_staged_for_download
 file_deleted_topic: file-deletions
 file_deleted_type: file_deleted
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 10
+db_version_collection: ifrsDbVersions

--- a/services/ifrs/example_config.yaml
+++ b/services/ifrs/example_config.yaml
@@ -1,4 +1,5 @@
 db_name: dev
+db_version_collection: ifrsDbVersions
 enable_opentelemetry: false
 file_deleted_topic: file-deletions
 file_deleted_type: file_deleted
@@ -29,6 +30,8 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_max_wait_sec: null
+migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 object_storages:

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "5.1.1"
+version = "6.0.0"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
+++ b/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
@@ -27,6 +27,7 @@ from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import JsonObject
 from hexkit.opentelemetry import start_span
 from hexkit.protocols.eventsub import EventSubscriberProtocol
+from pydantic import UUID4
 
 from ifrs.core.models import FileMetadataBase
 from ifrs.ports.inbound.file_registry import FileRegistryPort
@@ -109,7 +110,7 @@ class EventSubTranslator(EventSubscriberProtocol):
         )
 
     async def _consume_validated(
-        self, *, payload: JsonObject, type_: str, topic: str, key: str
+        self, *, payload: JsonObject, type_: str, topic: str, key: str, event_id: UUID4
     ):
         """Process an inbound event"""
         if (

--- a/services/ifrs/src/ifrs/config.py
+++ b/services/ifrs/src/ifrs/config.py
@@ -20,7 +20,7 @@ from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb import MongoDbConfig
+from hexkit.providers.mongodb.migrations import MigrationConfig
 
 from ifrs.adapters.inbound.event_sub import EventSubTranslatorConfig
 from ifrs.adapters.outbound.event_pub import EventPubTranslatorConfig
@@ -30,7 +30,7 @@ SERVICE_NAME = "ifrs"
 
 @config_from_yaml(prefix=SERVICE_NAME)
 class Config(
-    MongoDbConfig,
+    MigrationConfig,
     KafkaConfig,
     EventSubTranslatorConfig,
     EventPubTranslatorConfig,

--- a/services/ifrs/src/ifrs/core/models.py
+++ b/services/ifrs/src/ifrs/core/models.py
@@ -15,7 +15,8 @@
 
 """Defines dataclasses for holding business-logic data"""
 
-from pydantic import BaseModel, Field
+from ghga_service_commons.utils.utc_dates import UTCDatetime
+from pydantic import UUID4, BaseModel, Field
 
 
 class FileMetadataBase(BaseModel):
@@ -24,7 +25,7 @@ class FileMetadataBase(BaseModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    upload_date: str = Field(
+    upload_date: UTCDatetime = Field(
         ...,
         description="The date and time when this file was ingested into the system.",
     )
@@ -82,7 +83,7 @@ class FileMetadataBase(BaseModel):
 class FileMetadata(FileMetadataBase):
     """The file metadata plus a object storage ID generated upon registration"""
 
-    object_id: str = Field(
+    object_id: UUID4 = Field(
         ..., description="A UUID to identify the file in object storage"
     )
     object_size: int = Field(

--- a/services/ifrs/src/ifrs/main.py
+++ b/services/ifrs/src/ifrs/main.py
@@ -20,6 +20,9 @@ from hexkit.opentelemetry import configure_opentelemetry
 
 from ifrs.config import Config
 from ifrs.inject import get_persistent_publisher, prepare_event_subscriber
+from ifrs.migrations import run_db_migrations
+
+DB_VERSION = 2
 
 
 async def consume_events(run_forever: bool = True):
@@ -27,6 +30,8 @@ async def consume_events(run_forever: bool = True):
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
@@ -37,6 +42,8 @@ async def publish_events(*, all: bool = False):
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with get_persistent_publisher(config=config) as persistent_publisher:
         if all:

--- a/services/ifrs/src/ifrs/migrations/__init__.py
+++ b/services/ifrs/src/ifrs/migrations/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""DB Migration logic"""
+
+from .definitions import V2Migration
+from .entry import run_db_migrations
+
+__all__ = ["V2Migration", "run_db_migrations"]

--- a/services/ifrs/src/ifrs/migrations/definitions.py
+++ b/services/ifrs/src/ifrs/migrations/definitions.py
@@ -1,0 +1,131 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic for IFRS"""
+
+from hexkit.providers.mongodb.migrations import (
+    Document,
+    MigrationDefinition,
+    Reversible,
+)
+from hexkit.providers.mongodb.migrations.helpers import (
+    convert_persistent_event_v6,
+    convert_uuids_and_datetimes_v6,
+)
+from hexkit.providers.mongokafka.provider.persistent_pub import PersistentKafkaEvent
+
+from ifrs.core.models import FileMetadata
+
+# Collection names defined as constants
+IFRS_PERSISTED_EVENTS = "ifrsPersistedEvents"
+FILE_METADATA = "file_metadata"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Migrate select fields in the IFRS's data base for hexkit v6.
+
+    Affected data:
+    - `file_metadata` collection:
+      - Fields affected:
+        - `object_id`: *str* -> *UUID4*
+        - `upload_date`: *str* -> *datetime*
+
+    - `ifrsPersistedEvents` collection:
+      - Fields affected:
+        - `created`: *str* -> *datetime*
+        - `correlation_id`: *str* -> *UUID4*
+        - `event_id`: new, *UUID4*
+        - `payload.object_id`: *str* -> *UUID4*
+        - `payload.upload_date`: *str* -> *datetime*
+
+    Event payload changes are required for the FileInternallyRegistered topic,
+    affecting `object_id` and `upload_date`.
+
+    This can be reversed by converting the UUIDs and datetimes back to strings.
+    """
+
+    version = 2
+
+    async def apply(self):
+        """Perform the migration"""
+        convert_file_metadata = convert_uuids_and_datetimes_v6(
+            uuid_fields=["object_id"], date_fields=["upload_date"]
+        )
+
+        async def convert_event(doc: Document) -> Document:
+            """Convert a persistent event and its payload."""
+            doc = await convert_persistent_event_v6(doc)
+
+            # The only payloads to migrate are ones that have object id
+            if "object_id" in doc["payload"]:
+                doc["payload"] = await convert_file_metadata(doc["payload"])
+
+            return doc
+
+        async with self.auto_finalize(
+            coll_names=[FILE_METADATA, IFRS_PERSISTED_EVENTS], copy_indexes=True
+        ):
+            # migrate the file metadata collection
+            await self.migrate_docs_in_collection(
+                coll_name=FILE_METADATA,
+                change_function=convert_file_metadata,
+                validation_model=FileMetadata,
+                id_field="file_id",
+            )
+            # migrate persistent events and their payload fields
+            await self.migrate_docs_in_collection(
+                coll_name=IFRS_PERSISTED_EVENTS,
+                change_function=convert_event,
+                validation_model=PersistentKafkaEvent,
+                id_field="compaction_key",
+            )
+
+    async def unapply(self):
+        """Reverse the migration"""
+
+        async def revert_file_metadata(doc: Document) -> Document:
+            """Convert object_id and upload_date to strings again.
+
+            Used on its own to migrate file_metadata, and as a helper in
+            migrating persistent events.
+            """
+            doc["object_id"] = str(doc["object_id"])
+            doc["upload_date"] = doc["upload_date"].isoformat()
+            return doc
+
+        async def revert_persistent_event(doc: Document) -> Document:
+            """Convert the fields back into strings"""
+            doc.pop("event_id")
+            doc["correlation_id"] = str(doc["correlation_id"])
+            doc["created"] = doc["created"].isoformat()
+
+            if "object_id" in doc["payload"]:
+                doc["payload"] = await revert_file_metadata(doc["payload"])
+            return doc
+
+        async with self.auto_finalize(
+            coll_names=[FILE_METADATA, IFRS_PERSISTED_EVENTS], copy_indexes=True
+        ):
+            # Revert file metadata collection
+            await self.migrate_docs_in_collection(
+                coll_name=FILE_METADATA,
+                change_function=revert_file_metadata,
+            )
+
+            # Revert persistent events
+            await self.migrate_docs_in_collection(
+                coll_name=IFRS_PERSISTED_EVENTS,
+                change_function=revert_persistent_event,
+            )

--- a/services/ifrs/src/ifrs/migrations/entry.py
+++ b/services/ifrs/src/ifrs/migrations/entry.py
@@ -1,0 +1,50 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing controller function for DB migrations"""
+
+from hexkit.providers.mongodb.migrations import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+)
+
+from ifrs.migrations.definitions import V2Migration
+
+MIGRATION_MAP = {2: V2Migration}
+
+
+async def run_db_migrations(
+    *,
+    config: MigrationConfig,
+    target_version: int,
+    migration_map: MigrationMap | None = None,
+):
+    """Run all migrations.
+
+    Args
+    - `config`: Config containing mongo_dsn string and DB versioning collection name
+    - `target_version`: Which version the db needs to be at for this version of the service
+    - `migration_map`: Mapping of version to migration definition. Defaults to `MIGRATION_MAP`.
+
+    `migration_map` can be specified for testing, but may be left unspecified for production.
+    """
+    migration_map = migration_map or MIGRATION_MAP
+
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/services/ifrs/src/ifrs/ports/inbound/file_registry.py
+++ b/services/ifrs/src/ifrs/ports/inbound/file_registry.py
@@ -17,6 +17,8 @@
 
 from abc import ABC, abstractmethod
 
+from pydantic import UUID4
+
 from ifrs.core import models
 
 
@@ -106,7 +108,7 @@ class FileRegistryPort(ABC):
         self,
         *,
         file_without_object_id: models.FileMetadataBase,
-        staging_object_id: str,
+        staging_object_id: UUID4,
         staging_bucket_id: str,
     ) -> None:
         """Registers a file and moves its content from the staging into the permanent
@@ -116,7 +118,7 @@ class FileRegistryPort(ABC):
         Args:
             file_without_object_id: metadata on the file to register.
             staging_object_id:
-                The S3 object ID for the staging bucket.
+                The UUID4 S3 object ID for the staging bucket.
             staging_bucket_id:
                 The S3 bucket ID for staging.
 
@@ -134,7 +136,7 @@ class FileRegistryPort(ABC):
         *,
         file_id: str,
         decrypted_sha256: str,
-        outbox_object_id: str,
+        outbox_object_id: UUID4,
         outbox_bucket_id: str,
     ) -> None:
         """Stage a registered file to the outbox.
@@ -146,7 +148,7 @@ class FileRegistryPort(ABC):
                 The checksum of the decrypted content. This is used to make sure that
                 this service and the outside client are talking about the same file.
             outbox_object_id:
-                The S3 object ID for the outbox bucket.
+                The UUID4 S3 object ID for the outbox bucket.
             outbox_bucket_id:
                 The S3 bucket ID for the outbox.
 

--- a/services/ifrs/src/ifrs/ports/outbound/event_pub.py
+++ b/services/ifrs/src/ifrs/ports/outbound/event_pub.py
@@ -17,6 +17,8 @@
 
 from abc import ABC, abstractmethod
 
+from pydantic import UUID4
+
 from ifrs.core import models
 
 
@@ -36,7 +38,7 @@ class EventPublisherPort(ABC):
         *,
         file_id: str,
         decrypted_sha256: str,
-        target_object_id: str,
+        target_object_id: UUID4,
         target_bucket_id: str,
         storage_alias: str,
     ) -> None:

--- a/services/ifrs/tests_ifrs/fixtures/example_data.py
+++ b/services/ifrs/tests_ifrs/fixtures/example_data.py
@@ -15,16 +15,18 @@
 
 """Example data used for testing."""
 
-from ghga_service_commons.utils.utc_dates import now_as_utc
+from uuid import uuid4
+
+from hexkit.utils import now_utc_ms_prec
 
 from ifrs.core import models
 
 EXAMPLE_METADATA_BASE = models.FileMetadataBase(
     file_id="examplefile001",
-    upload_date=now_as_utc().isoformat(),
+    upload_date=now_utc_ms_prec(),
     decryption_secret_id="some-secret-id",
     decrypted_size=64 * 1024**2,
-    encrypted_part_size=16 * 1024**2,
+    encrypted_part_size=64 * 1024**2,
     content_offset=16 * 1024**2,
     # The checksums are only examples, they don't correspond to a particular file:
     decrypted_sha256="0677de3685577a06862f226bb1bfa8f889e96e59439d915543929fb4f011d096",
@@ -43,6 +45,6 @@ EXAMPLE_METADATA_BASE = models.FileMetadataBase(
 
 EXAMPLE_METADATA = models.FileMetadata(
     **EXAMPLE_METADATA_BASE.model_dump(),
-    object_id="objectid001",
+    object_id=uuid4(),
     object_size=64 * 1024**2 + 1234567,  #  dummy value
 )

--- a/services/ifrs/tests_ifrs/fixtures/example_data.py
+++ b/services/ifrs/tests_ifrs/fixtures/example_data.py
@@ -26,7 +26,7 @@ EXAMPLE_METADATA_BASE = models.FileMetadataBase(
     upload_date=now_utc_ms_prec(),
     decryption_secret_id="some-secret-id",
     decrypted_size=64 * 1024**2,
-    encrypted_part_size=64 * 1024**2,
+    encrypted_part_size=16 * 1024**2,
     content_offset=16 * 1024**2,
     # The checksums are only examples, they don't correspond to a particular file:
     decrypted_sha256="0677de3685577a06862f226bb1bfa8f889e96e59439d915543929fb4f011d096",

--- a/services/ifrs/tests_ifrs/fixtures/test_config.yaml
+++ b/services/ifrs/tests_ifrs/fixtures/test_config.yaml
@@ -24,3 +24,5 @@ file_staged_type: file_staged_for_download
 file_deleted_topic: file-deletions
 file_deleted_type: file_deleted
 otel_exporter_endpoint: http://localhost:4318
+migration_wait_sec: 2
+db_version_collection: ifrsDbVersions

--- a/services/ifrs/tests_ifrs/test_ifrs_typical_journey.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_typical_journey.py
@@ -44,7 +44,7 @@ async def test_happy_journey(
     file_object = tmp_file.model_copy(
         update={
             "bucket_id": joint_fixture.staging_bucket,
-            "object_id": EXAMPLE_METADATA.object_id,
+            "object_id": str(EXAMPLE_METADATA.object_id),
         }
     )
     await storage.populate_file_objects(file_objects=[file_object])
@@ -78,7 +78,7 @@ async def test_happy_journey(
     # check that the file content is now in both the staging and the permanent storage:
     assert await storage.storage.does_object_exist(
         bucket_id=joint_fixture.staging_bucket,
-        object_id=EXAMPLE_METADATA.object_id,
+        object_id=str(EXAMPLE_METADATA.object_id),
     )
     assert await storage.storage.does_object_exist(
         bucket_id=bucket_id,
@@ -112,20 +112,20 @@ async def test_happy_journey(
     # check that the file content is now in all three storage entities:
     assert await storage.storage.does_object_exist(
         bucket_id=joint_fixture.staging_bucket,
-        object_id=EXAMPLE_METADATA.object_id,
+        object_id=str(EXAMPLE_METADATA.object_id),
     )
     assert await storage.storage.does_object_exist(
         bucket_id=bucket_id,
         object_id=object_id,
     )
     assert await storage.storage.does_object_exist(
-        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=str(EXAMPLE_METADATA.object_id)
     )
 
     # check that the file content in the outbox is identical to the content in the
     # staging:
     download_url = await storage.storage.get_object_download_url(
-        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=str(EXAMPLE_METADATA.object_id)
     )
     response = requests.get(download_url, timeout=60)
     response.raise_for_status()

--- a/services/ifrs/tests_ifrs/test_migrations.py
+++ b/services/ifrs/tests_ifrs/test_migrations.py
@@ -1,0 +1,182 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for migration logic"""
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+
+from ifrs.migrations import run_db_migrations
+from tests_ifrs.fixtures.config import get_config
+
+pytestmark = pytest.mark.asyncio()
+
+
+async def test_v2_migration(mongodb: MongoDbFixture):
+    """Test the v2 migration, which should update the persistent event collection
+    so the fields use actual UUID and datetime field types.
+    """
+    config = get_config(sources=[mongodb.config])
+    db = mongodb.client[config.db_name]
+    events_collection = db["ifrsPersistedEvents"]
+    metadata_collection = db["file_metadata"]
+
+    # affected fields - share value for fields of same type to simplify test
+    date = datetime(2025, 4, 9, 15, 10, 2, 284123, tzinfo=UTC)
+    migrated_date = date.replace(microsecond=284000)
+    reverted_date = migrated_date.isoformat()
+    old_uuid = "794fa7ab-fa80-493b-a08d-a6be41a07cde"
+    migrated_uuid = UUID(old_uuid)
+
+    # Prepare the old, migrated, and reverted data ahead of time
+    # Start with the payloads for the persisted events: 1 affected and 1 unaffected
+    unaffected_payload = {"file_id": "some-other-file"}
+    affected_payload = {
+        "s3_endpoint_alias": "test-alias",
+        "file_id": "examplefile001",
+        "object_id": old_uuid,
+        "bucket_id": "bucket1",
+        "decrypted_sha256": "",
+        "decrypted_size": 1000,
+        "decryption_secret_id": str(uuid4()),
+        "content_offset": 128,
+        "encrypted_size": 1128,
+        "encrypted_part_size": 16,
+        "encrypted_parts_md5": "abc123",
+        "encrypted_parts_sha256": "abc123456",
+        "upload_date": date.isoformat(),
+    }
+    migrated_affected_payload = affected_payload.copy()
+    migrated_affected_payload["object_id"] = migrated_uuid
+    migrated_affected_payload["upload_date"] = migrated_date
+
+    reverted_affected_payload = affected_payload.copy()
+    reverted_affected_payload["upload_date"] = reverted_date
+
+    payloads: list[dict[str, Any]] = [affected_payload, unaffected_payload]
+    migrated_payloads: list[dict[str, Any]] = [
+        migrated_affected_payload,
+        unaffected_payload,
+    ]
+    reverted_payloads: list[dict[str, Any]] = [
+        reverted_affected_payload,
+        unaffected_payload,
+    ]
+
+    old_events: list[dict[str, Any]] = []
+    expected_migrated_events: list[dict[str, Any]] = []
+    expected_reverted_events: list[dict[str, Any]] = []
+
+    for i in range(2):
+        old_event = {
+            "_id": f"test-topic:key{i}",
+            "topic": "test-topic",
+            "payload": payloads[i],
+            "key": f"key{i}",
+            "type_": "some-type",
+            "headers": {},
+            "correlation_id": old_uuid,
+            "created": date.isoformat(),
+            "published": True,
+        }
+
+        migrated_event = old_event.copy()
+        migrated_event.update(
+            {
+                "correlation_id": migrated_uuid,
+                "created": migrated_date,
+                "payload": migrated_payloads[i],
+            }
+        )
+        reverted_event = old_event.copy()
+        reverted_event.update(
+            {"created": reverted_date, "payload": reverted_payloads[i]}
+        )
+
+        old_events.append(old_event)
+        expected_migrated_events.append(migrated_event)
+        expected_reverted_events.append(reverted_event)
+
+    # Now set up the same trio of data for the other collection (file_metadata)
+    old_metadata: list[dict[str, Any]] = []
+    expected_migrated_metadata: list[dict[str, Any]] = []
+    expected_reverted_metadata: list[dict[str, Any]] = []
+    for i in range(3):
+        old_file_metadata = {
+            "_id": f"examplefile00{i}",
+            "upload_date": date.isoformat(),
+            "decryption_secret_id": "some-secret-id",
+            "decrypted_size": 64 * 1024**2,
+            "encrypted_part_size": 64 * 1024**2,
+            "content_offset": 64 * 1024**2,
+            "decrypted_sha256": "abc12345",
+            "encrypted_parts_md5": ["1", "z", "4"],
+            "encrypted_parts_sha256": ["a", "b", "c"],
+            "storage_alias": "my-cool-storage",
+            "object_id": old_uuid,
+            "object_size": 64 * 1024**2 + 1234567,
+        }
+        migrated_file_metadata = old_file_metadata.copy()
+        migrated_file_metadata.update(
+            {"upload_date": migrated_date, "object_id": migrated_uuid}
+        )
+        reverted_file_metadata = old_file_metadata.copy()
+        reverted_file_metadata.update({"upload_date": reverted_date})
+
+        old_metadata.append(old_file_metadata)
+        expected_migrated_metadata.append(migrated_file_metadata)
+        expected_reverted_metadata.append(reverted_file_metadata)
+
+    # Clear DB and insert test data for both collections
+    events_collection.delete_many({})
+    metadata_collection.delete_many({})
+    events_collection.insert_many(old_events)
+    metadata_collection.insert_many(old_metadata)
+
+    # Run the migration targeting version 2
+    await run_db_migrations(config=config, target_version=2)
+
+    # Compare migrated EVENT docs against expected docs
+    migrated_events = sorted(
+        events_collection.find({}).to_list(), key=lambda d: d["_id"]
+    )
+
+    # Verify event_id is there and that it is a UUID, removing it in the process
+    assert all(isinstance(doc.pop("event_id"), UUID) for doc in migrated_events)
+    assert migrated_events == expected_migrated_events  # without event_id, should match
+
+    # Compare migrated FILE METADATA docs against expected docs
+    migrated_metadata = sorted(
+        metadata_collection.find({}).to_list(), key=lambda d: d["_id"]
+    )
+    assert migrated_metadata == expected_migrated_metadata
+
+    # Run reverse migration targeting version 1
+    await run_db_migrations(config=config, target_version=1)
+
+    # Compare reversal with expected data
+    reverted_events = sorted(
+        events_collection.find({}).to_list(), key=lambda d: d["_id"]
+    )
+    assert reverted_events == expected_reverted_events
+
+    reverted_metadata = sorted(
+        metadata_collection.find({}).to_list(), key=lambda d: d["_id"]
+    )
+    assert reverted_metadata == expected_reverted_metadata


### PR DESCRIPTION
Moves IFRS to version `6.0.0`.

Adds IFRS v2 migration to update the `file_metadata` and `ifrsPersistedEvents` collections.

Updates core module error logging to include traceback.

Uses `MongoDbDaoFactory` context manager.