### PR TITLE
FIS: Fix v3 migration for funky correlation IDs

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "6.0.0"
+version = "6.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "6.0.0"
+version = "6.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.15",

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:9.0.0
+docker pull ghga/file-ingest-service:9.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:9.0.0 .
+docker build -t ghga/file-ingest-service:9.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:9.0.0 --help
+docker run -p 8080:8080 ghga/file-ingest-service:9.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -109,7 +109,7 @@ info:
   description: A service to ingest s3 file upload metadata produced by the data-steward-kit
     upload command
   title: File Ingest Service
-  version: 9.0.0
+  version: 9.0.1
 openapi: 3.1.0
 paths:
   /federated/ingest_metadata:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "9.0.0"
+version = "9.0.1"
 description = "File Ingest Service - A lightweight service to propagate file upload metadata to the GHGA file backend services"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
There were some non-v4 UUID string values for the correlation ID in the FIS persisted events collection. We think these might have come from the api gateway in before we switched. The values are all older and cutoff after a certain date. Therefore, the solution for now is to simply replace these values in the migration when encountered, log the switch, and keep an eye out for the issue in the future. If it comes up again, we will perform a more thorough investigation.