### PR TITLE
FIS: Log user agent headers for received requests (GSI-2226)

### DIFF
--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, status
+from fastapi import APIRouter, Body, HTTPException, Request, status
 from pydantic import UUID4
 
 from fis.adapters.inbound.fastapi_ import dummies
@@ -30,6 +30,35 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def log_user_agent_header(
+    request: Request, endpoint_description: str, storage_alias: str = ""
+) -> None:
+    """Log a structured message from the User-Agent header.
+
+    Expects the format 'ClientName/1.0.0'. Adapts the message for a missing or
+    malformed header, or a missing storage alias.
+    """
+    raw_user_agent_header = request.headers.get("user-agent")
+    extra = {"user_agent": raw_user_agent_header}
+    client_name, _, client_version = (raw_user_agent_header or "").partition("/")
+    has_client = bool(client_name and client_version)
+
+    client_part = "from unknown client"
+    if has_client:
+        extra["client_name"] = client_name
+        extra["client_version"] = client_version
+        client_part = f"from {client_name}, version {client_version}"
+
+    alias_part = f", originating from {storage_alias}" if storage_alias else ""
+    log.info(
+        "Received request %s for the %s endpoint%s.",
+        client_part,
+        endpoint_description,
+        alias_part,
+        extra=extra,
+    )
+
+
 @router.get(
     "/health",
     summary="health",
@@ -37,8 +66,9 @@ router = APIRouter()
     status_code=200,
 )
 @TRACER.start_as_current_span("routes.health")
-async def health():
+async def health(request: Request):
     """Used to test if this service is alive"""
+    log_user_agent_header(request, "health")
     return {"status": "OK"}
 
 
@@ -52,10 +82,12 @@ async def health():
 @TRACER.start_as_current_span("routes.list_uploads")
 async def list_uploads(
     storage_alias: str,
+    request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
 ) -> list[models.BaseFileInformation]:
     """Return a list of not-yet-interrogated files for a Data Hub (storage_alias)"""
