### PR TITLE
Improve DCS storage cleaner ergonomics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,11 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:
-    - name: Install coveralls
-      run: pip3 install --upgrade coveralls
     - name: Finished
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        carryforward: "dcs,ekss,fis,ifrs,pcs,ucs"
         fail-on-error: false
-        parallel: true
+        parallel-finished: true

--- a/monorepo.code-workspace
+++ b/monorepo.code-workspace
@@ -9,10 +9,6 @@
 			"path": "services/ifrs"
 		},
 		{
-			"name":"Interrogation Room",
-			"path": "services/irs"
-		},
-		{
 			"name": "Purge Controller",
 			"path": "services/pcs"
 		},

--- a/services/dcs/.readme_generation/description.md
+++ b/services/dcs/.readme_generation/description.md
@@ -16,10 +16,10 @@ described [here](./dcs/core/auth_policies.py).
 All files that can be requested are registered in a MongoDB database owned and
 controlled by this service. Registration of new events happens through a Kafka event.
 
-It serves pre-signed URLs to S3 objects located in a single so-called outbox bucket.
+It serves pre-signed URLs to S3 objects located in a single so-called download bucket.
 If the file is not already in the bucket when the user calls the object endpoint,
-an event is published to request staging the file to the outbox. The staging has to
-be carried out by a different service.
+an event is published to request staging the file to the download bucket. The staging 
+has to be carried out by a different service.
 
 For more details on the events consumed and produced by this service, see the
 configuration.

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -557,6 +557,21 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/download_bucket_cache_timeout"></a>**`download_bucket_cache_timeout`** *(integer)*: Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
+
+
+  Examples:
+
+  ```json
+  7
+  ```
+
+
+  ```json
+  30
+  ```
+
+
 - <a id="properties/drs_server_uri"></a>**`drs_server_uri`** *(string, required)*: The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.
 
 
@@ -624,21 +639,6 @@ The service requires the following configuration parameters:
 
   ```json
   60
-  ```
-
-
-- <a id="properties/download_bucket_cache_timeout"></a>**`download_bucket_cache_timeout`** *(integer)*: Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
-
-
-  Examples:
-
-  ```json
-  7
-  ```
-
-
-  ```json
-  30
   ```
 
 

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -22,10 +22,10 @@ described [here](./dcs/core/auth_policies.py).
 All files that can be requested are registered in a MongoDB database owned and
 controlled by this service. Registration of new events happens through a Kafka event.
 
-It serves pre-signed URLs to S3 objects located in a single so-called outbox bucket.
+It serves pre-signed URLs to S3 objects located in a single so-called download bucket.
 If the file is not already in the bucket when the user calls the object endpoint,
-an event is published to request staging the file to the outbox. The staging has to
-be carried out by a different service.
+an event is published to request staging the file to the download bucket. The staging 
+has to be carried out by a different service.
 
 For more details on the events consumed and produced by this service, see the
 configuration.
@@ -567,7 +567,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/staging_speed"></a>**`staging_speed`** *(integer)*: When trying to access a DRS object that is not yet in the outbox, assume that this many megabytes can be staged per second. Default: `100`.
+- <a id="properties/staging_speed"></a>**`staging_speed`** *(integer)*: When trying to access a DRS object that is not yet in the download bucket, assume that this many megabytes can be staged per second. Default: `100`.
 
 
   Examples:
@@ -582,7 +582,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/retry_after_min"></a>**`retry_after_min`** *(integer)*: When trying to access a DRS object that is not yet in the outbox, wait at least this number of seconds before trying again. Default: `5`.
+- <a id="properties/retry_after_min"></a>**`retry_after_min`** *(integer)*: When trying to access a DRS object that is not yet in the download bucket, wait at least this number of seconds before trying again. Default: `5`.
 
 
   Examples:
@@ -597,7 +597,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/retry_after_max"></a>**`retry_after_max`** *(integer)*: When trying to access a DRS object that is not yet in the outbox, wait at most this number of seconds before trying again. Default: `300`.
+- <a id="properties/retry_after_max"></a>**`retry_after_max`** *(integer)*: When trying to access a DRS object that is not yet in the download bucket, wait at most this number of seconds before trying again. Default: `300`.
 
 
   Examples:
