### PR TITLE
FIS: Limit v3 mig batch size

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "6.0.1"
+version = "6.0.2"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "6.0.1"
+version = "6.0.2"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.15",

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:9.0.1
+docker pull ghga/file-ingest-service:9.0.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:9.0.1 .
+docker build -t ghga/file-ingest-service:9.0.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:9.0.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:9.0.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -109,7 +109,7 @@ info:
   description: A service to ingest s3 file upload metadata produced by the data-steward-kit
     upload command
   title: File Ingest Service
-  version: 9.0.1
+  version: 9.0.2
 openapi: 3.1.0
 paths:
   /federated/ingest_metadata:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "9.0.1"
+version = "9.0.2"
 description = "File Ingest Service - A lightweight service to propagate file upload metadata to the GHGA file backend services"
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/migrations/definitions.py
+++ b/services/fis/src/fis/migrations/definitions.py
@@ -136,6 +136,7 @@ class V3Migration(MigrationDefinition, Reversible):
                 change_function=convert_persisted_event,
                 validation_model=PersistentKafkaEvent,
                 id_field="compaction_key",
+                batch_size=25,
             )
 
     async def unapply(self):
@@ -160,4 +161,5 @@ class V3Migration(MigrationDefinition, Reversible):
             await self.migrate_docs_in_collection(
                 coll_name=FIS_PERSISTED_EVENTS,
                 change_function=revert_persistent_event,
+                batch_size=25,
             )


### PR DESCRIPTION
Reduces batch limit from 1000 to 25 for the v3 migration to see how this affects performance.
Bumps FIS to version `9.0.2` and the monorepo to `6.0.2`