+    log_user_agent_header(request, "list_uploads", storage_alias)
     try:
         return await interrogator.get_files_not_yet_interrogated(
             storage_alias=storage_alias
@@ -76,6 +108,7 @@ async def list_uploads(
 @TRACER.start_as_current_span("routes.get_removable_files")
 async def get_removable_files(
     storage_alias: str,
+    request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
     object_ids: list[UUID4] = Body(),
@@ -83,6 +116,7 @@ async def get_removable_files(
     """Returns a subset of the provided object ID list containing the IDs of all S3
     objects which may be now removed from the interrogation bucket.
     """
+    log_user_agent_header(request, "get_removable_files", storage_alias)
     try:
         return [
             o for o in object_ids if await interrogator.check_if_removable(object_id=o)
@@ -107,11 +141,13 @@ async def get_removable_files(
 @TRACER.start_as_current_span("routes.post_interrogation_report")
 async def post_interrogation_report(
     storage_alias: str,
+    request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
     report: models.InterrogationReportWithSecret = Body(),
 ) -> None:
     """Post an InterrogationReport"""
+    log_user_agent_header(request, "post_interrogation_report", storage_alias)
     try:
         await interrogator.handle_interrogation_report(report=report)
     except InterrogationHandlerPort.FileNotFoundError as err:

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -40,14 +40,14 @@ def log_user_agent_header(
     """
     raw_user_agent_header = request.headers.get("user-agent")
     extra = {"user_agent": raw_user_agent_header}
-    client_name, _, client_version = (raw_user_agent_header or "").partition("/")
-    has_client = bool(client_name and client_version)
 
-    client_part = "from unknown client"
-    if has_client:
-        extra["client_name"] = client_name
-        extra["client_version"] = client_version
-        client_part = f"from {client_name}, version {client_version}"
+    parts = (raw_user_agent_header or "").split("/")
+
+    client_part = raw_user_agent_header
+    if (len(parts) == 2) and all(parts):
+        extra["client_name"] = parts[0]
+        extra["client_version"] = parts[1]
+        client_part = f"from {parts[0]}, version {parts[1]}"
 
     alias_part = f", originating from {storage_alias}" if storage_alias else ""
     log.info(

--- a/services/fis/tests_fis/unit/test_api.py
+++ b/services/fis/tests_fis/unit/test_api.py
@@ -78,8 +78,8 @@ async def test_health(
 
     # No User-Agent header → logged as unknown client, no storage alias
     with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
-        await rest_client.get(url, headers={"User-Agent": "Some other thing"})
-    assert "unknown client" in caplog.text
+        await rest_client.get(url, headers={"User-Agent": "Boto3/1.2.3 Python/3.12"})
+    assert "Boto3/1.2.3 Python/3.12" in caplog.text
     assert "health endpoint" in caplog.text
     assert "originating from" not in caplog.text
     caplog.clear()

--- a/services/fis/tests_fis/unit/test_api.py
+++ b/services/fis/tests_fis/unit/test_api.py
@@ -15,6 +15,7 @@
 
 """Unit tests for the API"""
 
+import logging
 from uuid import uuid4
 
 import pytest
@@ -63,15 +64,40 @@ def jwt_factory(data_hub_jwks):
     return JWTTestFactory(data_hub_jwks)
 
 
-async def test_health(rest_client: AsyncTestClient, rig: JointRig):
+ROUTES_LOGGER = "fis.adapters.inbound.fastapi_.routes"
+TEST_USER_AGENT = "DataHubFileService/1.0.0"
+
+
+async def test_health(
+    rest_client: AsyncTestClient, rig: JointRig, caplog: pytest.LogCaptureFixture
+):
     """Test the GET /health endpoint"""
     url = "/health"
     response = await rest_client.get(url)
     assert response.status_code == 200
 
+    # No User-Agent header → logged as unknown client, no storage alias
+    with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
+        await rest_client.get(url, headers={"User-Agent": "Some other thing"})
+    assert "unknown client" in caplog.text
+    assert "health endpoint" in caplog.text
+    assert "originating from" not in caplog.text
+    caplog.clear()
+
+    # With User-Agent header → client name and version logged, still no storage alias
+    with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
+        await rest_client.get(url, headers={"User-Agent": TEST_USER_AGENT})
+    assert "DataHubFileService" in caplog.text
+    assert "1.0.0" in caplog.text
+    assert "health endpoint" in caplog.text
+    assert "originating from" not in caplog.text
+
 
 async def test_list_uploads(
-    rest_client: AsyncTestClient, rig: JointRig, jwt_factory: JWTTestFactory
+    rest_client: AsyncTestClient,
+    rig: JointRig,
+    jwt_factory: JWTTestFactory,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test the GET /storages/{storage_alias}/uploads endpoint"""
     url = f"/storages/{HUB1}/uploads"
@@ -107,9 +133,22 @@ async def test_list_uploads(
     for a, b in zip(files_received_sorted, files_expected_sorted, strict=True):
         assert a.model_dump() == b.model_dump()
 
+    # Verify user agent logging includes client name and storage alias
+    with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
+        await rest_client.get(
+            url,
+            headers={**jwt_factory.auth_header(HUB1), "User-Agent": TEST_USER_AGENT},
+        )
+    assert "DataHubFileService" in caplog.text
+    assert "1.0.0" in caplog.text
+    assert HUB1 in caplog.text
+
 
 async def test_get_removable_files(
-    rest_client: AsyncTestClient, rig: JointRig, jwt_factory: JWTTestFactory
+    rest_client: AsyncTestClient,
+    rig: JointRig,
+    jwt_factory: JWTTestFactory,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test the POST /storages/{storage_alias}/uploads/can_remove endpoint"""
     url = f"/storages/{HUB1}/uploads/can_remove"
@@ -165,11 +204,23 @@ async def test_get_removable_files(
     response = await rest_client.post(url, json=["blahblah"], headers=correct_headers)
     assert response.status_code == 422
 
+    # Verify user agent logging includes client name and storage alias
+    with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
+        await rest_client.post(
+            url,
+            json=[],
+            headers={**correct_headers, "User-Agent": TEST_USER_AGENT},
+        )
+    assert "DataHubFileService" in caplog.text
+    assert "1.0.0" in caplog.text
+    assert HUB1 in caplog.text
+
 
 async def test_post_interrogation_report(
     rest_client: AsyncTestClient,
     rig: JointRig,
     jwt_factory: JWTTestFactory,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test the POST /storages/{storage_alias}/interrogation-reports endpoint"""
     url = f"/storages/{HUB1}/interrogation-reports"
@@ -270,3 +321,14 @@ async def test_post_interrogation_report(
         url, json=invalid_failure_report, headers=correct_headers
     )
     assert response.status_code == 422
+
+    # Verify user agent logging includes client name and storage alias
+    with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
+        await rest_client.post(
+            url,
+            json=success_report,
+            headers={**correct_headers, "User-Agent": TEST_USER_AGENT},
+        )
+    assert "DataHubFileService" in caplog.text
+    assert "1.0.0" in caplog.text
+    assert HUB1 in caplog.text


### PR DESCRIPTION
This logs the received user-agent headers along with the data hub alias (storage_alias) for FIS's HTTP API.