@@ -627,7 +627,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/outbox_cache_timeout"></a>**`outbox_cache_timeout`** *(integer)*: Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
+- <a id="properties/download_bucket_cache_timeout"></a>**`download_bucket_cache_timeout`** *(integer)*: Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request. Default: `7`.
 
 
   Examples:

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -558,7 +558,7 @@
     },
     "staging_speed": {
       "default": 100,
-      "description": "When trying to access a DRS object that is not yet in the outbox, assume that this many megabytes can be staged per second.",
+      "description": "When trying to access a DRS object that is not yet in the download bucket, assume that this many megabytes can be staged per second.",
       "examples": [
         100,
         500
@@ -568,7 +568,7 @@
     },
     "retry_after_min": {
       "default": 5,
-      "description": "When trying to access a DRS object that is not yet in the outbox, wait at least this number of seconds before trying again.",
+      "description": "When trying to access a DRS object that is not yet in the download bucket, wait at least this number of seconds before trying again.",
       "examples": [
         5,
         10
@@ -578,7 +578,7 @@
     },
     "retry_after_max": {
       "default": 300,
-      "description": "When trying to access a DRS object that is not yet in the outbox, wait at most this number of seconds before trying again.",
+      "description": "When trying to access a DRS object that is not yet in the download bucket, wait at most this number of seconds before trying again.",
       "examples": [
         30,
         300
@@ -596,14 +596,14 @@
       "title": "Presigned URL expiration time in seconds",
       "type": "integer"
     },
-    "outbox_cache_timeout": {
+    "download_bucket_cache_timeout": {
       "default": 7,
-      "description": "Time in days since last access after which a file present in the outbox should be unstaged and has to be requested from permanent storage again for the next request.",
+      "description": "Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request.",
       "examples": [
         7,
         30
       ],
-      "title": "Outbox Cache Timeout",
+      "title": "Download Bucket Cache Timeout",
       "type": "integer"
     },
     "auth_key": {

--- a/services/dcs/config_schema.json
+++ b/services/dcs/config_schema.json
@@ -548,6 +548,16 @@
       ],
       "title": "Migration Max Wait Sec"
     },
+    "download_bucket_cache_timeout": {
+      "default": 7,
+      "description": "Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request.",
+      "examples": [
+        7,
+        30
+      ],
+      "title": "Download Bucket Cache Timeout",
+      "type": "integer"
+    },
     "drs_server_uri": {
       "description": "The base of the DRS URI to access DRS objects. Has to start with 'drs://' and end with '/'.",
       "examples": [
@@ -594,16 +604,6 @@
       ],
       "exclusiveMinimum": 0,
       "title": "Presigned URL expiration time in seconds",
-      "type": "integer"
-    },
-    "download_bucket_cache_timeout": {
-      "default": 7,
-      "description": "Time in days since last access after which a file present in the download bucket should be unstaged and has to be requested from permanent storage again for the next request.",
-      "examples": [
-        7,
-        30
-      ],
-      "title": "Download Bucket Cache Timeout",
       "type": "integer"
     },
     "auth_key": {

--- a/services/dcs/example_config.yaml
+++ b/services/dcs/example_config.yaml
@@ -29,6 +29,7 @@ cors_exposed_headers: null
 db_name: dev
 db_version_collection: dcsDbVersions
 docs_url: /docs
+download_bucket_cache_timeout: 7
 download_served_topic: file-downloads
 download_served_type: download_served
 drs_server_uri: drs://localhost:8080/
@@ -78,7 +79,6 @@ object_storages:
       s3_session_token: null
 openapi_url: /openapi.json
 otel_trace_sampling_rate: 1.0
-outbox_cache_timeout: 7
 per_request_jitter: 0.0
 port: 8080
 presigned_url_expires_after: 30

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/http_responses.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/http_responses.py
@@ -28,10 +28,10 @@ class HttpEnvelopeResponse(JSONResponse):
         super().__init__(content=envelope, status_code=status_code)
 
 
-class HttpObjectNotInOutboxResponse(JSONResponse):
-    """Returned, when a file has not been staged to the outbox yet."""
+class HttpObjectNotInDownloadBucketResponse(JSONResponse):
+    """Returned, when a file has not been staged to the download bucket yet."""
 
-    response_id = "objectNotInOutbox"
+    response_id = "objectNotInDownloadBucket"
 
     def __init__(
         self,

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -27,6 +27,7 @@ from dcs.adapters.inbound.fastapi_ import (
 )
 from dcs.constants import TRACER
 from dcs.core.auth_policies import WorkOrderContext
+from dcs.core.errors import StorageAliasNotConfiguredError
 from dcs.core.models import DrsObjectResponseModel
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 
@@ -131,7 +132,7 @@ async def get_drs_object(
             object_id=object_id
         ) from object_not_found_error
 
-    except data_repository.StorageAliasNotConfiguredError as configuration_error:
+    except StorageAliasNotConfiguredError as configuration_error:
         raise http_exceptions.HttpInternalServerError() from configuration_error
 
 

--- a/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
+++ b/services/dcs/src/dcs/adapters/inbound/fastapi_/routes.py
@@ -46,7 +46,7 @@ RESPONSES = {
         ),
         "model": http_exceptions.HttpObjectNotFoundError.get_body_model(),
     },
-    "objectNotInOutbox": {
+    "objectNotInDownloadBucket": {
         "description": (
             "The operation is delayed and will continue asynchronously. "
             + "The client should retry this same request after the delay "
@@ -88,7 +88,7 @@ async def health():
     response_model=DrsObjectResponseModel,
     response_description="The DrsObject was found successfully.",
     responses={
-        status.HTTP_202_ACCEPTED: RESPONSES["objectNotInOutbox"],
+        status.HTTP_202_ACCEPTED: RESPONSES["objectNotInDownloadBucket"],
         status.HTTP_403_FORBIDDEN: RESPONSES["wrongFileAuthorizationError"],
         status.HTTP_404_NOT_FOUND: RESPONSES["noSuchObject"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: RESPONSES["internalServerError"],
@@ -120,7 +120,7 @@ async def get_drs_object(
         )
     except data_repository.RetryAccessLaterError as retry_later_error:
         # tell client to retry after 5 minutes
-        response = http_responses.HttpObjectNotInOutboxResponse(
+        response = http_responses.HttpObjectNotInDownloadBucketResponse(
             retry_after=retry_later_error.retry_after
         )
         response.headers["Cache-Control"] = "no-store"

--- a/services/dcs/src/dcs/cli.py
+++ b/services/dcs/src/dcs/cli.py
@@ -24,7 +24,7 @@ from dcs.main import (
     consume_events,
     migrate_db,
     publish_events,
-    run_download_bucket_cleanup,
+    run_download_bucket_cleaner,
     run_rest_app,
 )
 
@@ -44,10 +44,10 @@ def sync_consume_events(run_forever: bool = True):
 
 
 @cli.command(name="cleanup-download-bucket")
-def sync_run_cleanup(remove_dangling_objects: bool = False):
+def sync_run_cleaner(remove_dangling_objects: bool = False):
     """Run download bucket cleanup"""
     asyncio.run(
-        run_download_bucket_cleanup(remove_dangling_objects=remove_dangling_objects)
+        run_download_bucket_cleaner(remove_dangling_objects=remove_dangling_objects)
     )
 
 

--- a/services/dcs/src/dcs/cli.py
+++ b/services/dcs/src/dcs/cli.py
@@ -24,7 +24,7 @@ from dcs.main import (
     consume_events,
     migrate_db,
     publish_events,
-    run_outbox_cleanup,
+    run_download_bucket_cleanup,
     run_rest_app,
 )
 
@@ -43,10 +43,12 @@ def sync_consume_events(run_forever: bool = True):
     asyncio.run(consume_events(run_forever=run_forever))
 
 
-@cli.command(name="cleanup-outbox")
+@cli.command(name="cleanup-donwload-bucket")
 def sync_run_cleanup(remove_dangling_objects: bool = False):
-    """Run outbox cleanup"""
-    asyncio.run(run_outbox_cleanup(remove_dangling_objects=remove_dangling_objects))
+    """Run download bucket cleanup"""
+    asyncio.run(
+        run_download_bucket_cleanup(remove_dangling_objects=remove_dangling_objects)
+    )
 
 
 @cli.command(name="publish-events")

--- a/services/dcs/src/dcs/cli.py
+++ b/services/dcs/src/dcs/cli.py
@@ -43,7 +43,7 @@ def sync_consume_events(run_forever: bool = True):
     asyncio.run(consume_events(run_forever=run_forever))
 
 
-@cli.command(name="cleanup-donwload-bucket")
+@cli.command(name="cleanup-download-bucket")
 def sync_run_cleanup(remove_dangling_objects: bool = False):
     """Run download bucket cleanup"""
     asyncio.run(

--- a/services/dcs/src/dcs/cli.py
+++ b/services/dcs/src/dcs/cli.py
@@ -44,9 +44,9 @@ def sync_consume_events(run_forever: bool = True):
 
 
 @cli.command(name="cleanup-outbox")
-def sync_run_cleanup():
+def sync_run_cleanup(remove_dangling_objects: bool = False):
     """Run outbox cleanup"""
-    asyncio.run(run_outbox_cleanup())
+    asyncio.run(run_outbox_cleanup(remove_dangling_objects=remove_dangling_objects))
 
 
 @cli.command(name="publish-events")

--- a/services/dcs/src/dcs/config.py
+++ b/services/dcs/src/dcs/config.py
@@ -32,6 +32,7 @@ from dcs.adapters.outbound.event_pub import EventPubTranslatorConfig
 from dcs.adapters.outbound.http.api_calls import HttpClientConfig
 from dcs.adapters.outbound.http.secrets import SecretsClientConfig
 from dcs.constants import SERVICE_NAME
+from dcs.core.bucket_cleanup import BucketCleanupConfig
 from dcs.core.data_repository import DataRepositoryConfig
 
 
@@ -51,6 +52,7 @@ class Config(
     DrsApiConfig,
     WorkOrderTokenConfig,
     DataRepositoryConfig,
+    BucketCleanupConfig,
     MigrationConfig,
     KafkaConfig,
     EventPubTranslatorConfig,

--- a/services/dcs/src/dcs/core/bucket_cleanup.py
+++ b/services/dcs/src/dcs/core/bucket_cleanup.py
@@ -1,0 +1,157 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Download bucket cleanup logic."""
+
+import logging
+import uuid
+from datetime import timedelta
+
+from ghga_service_commons.utils.multinode_storage import (
+    S3ObjectStorages,
+    S3ObjectStoragesConfig,
+)
+from hexkit.protocols.dao import NoHitsFoundError
+from hexkit.utils import now_utc_ms_prec
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+from dcs.core.errors import StorageAliasNotConfiguredError
+from dcs.ports.inbound.bucket_cleanup import BucketCleanerPort
+from dcs.ports.outbound.dao import DrsObjectDaoPort
+
+log = logging.getLogger(__name__)
+
+
+class BucketCleanupConfig(BaseSettings):
+    """Config parameters needed for the DownloadBucketCleaner."""
+
+    download_bucket_cache_timeout: int = Field(
+        default=7,
+        description="Time in days since last access after which a file present in the "
+        + "download bucket should be unstaged and has to be requested from "
+        + "permanent storage again for the next request.",
+        examples=[7, 30],
+    )
+
+
+class DownloadBucketCleaner(BucketCleanerPort):
+    """A service that manages download bucket cleanup."""
+
+    def __init__(
+        self,
+        *,
+        config: BucketCleanupConfig,
+        drs_object_dao: DrsObjectDaoPort,
+        object_storages: S3ObjectStorages,
+    ):
+        """Initialize with essential config params and outbound adapters."""
+        self._config = config
+        self._drs_object_dao = drs_object_dao
+        self._object_storages = object_storages
+
+    async def cleanup_download_buckets(
+        self,
+        *,
+        object_storages_config: S3ObjectStoragesConfig,
+        remove_dangling_objects: bool = False,
+    ):
+        """Run cleanup task for all download buckets configured in the service config."""
+        for storage_alias in object_storages_config.object_storages:
+            await self.cleanup_download_bucket(
+                storage_alias=storage_alias,
+                remove_dangling_objects=remove_dangling_objects,
+            )
+
+    async def cleanup_download_bucket(
+        self, *, storage_alias: str, remove_dangling_objects: bool = False
+    ):
+        """
+        Check if files present in the download bucket have outlived their allocated time
+        and remove all that do.
+        For each file in the download bucket, its 'last_accessed' field is checked and compared
+        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
+        option is met or exceeded, the corresponding file is removed from the download bucket.
+        """
+        # Run on demand through CLI, so crashing should be ok if the alias is not configured
+        log.info(
+            "Starting download bucket cleanup for storage identified by alias %s.",
+            storage_alias,
+        )
+        try:
+            bucket_id, object_storage = self._object_storages.for_alias(storage_alias)
+        except KeyError:
+            storage_alias_not_configured = StorageAliasNotConfiguredError(
+                alias=storage_alias
+            )
+            log.critical(storage_alias_not_configured)
+            log.info(
+                "Skipping download bucket cleanup for storage %s as it is not configured.",
+                storage_alias,
+            )
+            return
+
+        threshold = now_utc_ms_prec() - timedelta(
+            days=self._config.download_bucket_cache_timeout
+        )
+
+        # filter to get all files in download bucket that should be removed
+        object_ids = [
+            uuid.UUID(x)
+            for x in await object_storage.list_all_object_ids(bucket_id=bucket_id)
+        ]
+        log.debug(
+            f"Retrieved list of deletion candidates for storage '{storage_alias}'"
+        )
+
+        for object_id in object_ids:
+            force_removal = False
+            try:
+                drs_object = await self._drs_object_dao.find_one(
+                    mapping={"object_id": object_id}
+                )
+            except NoHitsFoundError:
+                if not remove_dangling_objects:
+                    cleanup_error = self.CleanupError(
+                        object_id=object_id,
+                        storage_alias=storage_alias,
+                        reason="Object not found in database, skipping.",
+                    )
+                    log.warning(cleanup_error)
+                    continue
+                force_removal = True
+
+            # only remove file if last access is later than download bucket_cache_timeout days ago
+            if force_removal or drs_object.last_accessed <= threshold:
+                log.info(
+                    "Deleting object %s from download bucket %s in storage %s.",
+                    object_id,
+                    bucket_id,
+                    storage_alias,
+                )
+                try:
+                    await object_storage.delete_object(
+                        bucket_id=bucket_id, object_id=str(object_id)
+                    )
+                except (
+                    object_storage.ObjectError,
+                    object_storage.ObjectStorageProtocolError,
+                ) as error:
+                    cleanup_error = self.CleanupError(
+                        object_id=object_id,
+                        storage_alias=storage_alias,
+                        reason=str(error),
+                    )
+                    log.error(cleanup_error)

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -278,7 +278,8 @@ class DataRepository(DataRepositoryPort):
         """
         # Run on demand through CLI, so crashing should be ok if the alias is not configured
         log.info(
-            f"Starting download bucket cleanup for storage identified by alias {storage_alias}."
+            "Starting download bucket cleanup for storage identified by alias %s.",
+            storage_alias,
         )
         try:
             bucket_id, object_storage = self._object_storages.for_alias(storage_alias)

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -19,14 +19,12 @@ import contextlib
 import logging
 import re
 import uuid
-from datetime import timedelta
 from time import perf_counter
 
 from ghga_service_commons.utils.multinode_storage import (
     S3ObjectStorages,
-    S3ObjectStoragesConfig,
 )
-from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError
+from hexkit.protocols.dao import ResourceNotFoundError
 from hexkit.protocols.objstorage import ObjectStorageProtocol
 from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4, Field, PositiveInt, field_validator
@@ -35,6 +33,7 @@ from pydantic_settings import BaseSettings
 from dcs.adapters.outbound.http import exceptions
 from dcs.constants import TRACER
 from dcs.core import models
+from dcs.core.errors import StorageAliasNotConfiguredError
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from dcs.ports.outbound.event_pub import EventPublisherPort
@@ -79,13 +78,6 @@ class DataRepositoryConfig(BaseSettings):
         description="Expiration time in seconds for presigned URLS. Positive integer required",
         title="Presigned URL expiration time in seconds",
         examples=[30, 60],
-    )
-    download_bucket_cache_timeout: int = Field(
-        default=7,
-        description="Time in days since last access after which a file present in the "
-        + "download bucket should be unstaged and has to be requested from "
-        + "permanent storage again for the next request.",
-        examples=[7, 30],
     )
 
     @field_validator("drs_server_uri")
@@ -184,7 +176,7 @@ class DataRepository(DataRepositoryPort):
         try:
             bucket_id, object_storage = self._object_storages.for_alias(storage_alias)
         except KeyError as exc:
-            storage_alias_not_configured = self.StorageAliasNotConfiguredError(
+            storage_alias_not_configured = StorageAliasNotConfiguredError(
                 alias=storage_alias
             )
             log.critical(storage_alias_not_configured, extra=log_extra)
@@ -252,100 +244,6 @@ class DataRepository(DataRepositoryPort):
             drs_server_uri_base=self._config.drs_server_uri,
             accession=accession,
         )
-
-    async def cleanup_download_buckets(
-        self,
-        *,
-        object_storages_config: S3ObjectStoragesConfig,
-        remove_dangling_objects: bool = False,
-    ):
-        """Run cleanup task for all download buckets configured in the service config."""
-        for storage_alias in object_storages_config.object_storages:
-            await self.cleanup_download_bucket(
-                storage_alias=storage_alias,
-                remove_dangling_objects=remove_dangling_objects,
-            )
-
-    async def cleanup_download_bucket(
-        self, *, storage_alias: str, remove_dangling_objects: bool = False
-    ):
-        """
-        Check if files present in the download bucket have outlived their allocated time
-        and remove all that do.
-        For each file in the download bucket, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
-        option is met or exceeded, the corresponding file is removed from the download bucket.
-        """
-        # Run on demand through CLI, so crashing should be ok if the alias is not configured
-        log.info(
-            "Starting download bucket cleanup for storage identified by alias %s.",
-            storage_alias,
-        )
-        try:
-            bucket_id, object_storage = self._object_storages.for_alias(storage_alias)
-        except KeyError:
-            storage_alias_not_configured = self.StorageAliasNotConfiguredError(
-                alias=storage_alias
-            )
-            log.critical(storage_alias_not_configured)
-            log.info(
-                "Skipping download bucket cleanup for storage %s as it is not configured.",
-                storage_alias,
-            )
-            return
-
-        threshold = now_utc_ms_prec() - timedelta(
-            days=self._config.download_bucket_cache_timeout
-        )
-
-        # filter to get all files in download bucket that should be removed
-        object_ids = [
-            uuid.UUID(x)
-            for x in await object_storage.list_all_object_ids(bucket_id=bucket_id)
-        ]
-        log.debug(
-            f"Retrieved list of deletion candidates for storage '{storage_alias}'"
-        )
-
-        for object_id in object_ids:
-            force_removal = False
-            try:
-                drs_object = await self._drs_object_dao.find_one(
-                    mapping={"object_id": object_id}
-                )
-            except NoHitsFoundError:
-                if not remove_dangling_objects:
-                    cleanup_error = self.CleanupError(
-                        object_id=object_id,
-                        storage_alias=storage_alias,
-                        reason="Object not found in database, skipping.",
-                    )
-                    log.warning(cleanup_error)
-                    continue
-                force_removal = True
-
-            # only remove file if last access is later than download bucket_cache_timeout days ago
-            if force_removal or drs_object.last_accessed <= threshold:
-                log.info(
-                    "Deleting object %s from download bucket %s in storage %s.",
-                    object_id,
-                    bucket_id,
-                    storage_alias,
-                )
-                try:
-                    await object_storage.delete_object(
-                        bucket_id=bucket_id, object_id=str(object_id)
-                    )
-                except (
-                    object_storage.ObjectError,
-                    object_storage.ObjectStorageProtocolError,
-                ) as error:
-                    cleanup_error = self.CleanupError(
-                        object_id=object_id,
-                        storage_alias=storage_alias,
-                        reason=str(error),
-                    )
-                    log.error(cleanup_error)
 
     async def register_new_file(self, *, file: models.DrsObjectBase):
         """Register a file as a new DRS Object."""
@@ -445,9 +343,7 @@ class DataRepository(DataRepositoryPort):
         try:
             bucket_id, object_storage = self._object_storages.for_alias(alias)
         except KeyError as exc:
-            storage_alias_not_configured = self.StorageAliasNotConfiguredError(
-                alias=alias
-            )
+            storage_alias_not_configured = StorageAliasNotConfiguredError(alias=alias)
             log.critical(storage_alias_not_configured)
             raise storage_alias_not_configured from exc
 

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -308,6 +308,7 @@ class DataRepository(DataRepositoryPort):
         )
 
         for object_id in object_ids:
+            force_removal = False
             try:
                 drs_object = await self._drs_object_dao.find_one(
                     mapping={"object_id": object_id}
@@ -321,9 +322,10 @@ class DataRepository(DataRepositoryPort):
                     )
                     log.warning(cleanup_error)
                     continue
+                force_removal = True
 
             # only remove file if last access is later than download bucket_cache_timeout days ago
-            if remove_dangling_objects or drs_object.last_accessed <= threshold:
+            if force_removal or drs_object.last_accessed <= threshold:
                 log.info(
                     "Deleting object %s from download bucket %s in storage %s.",
                     object_id,
@@ -344,7 +346,6 @@ class DataRepository(DataRepositoryPort):
                         reason=str(error),
                     )
                     log.error(cleanup_error)
-                    continue
 
     async def register_new_file(self, *, file: models.DrsObjectBase):
         """Register a file as a new DRS Object."""

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -257,13 +257,18 @@ class DataRepository(DataRepositoryPort):
         self,
         *,
         object_storages_config: S3ObjectStoragesConfig,
+        remove_dangling_objects: bool = False,
     ):
         """Run cleanup task for all outbox buckets configured in the service config."""
         for storage_alias in object_storages_config.object_storages:
-            await self.cleanup_outbox(storage_alias=storage_alias)
+            await self.cleanup_outbox(
+                storage_alias=storage_alias,
+                remove_dangling_objects=remove_dangling_objects,
+            )
 
-    # TODO: future: Rename references to 'outbox/outbox bucket' as 'download bucket'
-    async def cleanup_outbox(self, *, storage_alias: str):
+    async def cleanup_outbox(
+        self, *, storage_alias: str, remove_dangling_objects: bool = False
+    ):
         """
         Check if files present in the outbox have outlived their allocated time and remove
         all that do.
@@ -306,18 +311,19 @@ class DataRepository(DataRepositoryPort):
                     mapping={"object_id": object_id}
                 )
             except NoHitsFoundError:
-                cleanup_error = self.CleanupError(
-                    object_id=object_id,
-                    storage_alias=storage_alias,
-                    reason="Object not found in database, skipping.",
-                )
-                log.warning(cleanup_error)
-                continue
+                if not remove_dangling_objects:
+                    cleanup_error = self.CleanupError(
+                        object_id=object_id,
+                        storage_alias=storage_alias,
+                        reason="Object not found in database, skipping.",
+                    )
+                    log.warning(cleanup_error)
+                    continue
 
             # only remove file if last access is later than outbox_cache_timeout days ago
-            if drs_object.last_accessed <= threshold:
+            if remove_dangling_objects or drs_object.last_accessed <= threshold:
                 log.info(
-                    f"Deleting object {object_id} from bucket {bucket_id} in storage {storage_alias}."
+                    f"Deleting object {object_id} from outbox bucket {bucket_id} in storage {storage_alias}."
                 )
                 try:
                     await object_storage.delete_object(

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -288,7 +288,8 @@ class DataRepository(DataRepositoryPort):
             )
             log.critical(storage_alias_not_configured)
             log.info(
-                f"Skipping download bucket cleanup for storage {storage_alias} as it is not configured."
+                "Skipping download bucket cleanup for storage %s as it is not configured.",
+                storage_alias,
             )
             return
 

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -160,7 +160,7 @@ class DataRepository(DataRepositoryPort):
     ) -> models.DrsObjectResponseModel:
         """
         Serve the specified DRS object with access information.
-        If it does not exists in the downloadbucket, yet, a RetryAccessLaterError
+        If it does not exists in the download bucket, yet, a RetryAccessLaterError
         is raised that instructs to retry the call after a specified amount of time.
         """
         log_extra = {"file_id": file_id, "accession": accession}

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -325,7 +325,10 @@ class DataRepository(DataRepositoryPort):
             # only remove file if last access is later than download bucket_cache_timeout days ago
             if remove_dangling_objects or drs_object.last_accessed <= threshold:
                 log.info(
-                    f"Deleting object {object_id} from download bucket {bucket_id} in storage {storage_alias}."
+                    "Deleting object %s from download bucket %s in storage %s.",
+                    object_id,
+                    bucket_id,
+                    storage_alias,
                 )
                 try:
                     await object_storage.delete_object(

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -55,21 +55,21 @@ class DataRepositoryConfig(BaseSettings):
     )
     staging_speed: int = Field(
         default=100,
-        description="When trying to access a DRS object that is not yet in the outbox,"
+        description="When trying to access a DRS object that is not yet in the download bucket,"
         + " assume that this many megabytes can be staged per second.",
         title="Staging speed in MB/s",
         examples=[100, 500],
     )
     retry_after_min: int = Field(
         default=5,
-        description="When trying to access a DRS object that is not yet in the outbox,"
+        description="When trying to access a DRS object that is not yet in the download bucket,"
         + " wait at least this number of seconds before trying again.",
         title="Minimum retry time in seconds when staging",
         examples=[5, 10],
     )
     retry_after_max: int = Field(
         default=300,
-        description="When trying to access a DRS object that is not yet in the outbox,"
+        description="When trying to access a DRS object that is not yet in the download bucket,"
         + " wait at most this number of seconds before trying again.",
         title="Maximum retry time in seconds when staging",
         examples=[30, 300],
@@ -80,11 +80,11 @@ class DataRepositoryConfig(BaseSettings):
         title="Presigned URL expiration time in seconds",
         examples=[30, 60],
     )
-    outbox_cache_timeout: int = Field(
+    download_bucket_cache_timeout: int = Field(
         default=7,
         description="Time in days since last access after which a file present in the "
-        + "outbox should be unstaged and has to be requested from permanent storage again "
-        + "for the next request.",
+        + "download bucket should be unstaged and has to be requested from "
+        + "permanent storage again for the next request.",
         examples=[7, 30],
     )
 
@@ -160,8 +160,8 @@ class DataRepository(DataRepositoryPort):
     ) -> models.DrsObjectResponseModel:
         """
         Serve the specified DRS object with access information.
-        If it does not exists in the outbox, yet, a RetryAccessLaterError is raised that
-        instructs to retry the call after a specified amount of time.
+        If it does not exists in the downloadbucket, yet, a RetryAccessLaterError
+        is raised that instructs to retry the call after a specified amount of time.
         """
         log_extra = {"file_id": file_id, "accession": accession}
         # make sure that metadata for the DRS object exists in the database:
@@ -253,32 +253,32 @@ class DataRepository(DataRepositoryPort):
             accession=accession,
         )
 
-    async def cleanup_outbox_buckets(
+    async def cleanup_download_buckets(
         self,
         *,
         object_storages_config: S3ObjectStoragesConfig,
         remove_dangling_objects: bool = False,
     ):
-        """Run cleanup task for all outbox buckets configured in the service config."""
+        """Run cleanup task for all download buckets configured in the service config."""
         for storage_alias in object_storages_config.object_storages:
-            await self.cleanup_outbox(
+            await self.cleanup_download_bucket(
                 storage_alias=storage_alias,
                 remove_dangling_objects=remove_dangling_objects,
             )
 
-    async def cleanup_outbox(
+    async def cleanup_download_bucket(
         self, *, storage_alias: str, remove_dangling_objects: bool = False
     ):
         """
-        Check if files present in the outbox have outlived their allocated time and remove
-        all that do.
-        For each file in the outbox, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the outbox_cache_timeout
-        option is met or exceeded, the corresponding file is removed from the outbox.
+        Check if files present in the download bucket have outlived their allocated time
+        and remove all that do.
+        For each file in the download bucket, its 'last_accessed' field is checked and compared
+        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
+        option is met or exceeded, the corresponding file is removed from the download bucket.
         """
         # Run on demand through CLI, so crashing should be ok if the alias is not configured
         log.info(
-            f"Starting outbox cleanup for storage identified by alias {storage_alias}."
+            f"Starting download bucket cleanup for storage identified by alias {storage_alias}."
         )
         try:
             bucket_id, object_storage = self._object_storages.for_alias(storage_alias)
@@ -288,15 +288,15 @@ class DataRepository(DataRepositoryPort):
             )
             log.critical(storage_alias_not_configured)
             log.info(
-                f"Skipping outbox cleanup for storage {storage_alias} as it is not configured."
+                f"Skipping download bucket cleanup for storage {storage_alias} as it is not configured."
             )
             return
 
         threshold = now_utc_ms_prec() - timedelta(
-            days=self._config.outbox_cache_timeout
+            days=self._config.download_bucket_cache_timeout
         )
 
-        # filter to get all files in outbox that should be removed
+        # filter to get all files in download bucket that should be removed
         object_ids = [
             uuid.UUID(x)
             for x in await object_storage.list_all_object_ids(bucket_id=bucket_id)
@@ -320,10 +320,10 @@ class DataRepository(DataRepositoryPort):
                     log.warning(cleanup_error)
                     continue
 
-            # only remove file if last access is later than outbox_cache_timeout days ago
+            # only remove file if last access is later than download bucket_cache_timeout days ago
             if remove_dangling_objects or drs_object.last_accessed <= threshold:
                 log.info(
-                    f"Deleting object {object_id} from outbox bucket {bucket_id} in storage {storage_alias}."
+                    f"Deleting object {object_id} from download bucket {bucket_id} in storage {storage_alias}."
                 )
                 try:
                     await object_storage.delete_object(

--- a/services/dcs/src/dcs/core/data_repository.py
+++ b/services/dcs/src/dcs/core/data_repository.py
@@ -282,7 +282,7 @@ class DataRepository(DataRepositoryPort):
                 alias=storage_alias
             )
             log.critical(storage_alias_not_configured)
-            log.warning(
+            log.info(
                 f"Skipping outbox cleanup for storage {storage_alias} as it is not configured."
             )
             return
@@ -305,12 +305,13 @@ class DataRepository(DataRepositoryPort):
                 drs_object = await self._drs_object_dao.find_one(
                     mapping={"object_id": object_id}
                 )
-            except NoHitsFoundError as error:
-                cleanup_error = self.CleanupError(object_id=object_id, from_error=error)
-                log.critical(cleanup_error)
-                log.warning(
-                    f"Object with id {object_id} in storage {storage_alias} not found in database, skipping."
+            except NoHitsFoundError:
+                cleanup_error = self.CleanupError(
+                    object_id=object_id,
+                    storage_alias=storage_alias,
+                    reason="Object not found in database, skipping.",
                 )
+                log.warning(cleanup_error)
                 continue
 
             # only remove file if last access is later than outbox_cache_timeout days ago
@@ -327,12 +328,11 @@ class DataRepository(DataRepositoryPort):
                     object_storage.ObjectStorageProtocolError,
                 ) as error:
                     cleanup_error = self.CleanupError(
-                        object_id=object_id, from_error=error
+                        object_id=object_id,
+                        storage_alias=storage_alias,
+                        reason=str(error),
                     )
-                    log.critical(cleanup_error)
-                    log.warning(
-                        f"Could not delete object with id {object_id} from storage {storage_alias}."
-                    )
+                    log.error(cleanup_error)
                     continue
 
     async def register_new_file(self, *, file: models.DrsObjectBase):

--- a/services/dcs/src/dcs/core/errors.py
+++ b/services/dcs/src/dcs/core/errors.py
@@ -1,0 +1,27 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared error classes used across the core domain."""
+
+
+class StorageAliasNotConfiguredError(RuntimeError):
+    """Raised when looking up an object storage configuration by alias fails."""
+
+    def __init__(self, *, alias: str):
+        message = (
+            f"Could not find a storage configuration for alias {alias}.\n"
+            + "Check íf your multi node configuration contains a corresponding entry."
+        )
+        super().__init__(message)

--- a/services/dcs/src/dcs/core/models.py
+++ b/services/dcs/src/dcs/core/models.py
@@ -63,7 +63,7 @@ class DrsObject(DrsObjectBase):
 
 
 class AccessTimeDrsObject(DrsObject):
-    """DRS Model with information for outbox caching strategy"""
+    """DRS Model with information for download bucket caching strategy"""
 
     last_accessed: UTCDatetime
 

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -172,7 +172,7 @@ async def prepare_download_bucket_cleaner(
     data_repo_override: DataRepositoryPort | None = None,
     remove_dangling_objects: bool = False,
 ) -> AsyncGenerator[DownloadBucketCleaner]:
-    """Construct and initialize a coroutine that cleans the downlaod bucket once invoked.
+    """Construct and initialize a coroutine that cleans the download bucket once invoked.
     By default, the core dependencies are automatically prepared but you can also
     provide them using the data_repo_override parameter.
     """

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -15,9 +15,8 @@
 
 """Module hosting the dependency injection container."""
 
-from collections.abc import AsyncGenerator, Coroutine
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, nullcontext
-from typing import Any, TypeAlias
 
 from fastapi import FastAPI
 from ghga_service_commons.auth.jwt_auth import JWTAuthContextProvider
@@ -160,26 +159,3 @@ async def prepare_event_subscriber(
             ) as event_subscriber,
         ):
             yield event_subscriber
-
-
-DownloadBucketCleaner: TypeAlias = Coroutine[Any, Any, None]
-
-
-@asynccontextmanager
-async def prepare_download_bucket_cleaner(
-    *,
-    config: Config,
-    data_repo_override: DataRepositoryPort | None = None,
-    remove_dangling_objects: bool = False,
-) -> AsyncGenerator[DownloadBucketCleaner]:
-    """Construct and initialize a coroutine that cleans the download bucket once invoked.
-    By default, the core dependencies are automatically prepared but you can also
-    provide them using the data_repo_override parameter.
-    """
-    async with prepare_core_with_override(
-        config=config, data_repo_override=data_repo_override
-    ) as data_repository:
-        yield data_repository.cleanup_download_buckets(
-            object_storages_config=config,
-            remove_dangling_objects=remove_dangling_objects,
-        )

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -170,6 +170,7 @@ async def prepare_outbox_cleaner(
     *,
     config: Config,
     data_repo_override: DataRepositoryPort | None = None,
+    remove_dangling_objects: bool = False,
 ) -> AsyncGenerator[OutboxCleaner]:
     """Construct and initialize a coroutine that cleans the outbox once invoked.
     By default, the core dependencies are automatically prepared but you can also
@@ -178,4 +179,7 @@ async def prepare_outbox_cleaner(
     async with prepare_core_with_override(
         config=config, data_repo_override=data_repo_override
     ) as data_repository:
-        yield data_repository.cleanup_outbox_buckets(object_storages_config=config)
+        yield data_repository.cleanup_outbox_buckets(
+            object_storages_config=config,
+            remove_dangling_objects=remove_dangling_objects,
+        )

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -35,7 +35,9 @@ from dcs.adapters.outbound.http.api_calls import get_configured_httpx_client
 from dcs.adapters.outbound.http.secrets import SecretsClient
 from dcs.config import Config
 from dcs.core.auth_policies import WorkOrderContext
+from dcs.core.bucket_cleanup import DownloadBucketCleaner
 from dcs.core.data_repository import DataRepository
+from dcs.ports.inbound.bucket_cleanup import BucketCleanerPort
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 
 
@@ -89,6 +91,21 @@ async def prepare_core(*, config: Config) -> AsyncGenerator[DataRepositoryPort]:
             object_storages=object_storages,
             event_publisher=event_publisher,
             secrets_client=secrets_client,
+            config=config,
+        )
+
+
+@asynccontextmanager
+async def prepare_cleaner(*, config: Config) -> AsyncGenerator[BucketCleanerPort]:
+    """Constructs and initializes the bucket cleanup service and its dependencies."""
+    object_storages = S3ObjectStorages(config=config)
+
+    async with MongoDbDaoFactory.construct(config=config) as dao_factory:
+        drs_object_dao = await get_drs_dao(dao_factory=dao_factory)
+
+        yield DownloadBucketCleaner(
+            drs_object_dao=drs_object_dao,
+            object_storages=object_storages,
             config=config,
         )
 

--- a/services/dcs/src/dcs/inject.py
+++ b/services/dcs/src/dcs/inject.py
@@ -162,24 +162,24 @@ async def prepare_event_subscriber(
             yield event_subscriber
 
 
-OutboxCleaner: TypeAlias = Coroutine[Any, Any, None]
+DownloadBucketCleaner: TypeAlias = Coroutine[Any, Any, None]
 
 
 @asynccontextmanager
-async def prepare_outbox_cleaner(
+async def prepare_download_bucket_cleaner(
     *,
     config: Config,
     data_repo_override: DataRepositoryPort | None = None,
     remove_dangling_objects: bool = False,
-) -> AsyncGenerator[OutboxCleaner]:
-    """Construct and initialize a coroutine that cleans the outbox once invoked.
+) -> AsyncGenerator[DownloadBucketCleaner]:
+    """Construct and initialize a coroutine that cleans the downlaod bucket once invoked.
     By default, the core dependencies are automatically prepared but you can also
     provide them using the data_repo_override parameter.
     """
     async with prepare_core_with_override(
         config=config, data_repo_override=data_repo_override
     ) as data_repository:
-        yield data_repository.cleanup_outbox_buckets(
+        yield data_repository.cleanup_download_buckets(
             object_storages_config=config,
             remove_dangling_objects=remove_dangling_objects,
         )

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -22,7 +22,7 @@ from hexkit.opentelemetry import configure_opentelemetry
 from dcs.config import Config
 from dcs.inject import (
     get_persistent_publisher,
-    prepare_download_bucket_cleaner,
+    prepare_core,
     prepare_event_subscriber,
     prepare_rest_app,
 )
@@ -57,10 +57,11 @@ async def run_download_bucket_cleanup(remove_dangling_objects: bool = False):
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
 
-    async with prepare_download_bucket_cleaner(
-        config=config, remove_dangling_objects=remove_dangling_objects
-    ) as cleanup_download_bucket:
-        await cleanup_download_bucket
+    async with prepare_core(config=config) as data_repository:
+        await data_repository.cleanup_download_buckets(
+            object_storages_config=config,
+            remove_dangling_objects=remove_dangling_objects,
+        )
 
 
 async def publish_events(*, all: bool = False):

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -51,13 +51,15 @@ async def consume_events(run_forever: bool = True):
         await event_subscriber.run(forever=run_forever)
 
 
-async def run_outbox_cleanup():
+async def run_outbox_cleanup(remove_dangling_objects: bool = False):
     """Check if outbox buckets contains files that should be cleaned up and perform clean-up."""
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
 
-    async with prepare_outbox_cleaner(config=config) as cleanup_outbox:
+    async with prepare_outbox_cleaner(
+        config=config, remove_dangling_objects=remove_dangling_objects
+    ) as cleanup_outbox:
         await cleanup_outbox
 
 

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -22,7 +22,7 @@ from hexkit.opentelemetry import configure_opentelemetry
 from dcs.config import Config
 from dcs.inject import (
     get_persistent_publisher,
-    prepare_core,
+    prepare_cleaner,
     prepare_event_subscriber,
     prepare_rest_app,
 )
@@ -51,14 +51,14 @@ async def consume_events(run_forever: bool = True):
         await event_subscriber.run(forever=run_forever)
 
 
-async def run_download_bucket_cleanup(remove_dangling_objects: bool = False):
+async def run_download_bucket_cleaner(remove_dangling_objects: bool = False):
     """Check if download buckets contains files that should be cleaned up and perform clean-up."""
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
 
-    async with prepare_core(config=config) as data_repository:
-        await data_repository.cleanup_download_buckets(
+    async with prepare_cleaner(config=config) as bucket_cleaner:
+        await bucket_cleaner.cleanup_download_buckets(
             object_storages_config=config,
             remove_dangling_objects=remove_dangling_objects,
         )

--- a/services/dcs/src/dcs/main.py
+++ b/services/dcs/src/dcs/main.py
@@ -22,8 +22,8 @@ from hexkit.opentelemetry import configure_opentelemetry
 from dcs.config import Config
 from dcs.inject import (
     get_persistent_publisher,
+    prepare_download_bucket_cleaner,
     prepare_event_subscriber,
-    prepare_outbox_cleaner,
     prepare_rest_app,
 )
 from dcs.migrations import run_db_migrations
@@ -51,16 +51,16 @@ async def consume_events(run_forever: bool = True):
         await event_subscriber.run(forever=run_forever)
 
 
-async def run_outbox_cleanup(remove_dangling_objects: bool = False):
-    """Check if outbox buckets contains files that should be cleaned up and perform clean-up."""
+async def run_download_bucket_cleanup(remove_dangling_objects: bool = False):
+    """Check if download buckets contains files that should be cleaned up and perform clean-up."""
     config = Config()
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
 
-    async with prepare_outbox_cleaner(
+    async with prepare_download_bucket_cleaner(
         config=config, remove_dangling_objects=remove_dangling_objects
-    ) as cleanup_outbox:
-        await cleanup_outbox
+    ) as cleanup_download_bucket:
+        await cleanup_download_bucket
 
 
 async def publish_events(*, all: bool = False):

--- a/services/dcs/src/dcs/ports/inbound/bucket_cleanup.py
+++ b/services/dcs/src/dcs/ports/inbound/bucket_cleanup.py
@@ -1,0 +1,56 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interface for download bucket cleanup."""
+
+from abc import ABC, abstractmethod
+
+from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
+from pydantic import UUID4
+
+
+class BucketCleanerPort(ABC):
+    """A service that manages download bucket cleanup."""
+
+    class CleanupError(RuntimeError):
+        """
+        Raised when removal of an object from the download bucket could not be performed
+        due to an underlying issue
+        """
+
+        def __init__(self, *, object_id: UUID4, storage_alias: str, reason: str):
+            message = f"Could not remove object {object_id} from download bucket in storage {storage_alias}: {reason}"
+            super().__init__(message)
+
+    @abstractmethod
+    async def cleanup_download_buckets(
+        self,
+        *,
+        object_storages_config: S3ObjectStoragesConfig,
+        remove_dangling_objects: bool = False,
+    ):
+        """Run cleanup task for all download buckets configured in the service config."""
+
+    @abstractmethod
+    async def cleanup_download_bucket(
+        self, *, storage_alias: str, remove_dangling_objects: bool = False
+    ):
+        """
+        Check if files present in the download bucket have outlived their allocated time
+        and remove all that do.
+        For each file in the download bucket, its 'last_accessed' field is checked and compared
+        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
+        option is met or exceeded, the corresponding file is removed from the download bucket.
+        """

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -17,7 +17,6 @@
 
 from abc import ABC, abstractmethod
 
-from ghga_service_commons.utils.multinode_storage import S3ObjectStoragesConfig
 from pydantic import UUID4
 
 from dcs.core import models
@@ -31,16 +30,6 @@ class DataRepositoryPort(ABC):
 
         def __init__(self):
             super().__init__("Failed to communicate with the Secrets API")
-
-    class CleanupError(RuntimeError):
-        """
-        Raised when removal of an object from the download bucket could not be performed
-        due to an underlying issue
-        """
-
-        def __init__(self, *, object_id: UUID4, storage_alias: str, reason: str):
-            message = f"Could not remove object {object_id} from download bucket in storage {storage_alias}: {reason}"
-            super().__init__(message)
 
     class DrsObjectNotFoundError(RuntimeError):
         """Raised when no DRS object was found corresponding to the given file ID."""
@@ -71,16 +60,6 @@ class DataRepositoryPort(ABC):
 
             super().__init__(message)
 
-    class StorageAliasNotConfiguredError(RuntimeError):
-        """Raised when looking up an object storage configuration by alias fails."""
-
-        def __init__(self, *, alias: str):
-            message = (
-                f"Could not find a storage configuration for alias {alias}.\n"
-                + "Check íf your multi node configuration contains a corresponding entry."
-            )
-            super().__init__(message)
-
     class UnexpectedAPIResponseError(RuntimeError):
         """Raise when API call returns unexpected return code"""
 
@@ -98,27 +77,6 @@ class DataRepositoryPort(ABC):
         Serve the specified DRS object with access information.
         If it does not exists in the download bucket, yet, a RetryAccessLaterError
         is raised that instructs to retry the call after a specified amount of time.
-        """
-
-    @abstractmethod
-    async def cleanup_download_buckets(
-        self,
-        *,
-        object_storages_config: S3ObjectStoragesConfig,
-        remove_dangling_objects: bool = False,
-    ):
-        """Run cleanup task for all download buckets configured in the service config."""
-
-    @abstractmethod
-    async def cleanup_download_bucket(
-        self, *, storage_alias: str, remove_dangling_objects: bool = False
-    ):
-        """
-        Check if files present in the download bucket have outlived their allocated time
-        and remove all that do.
-        For each file in the download bucket, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
-        option is met or exceeded, the corresponding file is removed from the download bucket.
         """
 
     @abstractmethod

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -38,8 +38,8 @@ class DataRepositoryPort(ABC):
         an underlying issue
         """
 
-        def __init__(self, *, object_id: UUID4, from_error: Exception):
-            message = f"Could not remove object {object_id} from outbox bucket: {str(from_error)}"
+        def __init__(self, *, object_id: UUID4, storage_alias: str, reason: str):
+            message = f"Could not remove object {object_id} from outbox bucket in storage {storage_alias}: {reason}"
             super().__init__(message)
 
     class DrsObjectNotFoundError(RuntimeError):

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -103,7 +103,10 @@ class DataRepositoryPort(ABC):
 
     @abstractmethod
     async def cleanup_outbox_buckets(
-        self, *, object_storages_config: S3ObjectStoragesConfig
+        self,
+        *,
+        object_storages_config: S3ObjectStoragesConfig,
+        remove_dangling_objects: bool = False,
     ):
         """Run cleanup task for all outbox buckets configured in the service config."""
         ...

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -34,12 +34,12 @@ class DataRepositoryPort(ABC):
 
     class CleanupError(RuntimeError):
         """
-        Raised when removal of an object from the outbox could not be performed due to
-        an underlying issue
+        Raised when removal of an object from the download bucket could not be performed
+        due to an underlying issue
         """
 
         def __init__(self, *, object_id: UUID4, storage_alias: str, reason: str):
-            message = f"Could not remove object {object_id} from outbox bucket in storage {storage_alias}: {reason}"
+            message = f"Could not remove object {object_id} from download bucket in storage {storage_alias}: {reason}"
             super().__init__(message)
 
     class DrsObjectNotFoundError(RuntimeError):
@@ -57,7 +57,7 @@ class DataRepositoryPort(ABC):
             super().__init__(message)
 
     class RetryAccessLaterError(RuntimeError):
-        """Raised when trying to access a DRS object that is not yet in the outbox.
+        """Raised when trying to access a DRS object that is not yet in the download bucket.
         Instructs to retry later.
         """
 
@@ -96,36 +96,32 @@ class DataRepositoryPort(ABC):
     ) -> models.DrsObjectResponseModel:
         """
         Serve the specified DRS object with access information.
-        If it does not exists in the outbox, yet, a RetryAccessLaterError is raised that
-        instructs to retry the call after a specified amount of time.
+        If it does not exists in the download bucket, yet, a RetryAccessLaterError
+        is raised that instructs to retry the call after a specified amount of time.
         """
-        ...
 
     @abstractmethod
-    async def cleanup_outbox_buckets(
+    async def cleanup_download_buckets(
         self,
         *,
         object_storages_config: S3ObjectStoragesConfig,
         remove_dangling_objects: bool = False,
     ):
-        """Run cleanup task for all outbox buckets configured in the service config."""
-        ...
+        """Run cleanup task for all download buckets configured in the service config."""
 
     @abstractmethod
-    async def cleanup_outbox(self, *, storage_alias: str):
+    async def cleanup_download_bucket(self, *, storage_alias: str):
         """
-        Check if files present in the outbox have outlived their allocated time and remove
-        all that do.
-        For each file in the outbox, its 'last_accessed' field is checked and compared
-        to the current datetime. If the threshold configured in the outbox_cache_timeout option
-        is met or exceeded, the corresponding file is removed from the outbox.
+        Check if files present in the download bucket have outlived their allocated time
+        and remove all that do.
+        For each file in the download bucket, its 'last_accessed' field is checked and compared
+        to the current datetime. If the threshold configured in the download_bucket_cache_timeout
+        option is met or exceeded, the corresponding file is removed from the download bucket.
         """
-        ...
 
     @abstractmethod
     async def register_new_file(self, *, file: models.DrsObjectBase):
         """Register a file as a new DRS Object."""
-        ...
 
     @abstractmethod
     async def serve_envelope(self, *, file_id: UUID4, public_key: str) -> str:
@@ -134,7 +130,6 @@ class DataRepositoryPort(ABC):
 
         :returns: base64 encoded envelope bytes
         """
-        ...
 
     @abstractmethod
     async def delete_file(self, *, file_id: UUID4) -> None:
@@ -145,4 +140,3 @@ class DataRepositoryPort(ABC):
         Args:
             file_id: The UUID4 used to identify the file to delete.
         """
-        ...

--- a/services/dcs/src/dcs/ports/inbound/data_repository.py
+++ b/services/dcs/src/dcs/ports/inbound/data_repository.py
@@ -110,7 +110,9 @@ class DataRepositoryPort(ABC):
         """Run cleanup task for all download buckets configured in the service config."""
 
     @abstractmethod
-    async def cleanup_download_bucket(self, *, storage_alias: str):
+    async def cleanup_download_bucket(
+        self, *, storage_alias: str, remove_dangling_objects: bool = False
+    ):
         """
         Check if files present in the download bucket have outlived their allocated time
         and remove all that do.

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -112,7 +112,7 @@ async def joint_fixture(
     # merge configs from different sources with the default one:
     auth_config = WorkOrderTokenConfig(auth_key=auth_key)
 
-    bucket_id = "test-outbox"
+    bucket_id = "test-download"
 
     node_config = S3ObjectStorageNodeConfig(bucket=bucket_id, credentials=s3.config)
     endpoint_aliases = EndpointAliases()
@@ -253,7 +253,7 @@ async def cleanup_fixture(
     test_file_expired.file_id = expired_file_id
     test_file_expired.object_id = EXPIRED_OBJECT_ID
     test_file_expired.last_accessed = utc_dates.now_as_utc() - timedelta(
-        days=joint_fixture.config.outbox_cache_timeout
+        days=joint_fixture.config.download_bucket_cache_timeout
     )
 
     # populate DB entries

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -50,7 +50,13 @@ from pydantic import UUID4
 from dcs.adapters.outbound.dao import get_drs_dao
 from dcs.config import Config, WorkOrderTokenConfig
 from dcs.core import models
-from dcs.inject import prepare_core, prepare_event_subscriber, prepare_rest_app
+from dcs.inject import (
+    prepare_cleaner,
+    prepare_core,
+    prepare_event_subscriber,
+    prepare_rest_app,
+)
+from dcs.ports.inbound.bucket_cleanup import BucketCleanerPort
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from tests_dcs.fixtures.config import get_config
@@ -218,30 +224,44 @@ async def populated_fixture(
 
 @dataclass
 class CleanupFixture:
-    """Fixture for cleanup test with DAO and test files"""
+    """Fixture for download bucket cleanup tests."""
 
+    config: Config
+    bucket_id: str
+    bucket_cleaner: BucketCleanerPort
+    s3: S3Fixture
+    endpoint_aliases: EndpointAliases
     mongodb_dao: DrsObjectDaoPort
-    joint: JointFixture
     cached_file_id: UUID4
     expired_file_id: UUID4
 
 
 @pytest_asyncio.fixture
 async def cleanup_fixture(
-    joint_fixture: JointFixture,
+    mongodb: MongoDbFixture,
+    s3: S3Fixture,
 ) -> AsyncGenerator[CleanupFixture]:
-    """Set up state for and populate CleanupFixture"""
-    # create common db dao to insert test data
-    mongodb_dao = await joint_fixture.mongodb.dao_factory.get_dao(
+    """Self-contained fixture for download bucket cleanup tests."""
+    bucket_id = "test-download"
+
+    endpoint_aliases = EndpointAliases()
+    node_config = S3ObjectStorageNodeConfig(bucket=bucket_id, credentials=s3.config)
+    object_storage_config = S3ObjectStoragesConfig(
+        object_storages={endpoint_aliases.valid_node: node_config}
+    )
+
+    config = get_config(sources=[mongodb.config, object_storage_config])
+
+    await s3.populate_buckets(buckets=[bucket_id])
+
+    # create db dao to insert test data
+    mongodb_dao = await mongodb.dao_factory.get_dao(
         name="drs_objects",
         dto_model=models.AccessTimeDrsObject,
         id_field="file_id",
     )
 
-    s3 = joint_fixture.s3
     file = EXAMPLE_FILE
-
-    # create AccessTimeDrsObjects for valid cached and expired cached file
 
     cached_file_id = uuid4()
     test_file_cached = file.model_copy(deep=True)
@@ -254,7 +274,7 @@ async def cleanup_fixture(
     test_file_expired.file_id = expired_file_id
     test_file_expired.object_id = EXPIRED_OBJECT_ID
     test_file_expired.last_accessed = utc_dates.now_as_utc() - timedelta(
-        days=joint_fixture.config.download_bucket_cache_timeout
+        days=config.download_bucket_cache_timeout
     )
 
     # populate DB entries
@@ -263,18 +283,23 @@ async def cleanup_fixture(
 
     # populate storage
     with temp_file_object(
-        bucket_id=joint_fixture.bucket_id,
+        bucket_id=bucket_id,
         object_id=str(test_file_cached.object_id),
     ) as cached_file:
         with temp_file_object(
-            bucket_id=joint_fixture.bucket_id,
+            bucket_id=bucket_id,
             object_id=str(test_file_expired.object_id),
         ) as expired_file:
             await s3.populate_file_objects([cached_file, expired_file])
 
-    yield CleanupFixture(
-        mongodb_dao=mongodb_dao,
-        joint=joint_fixture,
-        cached_file_id=cached_file_id,
-        expired_file_id=expired_file_id,
-    )
+    async with prepare_cleaner(config=config) as bucket_cleaner:
+        yield CleanupFixture(
+            config=config,
+            bucket_id=bucket_id,
+            bucket_cleaner=bucket_cleaner,
+            s3=s3,
+            endpoint_aliases=endpoint_aliases,
+            mongodb_dao=mongodb_dao,
+            cached_file_id=cached_file_id,
+            expired_file_id=expired_file_id,
+        )

--- a/services/dcs/tests_dcs/fixtures/joint.py
+++ b/services/dcs/tests_dcs/fixtures/joint.py
@@ -16,6 +16,7 @@
 """Join the functionality of all fixtures for API-level integration testing."""
 
 __all__ = [
+    "CleanupFixture",
     "JointFixture",
     "PopulatedFixture",
     "cleanup_fixture",

--- a/services/dcs/tests_dcs/fixtures/test_config.yaml
+++ b/services/dcs/tests_dcs/fixtures/test_config.yaml
@@ -12,7 +12,7 @@ staging_speed: 100
 presigned_url_expires_after: 30
 object_storages:
   test:
-    bucket: test-outbox
+    bucket: test-download
     credentials:
       s3_endpoint_url: http://dcs:4566
       s3_access_key_id: test

--- a/services/dcs/tests_dcs/test_edge_cases.py
+++ b/services/dcs/tests_dcs/test_edge_cases.py
@@ -28,6 +28,7 @@ from pydantic import UUID4
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.core import models
+from dcs.core.errors import StorageAliasNotConfiguredError
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 from tests_dcs.fixtures.joint import EXAMPLE_FILE, JointFixture, PopulatedFixture
 from tests_dcs.fixtures.mock_api.app import router
@@ -139,7 +140,7 @@ async def test_deletion_config_error(
     )
 
     data_repository = storage_unavailable_fixture.joint.data_repository
-    with pytest.raises(data_repository.StorageAliasNotConfiguredError):
+    with pytest.raises(StorageAliasNotConfiguredError):
         await data_repository.delete_file(file_id=storage_unavailable_fixture.file_id)
 
 

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -77,7 +77,7 @@ async def test_happy_journey(
 
     # request access to the newly registered file:
     # (An check that an event is published indicating that the file is not in
-    # outbox yet.)
+    # download bucket yet.)
 
     non_staged_requested_event = NonStagedFileRequested(
         file_id=example_file.file_id,
@@ -105,7 +105,7 @@ async def test_happy_journey(
     # the example file is small, so we expect the minimum wait time
     assert retry_after == joint_fixture.config.retry_after_min
 
-    # place the requested file into the outbox bucket (it is not important here that
+    # place the requested file into the download bucket (it is not important here that
     # the file content does not match the announced decrypted_sha256 checksum):
     file_object = tmp_file.model_copy(
         update={
@@ -190,7 +190,7 @@ async def test_happy_deletion(
     drs_object = await populated_fixture.mongodb_dao.get_by_id(file_id)
     object_id = str(drs_object.object_id)
 
-    # place example content in the outbox bucket:
+    # place example content in the download bucket:
     file_object = tmp_file.model_copy(
         update={
             "bucket_id": joint_fixture.bucket_id,
@@ -220,10 +220,10 @@ async def test_happy_deletion(
 
 
 async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
-    """Test multiple outbox bucket cleanup handling."""
+    """Test multiple download buckets cleanup handling."""
     data_repository = cleanup_fixture.joint.data_repository
 
-    await data_repository.cleanup_outbox_buckets(
+    await data_repository.cleanup_download_buckets(
         object_storages_config=cleanup_fixture.joint.config
     )
 
@@ -238,7 +238,7 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
         object_id=str(cached_object.object_id),
     )
 
-    # check if expired object has been removed from outbox
+    # check if expired object has been removed from download bucket
     expired_object = await cleanup_fixture.mongodb_dao.get_by_id(expired_id)
     assert not await s3.storage.does_object_exist(
         bucket_id=cleanup_fixture.joint.bucket_id,
@@ -246,7 +246,7 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
     )
 
     with caplog.at_level(logging.ERROR):
-        await data_repository.cleanup_outbox(
+        await data_repository.cleanup_download_bucket(
             storage_alias=cleanup_fixture.joint.endpoint_aliases.fake_node
         )
 

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -17,6 +17,7 @@
 
 import logging
 import re
+from datetime import timedelta
 from uuid import uuid4
 
 import httpx
@@ -24,8 +25,10 @@ import pytest
 from fastapi import status
 from hexkit.providers.akafka.testutils import ExpectedEvent
 from hexkit.providers.s3.testutils import FileObject, temp_file_object
+from hexkit.utils import now_utc_ms_prec
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
+from dcs.core import models
 from dcs.core.models import FileDownloadServed, NonStagedFileRequested
 from tests_dcs.fixtures.joint import CleanupFixture, JointFixture, PopulatedFixture
 from tests_dcs.fixtures.mock_api.app import router
@@ -260,20 +263,68 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
     assert expected_message in caplog.records[0].message
 
 
-async def test_bucket_cleanup_dangling_object(joint_fixture: JointFixture, caplog):
-    """Test that stale objects in the download bucket with no DB entry are handled."""
+async def test_bucket_cleanup_dangling_objects(joint_fixture: JointFixture, caplog):
+    """Test that stale objects in the download bucket with no DB entry are handled.
+
+    Also verifies that objects with DB entries are handled correctly: expired objects
+    (last_accessed beyond the cache timeout) are removed, while objects within the
+    threshold are left in place.
+    """
+    s3 = joint_fixture.s3
+    bucket_id = joint_fixture.bucket_id
+    data_repository = joint_fixture.data_repository
+    storage_alias = joint_fixture.endpoint_aliases.valid_node
+    timeout_days = joint_fixture.config.download_bucket_cache_timeout
+
+    mongodb_dao = await joint_fixture.mongodb.dao_factory.get_dao(
+        name="drs_objects",
+        dto_model=models.AccessTimeDrsObject,
+        id_field="file_id",
+    )
+
+    # Object with DB entry, within expiration threshold
+    cached_object_id = uuid4()
+    cached_db_entry = models.AccessTimeDrsObject(
+        file_id=uuid4(),
+        object_id=cached_object_id,
+        decrypted_sha256="0" * 64,
+        creation_date=now_utc_ms_prec(),
+        decrypted_size=1,
+        secret_id="cached-secret",
+        encrypted_size=1,
+        storage_alias=storage_alias,
+        last_accessed=now_utc_ms_prec(),
+    )
+    await mongodb_dao.insert(cached_db_entry)
+    with temp_file_object(bucket_id=bucket_id, object_id=str(cached_object_id)) as f:
+        await s3.populate_file_objects([f])
+
+    # Object with DB entry, beyond expiration threshold
+    expired_object_id = uuid4()
+    expired_db_entry = models.AccessTimeDrsObject(
+        file_id=uuid4(),
+        object_id=expired_object_id,
+        decrypted_sha256="0" * 64,
+        creation_date=now_utc_ms_prec(),
+        decrypted_size=1,
+        secret_id="expired-secret",
+        encrypted_size=1,
+        storage_alias=storage_alias,
+        last_accessed=now_utc_ms_prec() - timedelta(days=timeout_days),
+    )
+    await mongodb_dao.insert(expired_db_entry)
+    with temp_file_object(bucket_id=bucket_id, object_id=str(expired_object_id)) as f:
+        await s3.populate_file_objects([f])
+
+    # Object with no DB entry
     stale_object_id = uuid4()
     with temp_file_object(
-        bucket_id=joint_fixture.bucket_id,
+        bucket_id=bucket_id,
         object_id=str(stale_object_id),
     ) as stale_file:
-        await joint_fixture.s3.populate_file_objects([stale_file])
+        await s3.populate_file_objects([stale_file])
 
-    data_repository = joint_fixture.data_repository
-    s3 = joint_fixture.s3
-    storage_alias = joint_fixture.endpoint_aliases.valid_node
-
-    # First run: without remove_dangling_objects, stale object should be logged and skipped
+    # first run without remove_dangling_objects
     with caplog.at_level(logging.WARNING):
         await data_repository.cleanup_download_buckets(
             object_storages_config=joint_fixture.config
@@ -288,20 +339,32 @@ async def test_bucket_cleanup_dangling_object(joint_fixture: JointFixture, caplo
     )
     assert any(expected_warning in record.message for record in caplog.records)
 
-    # Stale object should still be present in the download bucket
+    # only expired object must have been removed, cached and dangling remain
     assert await s3.storage.does_object_exist(
-        bucket_id=joint_fixture.bucket_id,
+        bucket_id=bucket_id,
+        object_id=str(cached_object_id),
+    )
+    assert not await s3.storage.does_object_exist(
+        bucket_id=bucket_id,
+        object_id=str(expired_object_id),
+    )
+    assert await s3.storage.does_object_exist(
+        bucket_id=bucket_id,
         object_id=str(stale_object_id),
     )
 
-    # Second run: with remove_dangling_objects=True, stale object should be deleted
+    # second run with remove_dangling_objects
     await data_repository.cleanup_download_buckets(
         object_storages_config=joint_fixture.config,
         remove_dangling_objects=True,
     )
 
-    # Verify stale object has been removed from the download bucket
+    # stale object must have been removed, cached object must still be in place
     assert not await s3.storage.does_object_exist(
-        bucket_id=joint_fixture.bucket_id,
+        bucket_id=bucket_id,
         object_id=str(stale_object_id),
+    )
+    assert await s3.storage.does_object_exist(
+        bucket_id=bucket_id,
+        object_id=str(cached_object_id),
     )

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -17,16 +17,21 @@
 
 import logging
 import re
+from uuid import uuid4
 
 import httpx
 import pytest
 from fastapi import status
 from hexkit.providers.akafka.testutils import ExpectedEvent
-from hexkit.providers.s3.testutils import FileObject
+from hexkit.providers.s3.testutils import FileObject, temp_file_object
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.core.models import FileDownloadServed, NonStagedFileRequested
-from tests_dcs.fixtures.joint import CleanupFixture, PopulatedFixture
+from tests_dcs.fixtures.joint import (
+    CleanupFixture,
+    JointFixture,
+    PopulatedFixture,
+)
 from tests_dcs.fixtures.mock_api.app import router
 from tests_dcs.fixtures.utils import generate_work_order_token
 
@@ -257,3 +262,50 @@ async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
     )
 
     assert expected_message in caplog.records[0].message
+
+
+async def test_bucket_cleanup_dangling_object(joint_fixture: JointFixture, caplog):
+    """Test that stale objects in the download bucket with no DB entry are handled."""
+    stale_object_id = uuid4()
+    with temp_file_object(
+        bucket_id=joint_fixture.bucket_id,
+        object_id=str(stale_object_id),
+    ) as stale_file:
+        await joint_fixture.s3.populate_file_objects([stale_file])
+
+    data_repository = joint_fixture.data_repository
+    s3 = joint_fixture.s3
+    storage_alias = joint_fixture.endpoint_aliases.valid_node
+
+    # First run: without remove_dangling_objects, stale object should be logged and skipped
+    with caplog.at_level(logging.WARNING):
+        await data_repository.cleanup_download_buckets(
+            object_storages_config=joint_fixture.config
+        )
+
+    expected_warning = str(
+        data_repository.CleanupError(
+            object_id=stale_object_id,
+            storage_alias=storage_alias,
+            reason="Object not found in database, skipping.",
+        )
+    )
+    assert any(expected_warning in record.message for record in caplog.records)
+
+    # Stale object should still be present in the download bucket
+    assert await s3.storage.does_object_exist(
+        bucket_id=joint_fixture.bucket_id,
+        object_id=str(stale_object_id),
+    )
+
+    # Second run: with remove_dangling_objects=True, stale object should be deleted
+    await data_repository.cleanup_download_buckets(
+        object_storages_config=joint_fixture.config,
+        remove_dangling_objects=True,
+    )
+
+    # Verify stale object has been removed from the download bucket
+    assert not await s3.storage.does_object_exist(
+        bucket_id=joint_fixture.bucket_id,
+        object_id=str(stale_object_id),
+    )

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -29,8 +29,12 @@ from hexkit.utils import now_utc_ms_prec
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.core import models
+from dcs.core.errors import StorageAliasNotConfiguredError
 from dcs.core.models import FileDownloadServed, NonStagedFileRequested
-from tests_dcs.fixtures.joint import CleanupFixture, JointFixture, PopulatedFixture
+from tests_dcs.fixtures.joint import (
+    CleanupFixture,
+    PopulatedFixture,
+)
 from tests_dcs.fixtures.mock_api.app import router
 from tests_dcs.fixtures.utils import generate_work_order_token
 
@@ -225,62 +229,55 @@ async def test_happy_deletion(
 
 async def test_bucket_cleanup(cleanup_fixture: CleanupFixture, caplog):
     """Test multiple download buckets cleanup handling."""
-    data_repository = cleanup_fixture.joint.data_repository
+    bucket_cleaner = cleanup_fixture.bucket_cleaner
 
-    await data_repository.cleanup_download_buckets(
-        object_storages_config=cleanup_fixture.joint.config
+    await bucket_cleaner.cleanup_download_buckets(
+        object_storages_config=cleanup_fixture.config
     )
 
     cached_id = cleanup_fixture.cached_file_id
     expired_id = cleanup_fixture.expired_file_id
-    s3 = cleanup_fixture.joint.s3
+    s3 = cleanup_fixture.s3
 
     # check if object within threshold is still there
     cached_object = await cleanup_fixture.mongodb_dao.get_by_id(cached_id)
     assert await s3.storage.does_object_exist(
-        bucket_id=cleanup_fixture.joint.bucket_id,
+        bucket_id=cleanup_fixture.bucket_id,
         object_id=str(cached_object.object_id),
     )
 
     # check if expired object has been removed from download bucket
     expired_object = await cleanup_fixture.mongodb_dao.get_by_id(expired_id)
     assert not await s3.storage.does_object_exist(
-        bucket_id=cleanup_fixture.joint.bucket_id,
+        bucket_id=cleanup_fixture.bucket_id,
         object_id=str(expired_object.object_id),
     )
 
     with caplog.at_level(logging.ERROR):
-        await data_repository.cleanup_download_bucket(
-            storage_alias=cleanup_fixture.joint.endpoint_aliases.fake_node
+        await bucket_cleaner.cleanup_download_bucket(
+            storage_alias=cleanup_fixture.endpoint_aliases.fake_node
         )
 
     expected_message = str(
-        data_repository.StorageAliasNotConfiguredError(
-            alias=cleanup_fixture.joint.endpoint_aliases.fake_node
-        )
+        StorageAliasNotConfiguredError(alias=cleanup_fixture.endpoint_aliases.fake_node)
     )
 
     assert expected_message in caplog.records[0].message
 
 
-async def test_bucket_cleanup_dangling_objects(joint_fixture: JointFixture, caplog):
+async def test_bucket_cleanup_dangling_objects(cleanup_fixture: CleanupFixture, caplog):
     """Test that stale objects in the download bucket with no DB entry are handled.
 
     Also verifies that objects with DB entries are handled correctly: expired objects
     (last_accessed beyond the cache timeout) are removed, while objects within the
     threshold are left in place.
     """
-    s3 = joint_fixture.s3
-    bucket_id = joint_fixture.bucket_id
-    data_repository = joint_fixture.data_repository
-    storage_alias = joint_fixture.endpoint_aliases.valid_node
-    timeout_days = joint_fixture.config.download_bucket_cache_timeout
-
-    mongodb_dao = await joint_fixture.mongodb.dao_factory.get_dao(
-        name="drs_objects",
-        dto_model=models.AccessTimeDrsObject,
-        id_field="file_id",
-    )
+    s3 = cleanup_fixture.s3
+    bucket_id = cleanup_fixture.bucket_id
+    bucket_cleaner = cleanup_fixture.bucket_cleaner
+    storage_alias = cleanup_fixture.endpoint_aliases.valid_node
+    timeout_days = cleanup_fixture.config.download_bucket_cache_timeout
+    mongodb_dao = cleanup_fixture.mongodb_dao
 
     # Object with DB entry, within expiration threshold
     cached_object_id = uuid4()
@@ -326,12 +323,12 @@ async def test_bucket_cleanup_dangling_objects(joint_fixture: JointFixture, capl
 
     # first run without remove_dangling_objects
     with caplog.at_level(logging.WARNING):
-        await data_repository.cleanup_download_buckets(
-            object_storages_config=joint_fixture.config
+        await bucket_cleaner.cleanup_download_buckets(
+            object_storages_config=cleanup_fixture.config
         )
 
     expected_warning = str(
-        data_repository.CleanupError(
+        bucket_cleaner.CleanupError(
             object_id=stale_object_id,
             storage_alias=storage_alias,
             reason="Object not found in database, skipping.",
@@ -354,8 +351,8 @@ async def test_bucket_cleanup_dangling_objects(joint_fixture: JointFixture, capl
     )
 
     # second run with remove_dangling_objects
-    await data_repository.cleanup_download_buckets(
-        object_storages_config=joint_fixture.config,
+    await bucket_cleaner.cleanup_download_buckets(
+        object_storages_config=cleanup_fixture.config,
         remove_dangling_objects=True,
     )
 

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -27,11 +27,7 @@ from hexkit.providers.s3.testutils import FileObject, temp_file_object
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.core.models import FileDownloadServed, NonStagedFileRequested
-from tests_dcs.fixtures.joint import (
-    CleanupFixture,
-    JointFixture,
-    PopulatedFixture,
-)
+from tests_dcs.fixtures.joint import CleanupFixture, JointFixture, PopulatedFixture
 from tests_dcs.fixtures.mock_api.app import router
 from tests_dcs.fixtures.utils import generate_work_order_token
 

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -125,7 +125,8 @@ components:
           title: Reason
         secret:
           anyOf:
-          - format: password
+          - contentMediaType: application/octet-stream
+            format: password
             type: string
             writeOnly: true
           - type: 'null'


### PR DESCRIPTION
### Main
- Adds a remove_dangling_objects flag (default: False) to the CLI of `cleanup_outbox` part of the data_repository. If dangling outbox objects are detected, i.e. no DB entry, but present in S3, setting this to true allows for removal of those objects
- Consolidated some split error messages into the actual `OutboxCleanupError` class and changed log levels, where appropriate
- Renamed outbox -> download bucket. This also affects the public CLI API
- Split cleanup from data repository functionality and moved it into its own core/port modules

### Misc
- Bumps patch version of DCS, doesn't touch repo version
- Adds missing changes to the coveralls part of the test action
- Removes remaining mention of IRS
- Fixes FIS OpenAPI doc issue triggered by action
- Adapts failing test cases to work again