### PR TITLE
[minor ver bump] UCS: Fold S3UploadDetails into FileUpload for simpler code (GSI-2253)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "10.0.0"
+version = "10.1.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "10.0.0"
+version = "10.1.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.19",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:11.0.0
+docker pull ghga/upload-controller-service:11.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:11.0.0 .
+docker build -t ghga/upload-controller-service:11.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:11.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:11.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -53,6 +53,13 @@ components:
           description: The name of the bucket where the file is currently stored
           title: Bucket Id
           type: string
+        completed:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: When the S3 multipart upload was completed
+          title: Completed
         decrypted_sha256:
           anyOf:
           - type: string
@@ -102,6 +109,11 @@ components:
             the inbox.
           title: Inbox Upload Completed
           type: boolean
+        initiated:
+          description: When the S3 multipart upload was initiated
+          format: date-time
+          title: Initiated
+          type: string
         object_id:
           description: The ID of the file specific to its S3 bucket
           format: uuid4
@@ -112,6 +124,10 @@ components:
             smaller)
           title: Part Size
           type: integer
+        s3_upload_id:
+          description: The ID of the S3 multipart upload
+          title: S3 Upload Id
+          type: string
         secret_id:
           anyOf:
           - type: string
@@ -151,6 +167,8 @@ components:
       - decrypted_size
       - encrypted_size
       - part_size
+      - s3_upload_id
+      - initiated
       title: file_upload
       type: object
     FileUploadCompletionRequest:
@@ -433,36 +451,6 @@ components:
       - file_alias
       title: HttpOrphanedMultipartUploadErrorData
       type: object
-    HttpS3UploadDetailsNotFoundError:
-      additionalProperties: false
-      properties:
-        data:
-          $ref: '#/components/schemas/HttpS3UploadDetailsNotFoundErrorData'
-        description:
-          description: A human readable message to the client explaining the cause
-            of the exception.
-          title: Description
-          type: string
-        exception_id:
-          const: s3UploadDetailsNotFound
-          title: Exception Id
-          type: string
-      required:
-      - data
-      - description
-      - exception_id
-      title: HttpS3UploadDetailsNotFoundError
-      type: object
-    HttpS3UploadDetailsNotFoundErrorData:
-      properties:
-        file_id:
-          format: uuid4
-          title: File Id
-          type: string
-      required:
-      - file_id
-      title: HttpS3UploadDetailsNotFoundErrorData
-      type: object
     HttpS3UploadNotFoundError:
       additionalProperties: false
       properties:
@@ -607,7 +595,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 11.0.0
+  version: 11.1.0
 openapi: 3.1.0
 paths:
   /boxes:
@@ -878,11 +866,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpS3UploadDetailsNotFoundError'
+                $ref: '#/components/schemas/HttpBoxNotFoundError'
           description: 'Exceptions by ID:
 
-            - s3UploadDetailsNotFound: S3 upload details for the file could not be
-            found.'
+            - boxNotFound: The FileUploadBox with the given ID does not exist.'
         '409':
           content:
             application/json:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "11.0.0"
+version = "11.1.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -144,25 +144,6 @@ class HttpOrphanedMultipartUploadError(HttpCustomExceptionBase):
         )
 
 
-class HttpS3UploadDetailsNotFoundError(HttpCustomExceptionBase):
-    """Thrown when S3 upload details for a file cannot be found."""
-
-    exception_id = "s3UploadDetailsNotFound"
-
-    class DataModel(BaseModel):
-        """Model for exception data"""
-
-        file_id: UUID4
-
-    def __init__(self, *, file_id: UUID4, status_code: int = 404):
-        """Construct message and init the exception."""
-        super().__init__(
-            status_code=status_code,
-            description=(f"S3 upload details for file ID {file_id} were not found."),
-            data={"file_id": str(file_id)},
-        )
-
-
 class HttpS3UploadNotFoundError(HttpCustomExceptionBase):
     """Thrown when an S3 multipart upload cannot be found."""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -80,13 +80,6 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpOrphanedMultipartUploadError.get_body_model(),
     },
-    "s3UploadDetailsNotFound": {
-        "description": (
-            "Exceptions by ID:"
-            + "\n- s3UploadDetailsNotFound: S3 upload details for the file could not be found."
-        ),
-        "model": http_exceptions.HttpS3UploadDetailsNotFoundError.get_body_model(),
-    },
     "s3UploadNotFound": {
         "description": (
             "Exceptions by ID:"
@@ -360,7 +353,7 @@ async def create_file_upload(
     response_description="The pre-signed URL for uploading the file part",
     responses={
         status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["noSuchStorage"],
-        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["s3UploadDetailsNotFound"]
+        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["fileUploadNotFound"]
         | ERROR_RESPONSES["s3UploadNotFound"],
     },
 )
@@ -390,10 +383,8 @@ async def get_part_upload_url(
         presigned_url = await upload_controller.get_part_upload_url(
             file_id=file_id, part_no=part_no
         )
-    except UploadControllerPort.S3UploadDetailsNotFoundError as error:
-        raise http_exceptions.HttpS3UploadDetailsNotFoundError(
-            file_id=file_id
-        ) from error
+    except UploadControllerPort.FileUploadNotFound as error:
+        raise http_exceptions.HttpFileUploadNotFoundError(file_id=file_id) from error
     except UploadControllerPort.UnknownStorageAliasError as error:
         raise http_exceptions.HttpUnknownStorageAliasError() from error
     except UploadControllerPort.UploadSessionNotFoundError as error:
@@ -414,7 +405,6 @@ async def get_part_upload_url(
     responses={
         status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["checksumMismatch"],
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"]
-        | ERROR_RESPONSES["s3UploadDetailsNotFound"]
         | ERROR_RESPONSES["fileUploadNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES[
@@ -459,10 +449,6 @@ async def complete_file_upload(
         ) from error
     except UploadControllerPort.FileUploadNotFound as error:
         raise http_exceptions.HttpFileUploadNotFoundError(file_id=file_id) from error
-    except UploadControllerPort.S3UploadDetailsNotFoundError as error:
-        raise http_exceptions.HttpS3UploadDetailsNotFoundError(
-            file_id=file_id
-        ) from error
     except UploadControllerPort.UploadCompletionError as error:
         raise http_exceptions.HttpUploadCompletionError(
             box_id=box_id, file_id=file_id
@@ -482,8 +468,7 @@ async def complete_file_upload(
     response_description="FileUpload removed successfully",
     responses={
         status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["noSuchStorage"],
-        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"]
-        | ERROR_RESPONSES["s3UploadDetailsNotFound"],
+        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES["uploadAbortError"],
     },
@@ -513,10 +498,6 @@ async def remove_file_upload(
     except UploadControllerPort.BoxStateError as error:
         raise http_exceptions.HttpBoxStateError(
             box_id=box_id, box_state=error.box_state
-        ) from error
-    except UploadControllerPort.S3UploadDetailsNotFoundError as error:
-        raise http_exceptions.HttpS3UploadDetailsNotFoundError(
-            file_id=file_id
         ) from error
     except UploadControllerPort.UnknownStorageAliasError as error:
         raise http_exceptions.HttpUnknownStorageAliasError() from error

--- a/services/ucs/src/ucs/adapters/outbound/dao.py
+++ b/services/ucs/src/ucs/adapters/outbound/dao.py
@@ -16,28 +16,15 @@
 """DAO translators for accessing the database."""
 
 from ghga_event_schemas.configs import FileUploadBoxEventsConfig, FileUploadEventsConfig
-from hexkit.protocols.dao import DaoFactoryProtocol
 from hexkit.protocols.daopub import DaoPublisher, DaoPublisherFactoryProtocol
 from hexkit.providers.mongodb import MongoDbIndex
 
 from ucs.constants import (
     FILE_UPLOAD_BOXES_COLLECTION,
     FILE_UPLOADS_COLLECTION,
-    S3_UPLOAD_DETAILS_COLLECTION,
 )
-from ucs.core.models import FileUpload, FileUploadBox, S3UploadDetails
-from ucs.ports.outbound.dao import S3UploadDetailsDao, UploadDaoPublisherFactoryPort
-
-
-async def get_s3_upload_details_dao(
-    *, dao_factory: DaoFactoryProtocol
-) -> S3UploadDetailsDao:
-    """Produce as S3UploadDetailsDao"""
-    return await dao_factory.get_dao(
-        name=S3_UPLOAD_DETAILS_COLLECTION,
-        dto_model=S3UploadDetails,
-        id_field="file_id",
-    )
+from ucs.core.models import FileUpload, FileUploadBox
+from ucs.ports.outbound.dao import UploadDaoPublisherFactoryPort
 
 
 class UploadDaoConfig(FileUploadBoxEventsConfig, FileUploadEventsConfig):

--- a/services/ucs/src/ucs/adapters/outbound/dao.py
+++ b/services/ucs/src/ucs/adapters/outbound/dao.py
@@ -26,6 +26,14 @@ from ucs.constants import (
 from ucs.core.models import FileUpload, FileUploadBox
 from ucs.ports.outbound.dao import UploadDaoPublisherFactoryPort
 
+# The following FileUpload fields are UCS-only and excluded from outbox events
+FIELDS_NOT_PUBLISHED: set[str] = {
+    "inbox_upload_completed",
+    "s3_upload_id",
+    "initiated",
+    "completed",
+}
+
 
 class UploadDaoConfig(FileUploadBoxEventsConfig, FileUploadEventsConfig):
     """Topic configuration for the published DTOs"""
@@ -64,7 +72,7 @@ class UploadDaoPublisherFactory(UploadDaoPublisherFactoryPort):
             name=FILE_UPLOADS_COLLECTION,
             id_field="id",
             dto_model=FileUpload,
-            dto_to_event=lambda x: x.model_dump(exclude={"inbox_upload_completed"}),
+            dto_to_event=lambda x: x.model_dump(exclude=FIELDS_NOT_PUBLISHED),
             event_topic=self._file_upload_topic,
             autopublish=True,
             indexes=[

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -22,7 +22,7 @@ from hexkit.protocols.objstorage import ObjectStorageProtocol
 from pydantic import UUID4
 
 from ucs.config import Config
-from ucs.core.models import FileUpload, S3UploadDetails
+from ucs.core.models import FileUpload, FileUploadBasics
 from ucs.ports.outbound.storage import S3ClientPort
 
 log = logging.getLogger(__name__)
@@ -63,7 +63,9 @@ class S3Client(S3ClientPort):
         bucket_id, _ = self._get_bucket_and_storage(storage_alias)
         return bucket_id
 
-    async def init_multipart_upload(self, *, file_upload: FileUpload) -> str:
+    async def init_multipart_upload(
+        self, *, file_upload_basics: FileUploadBasics
+    ) -> str:
         """Initiate a new multipart upload for a FileUpload.
 
         Returns a str containing the multipart upload ID.
@@ -72,9 +74,11 @@ class S3Client(S3ClientPort):
             `UnknownStorageAliasError` if the storage alias is not known.
             `OrphanedMultipartUploadError` if an S3 upload is already in progress.
         """
-        bucket_id = file_upload.bucket_id
-        object_id = file_upload.object_id
-        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
+        bucket_id = file_upload_basics.bucket_id
+        object_id = file_upload_basics.object_id
+        _, object_storage = self._get_bucket_and_storage(
+            file_upload_basics.storage_alias
+        )
 
         try:
             s3_upload_id = await object_storage.init_multipart_upload(
@@ -83,18 +87,18 @@ class S3Client(S3ClientPort):
             log.info(
                 "S3 multipart upload %s created for file ID %s (file alias %s)",
                 s3_upload_id,
-                file_upload.id,
-                file_upload.alias,
+                file_upload_basics.id,
+                file_upload_basics.alias,
             )
             return s3_upload_id
         except object_storage.MultiPartUploadAlreadyExistsError as err:
             #  See the long note on UploadController.initiate_file_upload()
             raise self.OrphanedMultipartUploadError(
-                file_id=file_upload.id, bucket_id=bucket_id
+                file_id=file_upload_basics.id, bucket_id=bucket_id
             ) from err
 
     async def get_part_upload_url(
-        self, *, s3_upload_details: S3UploadDetails, part_no: int
+        self, *, file_upload: FileUpload, part_no: int
     ) -> str:
         """Get a pre-signed URL to upload a specific part of a multipart upload.
 
@@ -102,36 +106,32 @@ class S3Client(S3ClientPort):
             `UnknownStorageAliasError` if the storage alias is not known.
             `S3UploadNotFoundError` if the multipart upload can't be found in S3.
         """
-        _, object_storage = self._get_bucket_and_storage(
-            s3_upload_details.storage_alias
-        )
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
         try:
             return await object_storage.get_part_upload_url(
-                upload_id=s3_upload_details.s3_upload_id,
-                bucket_id=s3_upload_details.bucket_id,
-                object_id=str(s3_upload_details.object_id),
+                upload_id=file_upload.s3_upload_id,
+                bucket_id=file_upload.bucket_id,
+                object_id=str(file_upload.object_id),
                 part_number=part_no,
             )
         except object_storage.MultiPartUploadNotFoundError as err:
             error = self.S3UploadNotFoundError(
-                s3_upload_id=s3_upload_details.s3_upload_id,
-                bucket_id=s3_upload_details.bucket_id,
+                s3_upload_id=file_upload.s3_upload_id,
+                bucket_id=file_upload.bucket_id,
             )
             log.error(
                 error,
                 exc_info=True,
                 extra={
-                    "s3_upload_id": s3_upload_details.s3_upload_id,
-                    "bucket_id": s3_upload_details.bucket_id,
-                    "file_id": s3_upload_details.file_id,
-                    "storage_alias": s3_upload_details.storage_alias,
+                    "s3_upload_id": file_upload.s3_upload_id,
+                    "bucket_id": file_upload.bucket_id,
+                    "file_id": file_upload.id,
+                    "storage_alias": file_upload.storage_alias,
                 },
             )
             raise error from err
 
-    async def complete_multipart_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def complete_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Instruct S3 to assemble all uploaded parts into the final object.
 
         Recovers idempotently if the upload was already completed (object exists).
@@ -140,13 +140,11 @@ class S3Client(S3ClientPort):
             `UnknownStorageAliasError` if the storage alias is not known.
             `S3UploadCompletionError` if the upload cannot be completed or found.
         """
-        bucket_id = s3_upload_details.bucket_id
-        object_id = str(s3_upload_details.object_id)
-        s3_upload_id = s3_upload_details.s3_upload_id
-        file_id = s3_upload_details.file_id
-        _, object_storage = self._get_bucket_and_storage(
-            s3_upload_details.storage_alias
-        )
+        bucket_id = file_upload.bucket_id
+        object_id = str(file_upload.object_id)
+        s3_upload_id = file_upload.s3_upload_id
+        file_id = file_upload.id
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
 
         try:
             await object_storage.complete_multipart_upload(
@@ -171,7 +169,7 @@ class S3Client(S3ClientPort):
                     + " since the expected object with ID %s exists. Proceeding to"
                     + " update DB.",
                     s3_upload_id,
-                    s3_upload_details.object_id,
+                    file_upload.object_id,
                 )
             else:
                 error = self.S3UploadCompletionError(
@@ -184,28 +182,26 @@ class S3Client(S3ClientPort):
                         "s3_upload_id": s3_upload_id,
                         "bucket_id": bucket_id,
                         "file_id": file_id,
-                        "storage_alias": s3_upload_details.storage_alias,
+                        "storage_alias": file_upload.storage_alias,
                     },
                 )
                 raise error from err
 
     async def get_object_etag(
-        self, *, s3_upload_details: S3UploadDetails, object_id: UUID4
+        self, *, file_upload: FileUpload, object_id: UUID4
     ) -> str:
         """Return the ETag of an object in the inbox bucket (quotes stripped).
 
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
         """
-        _, object_storage = self._get_bucket_and_storage(
-            s3_upload_details.storage_alias
-        )
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
         etag = await object_storage.get_object_etag(
-            bucket_id=s3_upload_details.bucket_id, object_id=str(object_id)
+            bucket_id=file_upload.bucket_id, object_id=str(object_id)
         )
         return etag.strip('"')
 
-    async def delete_inbox_file(self, *, s3_upload_details: S3UploadDetails) -> None:
+    async def delete_inbox_file(self, *, file_upload: FileUpload) -> None:
         """Delete a fully uploaded file from the inbox, or abort any stale multipart.
 
         If the object exists it is deleted. If only an in-progress multipart upload
@@ -215,13 +211,11 @@ class S3Client(S3ClientPort):
             `UnknownStorageAliasError` if the storage alias is not known.
             `S3UploadAbortError` if an abort is required but fails.
         """
-        object_id = str(s3_upload_details.object_id)
-        s3_upload_id = s3_upload_details.s3_upload_id
-        bucket_id = s3_upload_details.bucket_id
-        file_id = s3_upload_details.file_id
-        _, object_storage = self._get_bucket_and_storage(
-            s3_upload_details.storage_alias
-        )
+        object_id = str(file_upload.object_id)
+        s3_upload_id = file_upload.s3_upload_id
+        bucket_id = file_upload.bucket_id
+        file_id = file_upload.id
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
 
         if await object_storage.does_object_exist(
             bucket_id=bucket_id, object_id=object_id
@@ -262,26 +256,22 @@ class S3Client(S3ClientPort):
                         "file_id": file_id,
                         "object_id": object_id,
                         "bucket_id": bucket_id,
-                        "storage_alias": s3_upload_details.storage_alias,
+                        "storage_alias": file_upload.storage_alias,
                     },
                 )
                 raise error from err
 
-    async def abort_multipart_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def abort_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Abort an in-progress multipart upload. Tolerates a missing upload.
 
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
             `S3UploadAbortError` if the abort fails.
         """
-        file_id = s3_upload_details.file_id
-        s3_upload_id = s3_upload_details.s3_upload_id
-        bucket_id = s3_upload_details.bucket_id
-        _, object_storage = self._get_bucket_and_storage(
-            s3_upload_details.storage_alias
-        )
+        file_id = file_upload.id
+        s3_upload_id = file_upload.s3_upload_id
+        bucket_id = file_upload.bucket_id
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
 
         try:
             log.debug(
@@ -290,7 +280,7 @@ class S3Client(S3ClientPort):
             await object_storage.abort_multipart_upload(
                 upload_id=s3_upload_id,
                 bucket_id=bucket_id,
-                object_id=str(s3_upload_details.object_id),
+                object_id=str(file_upload.object_id),
             )
             log.info("Successfully aborted S3 upload %s", s3_upload_id)
         except object_storage.MultiPartUploadAbortError as err:
@@ -303,7 +293,7 @@ class S3Client(S3ClientPort):
                 extra={
                     "file_id": file_id,
                     "bucket_id": bucket_id,
-                    "storage_alias": s3_upload_details.storage_alias,
+                    "storage_alias": file_upload.storage_alias,
                     "s3_upload_id": s3_upload_id,
                 },
             )

--- a/services/ucs/src/ucs/constants.py
+++ b/services/ucs/src/ucs/constants.py
@@ -18,6 +18,5 @@ from opentelemetry import trace
 
 SERVICE_NAME = "ucs"
 TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
-S3_UPLOAD_DETAILS_COLLECTION = "s3UploadDetails"
 FILE_UPLOAD_BOXES_COLLECTION = "fileUploadBoxes"
 FILE_UPLOADS_COLLECTION = "fileUploads"

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -16,7 +16,6 @@
 """Implements the UploadController class to manage file uploads"""
 
 import logging
-from contextlib import suppress
 from typing import Any
 from uuid import uuid4
 
@@ -30,13 +29,12 @@ from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4
 
 from ucs.config import Config
-from ucs.core.models import FileUpload, FileUploadBox, S3UploadDetails
+from ucs.core.models import FileUpload, FileUploadBasics, FileUploadBox
 from ucs.ports.inbound.controller import UploadControllerPort
 from ucs.ports.outbound.dao import (
     FileUploadBoxDao,
     FileUploadDao,
     ResourceNotFoundError,
-    S3UploadDetailsDao,
 )
 from ucs.ports.outbound.storage import S3ClientPort
 
@@ -52,54 +50,29 @@ class UploadController(UploadControllerPort):
         config: Config,
         file_upload_box_dao: FileUploadBoxDao,
         file_upload_dao: FileUploadDao,
-        s3_upload_details_dao: S3UploadDetailsDao,
         s3_client: S3ClientPort,
     ):
         self._config = config
         self._file_upload_box_dao = file_upload_box_dao
         self._file_upload_dao = file_upload_dao
-        self._s3_upload_details_dao = s3_upload_details_dao
         self._s3_client = s3_client
 
-    async def _insert_file_upload_if_new(  # noqa: PLR0913
+    async def _insert_file_upload(
         self,
         *,
         box: FileUploadBox,
-        alias: str,
-        bucket_id: str,
-        decrypted_size: int,
-        encrypted_size: int,
-        part_size: int,
-    ) -> FileUpload:
-        """Create a new FileUpload for the provided file alias and return it.
+        file_upload: FileUpload,
+    ) -> None:
+        """Insert a new FileUpload, replacing a failed/cancelled one if needed.
 
-        This method tries to insert a new FileUpload with random UUID4s for file_id
-        and object_id.
-
-        Raises `FileUploadAlreadyExists` if there's already a FileUpload for this alias
-        and box_id.
+        Raises `FileUploadAlreadyExists` if an active FileUpload already exists for
+        this alias and box_id.
         """
         box_id = box.id
-        file_id = uuid4()
-        object_id = uuid4()
+        alias = file_upload.alias
 
         try:
-            file_upload = FileUpload(
-                id=file_id,
-                box_id=box_id,
-                alias=alias,
-                state="init",
-                state_updated=now_utc_ms_prec(),
-                storage_alias=box.storage_alias,
-                bucket_id=bucket_id,
-                object_id=object_id,
-                decrypted_size=decrypted_size,
-                encrypted_size=encrypted_size,
-                part_size=part_size,
-            )
-
             await self._file_upload_dao.insert(file_upload)
-            return file_upload
         except UniqueConstraintViolationError as err:
             # If there's already a FileUpload in the box with this alias, retrieve it
             try:
@@ -137,9 +110,6 @@ class UploadController(UploadControllerPort):
                 log.error(error, extra=logging_extras)
                 raise error from err
 
-            # If successful, return the new file upload instance
-            return file_upload
-
     async def _try_to_replace_upload(
         self,
         box: FileUploadBox,
@@ -168,17 +138,6 @@ class UploadController(UploadControllerPort):
             new_upload.id,
             extra=logging_extras,
         )
-        # Make sure to delete S3UploadDetails for the old FileUpload and log it
-        with suppress(ResourceNotFoundError):
-            await self._s3_upload_details_dao.delete(existing_upload.id)
-            log.info(
-                "Cleaned out S3UploadDetails for old, %s FileUpload %s because it"
-                + " is being superseded by FileUpload %s.",
-                existing_upload.state,
-                existing_upload.id,
-                new_upload.id,
-                extra=logging_extras,
-            )
         await self._file_upload_dao.delete(existing_upload.id)
         await self._file_upload_dao.insert(new_upload)
         return True
@@ -206,9 +165,7 @@ class UploadController(UploadControllerPort):
 
         return box
 
-    async def _remove_completed_file_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def _remove_completed_file_upload(self, *, file_upload: FileUpload) -> None:
         """Delete a completely uploaded file from S3 or abort any stale multipart.
 
         Does not delete any data from the DB.
@@ -219,21 +176,19 @@ class UploadController(UploadControllerPort):
           If this occurs, developer intervention might be required.
         """
         try:
-            await self._s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+            await self._s3_client.delete_inbox_file(file_upload=file_upload)
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(
-                storage_alias=s3_upload_details.storage_alias
+                storage_alias=file_upload.storage_alias
             ) from err
         except S3ClientPort.S3UploadAbortError as err:
             raise self.UploadAbortError(
-                file_id=s3_upload_details.file_id,
-                s3_upload_id=s3_upload_details.s3_upload_id,
-                bucket_id=s3_upload_details.bucket_id,
+                file_id=file_upload.id,
+                s3_upload_id=file_upload.s3_upload_id,
+                bucket_id=file_upload.bucket_id,
             ) from err
 
-    async def _remove_incomplete_file_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def _remove_incomplete_file_upload(self, *, file_upload: FileUpload) -> None:
         """Abort an incomplete S3 multipart upload.
 
         Does not delete any data from the DB.
@@ -243,18 +198,16 @@ class UploadController(UploadControllerPort):
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         """
         try:
-            await self._s3_client.abort_multipart_upload(
-                s3_upload_details=s3_upload_details
-            )
+            await self._s3_client.abort_multipart_upload(file_upload=file_upload)
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(
-                storage_alias=s3_upload_details.storage_alias
+                storage_alias=file_upload.storage_alias
             ) from err
         except S3ClientPort.S3UploadAbortError as err:
             raise self.UploadAbortError(
-                file_id=s3_upload_details.file_id,
-                s3_upload_id=s3_upload_details.s3_upload_id,
-                bucket_id=s3_upload_details.bucket_id,
+                file_id=file_upload.id,
+                s3_upload_id=file_upload.s3_upload_id,
+                bucket_id=file_upload.bucket_id,
             ) from err
 
     async def initiate_file_upload(
@@ -278,10 +231,8 @@ class UploadController(UploadControllerPort):
         - `UploadAlreadyInProgressError` if an upload is already in progress.
         """
         extra: dict[str, Any] = {"box_id": box_id, "alias": alias}
-        # Get the box and create the FileUpload
+        # Get the box and resolve S3 storage details
         box = await self._get_unlocked_box(box_id=box_id)
-
-        # Get the S3 storage details
         storage_alias = box.storage_alias
         try:
             bucket_id = self._s3_client.get_bucket_id_for_alias(
@@ -292,60 +243,59 @@ class UploadController(UploadControllerPort):
         extra["storage_alias"] = storage_alias
         extra["bucket_id"] = bucket_id
 
-        initiated = now_utc_ms_prec()  # Generate timestamp early to minimize error risk
-        file_upload = await self._insert_file_upload_if_new(
-            box=box,
+        file_id = uuid4()
+        object_id = uuid4()
+        initiated = now_utc_ms_prec()
+
+        file_upload_basics = FileUploadBasics(
+            id=file_id,
+            box_id=box.id,
             alias=alias,
+            storage_alias=storage_alias,
             bucket_id=bucket_id,
+            object_id=object_id,
             decrypted_size=decrypted_size,
             encrypted_size=encrypted_size,
             part_size=part_size,
         )
-        file_id = file_upload.id
-        object_id = file_upload.object_id
-        log.info("FileUpload %s added for alias %s.", file_id, alias, extra=extra)
 
-        # Initiate a new multipart file upload on the S3 instance
+        # Initiate a new multipart file upload on S3
         try:
             s3_upload_id = await self._s3_client.init_multipart_upload(
-                file_upload=file_upload
+                file_upload_basics=file_upload_basics
             )
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(storage_alias=storage_alias) from err
         except S3ClientPort.OrphanedMultipartUploadError as err:
-            #  _insert_file_upload_if_new precludes the existence of a FileUpload
-            #  with the same `file_id`. If there's no FileUpload with the same file_id,
-            #  then there cannot be an upload for said file_id. Since each FileUpload
-            #  gets a freshly generated object_id, a collision here would be extremely
-            #  unlikely. The most likely cause is a crash between creating the S3 upload
-            #  and inserting the S3UploadDetails. We can't assign S3 upload IDs, so if
-            #  that data isn't saved to the DB, it is only preserved in the logs. There
-            #  is no straightforward way to get the upload ID programmatically, so we
-            #  can't auto-abort it, either. In this case someone will have to
-            #  manually intervene to cancel the upload. We will delete the FileUpload,
-            #  however, so the user can immediately retry.
+            #  Each upload uses a freshly generated object_id, so a collision is
+            #  extremely unlikely. The most likely cause is a crash between a previous
+            #  S3 init and the subsequent DB insert. We can't assign S3 upload IDs, so
+            #  that data isn't recoverable programmatically — manual intervention is
+            #  needed to cancel the orphaned upload.
             log.critical(str(err), extra=extra)
-            await self._file_upload_dao.delete(file_id)
-            log.info("Cleanup performed - FileUpload %s deleted.", file_id)
             raise self.UploadAlreadyInProgressError(
                 file_id=file_id, bucket_id=bucket_id
             ) from err
 
-        # Insert S3UploadDetails. Don't check for duplicate because insert only
-        #  occurs in this method and only if the FileUpload alias is new. The check for
-        #  duplicates is performed in `_insert_validated_file_upload`.
-        s3_upload = S3UploadDetails(
-            file_id=file_id,
+        # Build and insert the complete FileUpload record
+        file_upload = FileUpload(
+            id=file_id,
+            box_id=box.id,
+            alias=alias,
+            state="init",
+            state_updated=now_utc_ms_prec(),
             storage_alias=storage_alias,
             bucket_id=bucket_id,
             object_id=object_id,
+            decrypted_size=decrypted_size,
+            encrypted_size=encrypted_size,
+            part_size=part_size,
             s3_upload_id=s3_upload_id,
             initiated=initiated,
         )
-        await self._s3_upload_details_dao.insert(s3_upload)
+        await self._insert_file_upload(box=box, file_upload=file_upload)
         log.info(
-            "FileUpload object with ID %s created for file alias %s. The S3 multipart"
-            + " upload ID is %s.",
+            "FileUpload %s created for alias %s with S3 multipart upload ID %s.",
             file_id,
             alias,
             s3_upload_id,
@@ -359,29 +309,28 @@ class UploadController(UploadControllerPort):
         the given number of the upload with the given file ID.
 
         Raises:
-        - `S3UploadDetailsNotFoundError` if no upload details are found.
+        - `FileUploadNotFound` if the FileUpload is not found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadSessionNotFoundError` if the upload session can't be found.
         """
-        # Retrieve the S3Upload record for this file ID
         try:
-            s3_upload_details = await self._s3_upload_details_dao.get_by_id(file_id)
+            file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
-            error = self.S3UploadDetailsNotFoundError(file_id=file_id)
+            error = self.FileUploadNotFound(file_id=file_id)
             log.error(
                 error,
                 extra={"file_id": file_id, "part_no": part_no},
             )
             raise error from err
 
-        s3_upload_id = s3_upload_details.s3_upload_id
+        s3_upload_id = file_upload.s3_upload_id
         try:
             return await self._s3_client.get_part_upload_url(
-                s3_upload_details=s3_upload_details, part_no=part_no
+                file_upload=file_upload, part_no=part_no
             )
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(
-                storage_alias=s3_upload_details.storage_alias
+                storage_alias=file_upload.storage_alias
             ) from err
         except S3ClientPort.S3UploadNotFoundError as err:
             log.error(
@@ -389,18 +338,17 @@ class UploadController(UploadControllerPort):
                 extra={
                     "s3_upload_id": s3_upload_id,
                     "file_id": file_id,
-                    "bucket_id": s3_upload_details.bucket_id,
+                    "bucket_id": file_upload.bucket_id,
                     "part_no": part_no,
-                    "storage_alias": s3_upload_details.storage_alias,
+                    "storage_alias": file_upload.storage_alias,
                 },
             )
             raise self.UploadSessionNotFoundError(
-                bucket_id=s3_upload_details.bucket_id, s3_upload_id=s3_upload_id
+                bucket_id=file_upload.bucket_id, s3_upload_id=s3_upload_id
             ) from err
 
     async def _compare_checksums(
         self,
-        s3_upload_details: S3UploadDetails,
         file_upload: FileUpload,
         expected_checksum: str,
     ) -> None:
@@ -415,11 +363,11 @@ class UploadController(UploadControllerPort):
         object_id = file_upload.object_id
         try:
             actual_checksum = await self._s3_client.get_object_etag(
-                s3_upload_details=s3_upload_details, object_id=object_id
+                file_upload=file_upload, object_id=object_id
             )
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(
-                storage_alias=s3_upload_details.storage_alias
+                storage_alias=file_upload.storage_alias
             ) from err
 
         if actual_checksum != expected_checksum:
@@ -431,7 +379,7 @@ class UploadController(UploadControllerPort):
             log.info("Marked FileUpload %s as 'failed'.", file_id)
             error = self.ChecksumMismatchError(file_id=file_id)
             extra = {
-                "bucket_id": s3_upload_details.bucket_id,
+                "bucket_id": file_upload.bucket_id,
                 "file_id": file_id,
                 "object_id": object_id,
                 "expected_checksum": expected_checksum,
@@ -456,7 +404,6 @@ class UploadController(UploadControllerPort):
 
         Raises:
         - `FileUploadNotFound` if the FileUpload isn't found.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `BoxNotFoundError` if the FileUploadBox isn't found.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.
@@ -477,37 +424,26 @@ class UploadController(UploadControllerPort):
             log.error(error, extra=extra)
             raise error from err
 
-        # Get s3 upload details
-        try:
-            s3_upload_details = await self._s3_upload_details_dao.get_by_id(file_id)
-        except ResourceNotFoundError as err:
-            error = self.S3UploadDetailsNotFoundError(file_id=file_id)
-            log.error(error, extra=extra)
-            raise error from err
-
         # Exit early if the FileUpload is complete (already in the inbox or archived)
         if file_upload.inbox_upload_completed:
             log.info("FileUpload with ID %s already complete.", file_id)
             return
 
         try:
-            await self._s3_client.complete_multipart_upload(
-                s3_upload_details=s3_upload_details
-            )
+            await self._s3_client.complete_multipart_upload(file_upload=file_upload)
         except S3ClientPort.UnknownStorageAliasError as err:
             raise self.UnknownStorageAliasError(
-                storage_alias=s3_upload_details.storage_alias
+                storage_alias=file_upload.storage_alias
             ) from err
         except S3ClientPort.S3UploadCompletionError as err:
             raise self.UploadCompletionError(
                 file_id=file_id,
-                s3_upload_id=s3_upload_details.s3_upload_id,
-                bucket_id=s3_upload_details.bucket_id,
+                s3_upload_id=file_upload.s3_upload_id,
+                bucket_id=file_upload.bucket_id,
             ) from err
 
         # Verify that the md5 checksum calculated by the connector matches the S3 etag
         await self._compare_checksums(
-            s3_upload_details=s3_upload_details,
             file_upload=file_upload,
             expected_checksum=encrypted_checksum,
         )
@@ -519,9 +455,8 @@ class UploadController(UploadControllerPort):
         file_upload.encrypted_parts_sha256 = encrypted_parts_sha256
         file_upload.inbox_upload_completed = True
         file_upload.state_updated = now_utc_ms_prec()
-        s3_upload_details.completed = now_utc_ms_prec()
+        file_upload.completed = now_utc_ms_prec()
         await self._file_upload_dao.update(file_upload)
-        await self._s3_upload_details_dao.update(s3_upload_details)
 
         # Update the FileUploadBox with new size and file count
         await self._update_box_stats(box_id=box_id, version=box_version)
@@ -534,7 +469,6 @@ class UploadController(UploadControllerPort):
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         """
@@ -548,24 +482,11 @@ class UploadController(UploadControllerPort):
             log.info("File %s not found - presumed already deleted.", file_id)
             return
 
-        # Retrieve the S3UploadDetails
-        try:
-            s3_upload_details = await self._s3_upload_details_dao.get_by_id(file_id)
-        except ResourceNotFoundError as err:
-            error = self.S3UploadDetailsNotFoundError(file_id=file_id)
-            log.error(error, extra={"box_id": box_id, "file_id": file_id})
-            raise error from err
-
         # Remove the file from S3 using slightly different approach based on if finished
         if file_upload.inbox_upload_completed:
-            await self._remove_completed_file_upload(
-                s3_upload_details=s3_upload_details
-            )
+            await self._remove_completed_file_upload(file_upload=file_upload)
         else:
-            await self._remove_incomplete_file_upload(
-                s3_upload_details=s3_upload_details
-            )
-        await self._s3_upload_details_dao.delete(file_id)
+            await self._remove_incomplete_file_upload(file_upload=file_upload)
 
         # Update the file_upload to 'cancelled'
         file_upload.state = "cancelled"
@@ -811,7 +732,6 @@ class UploadController(UploadControllerPort):
         interrogation report and remove it from the inbox bucket.
 
         Raises:
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `FileUploadNotFound` if the FileUpload isn't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
@@ -852,15 +772,7 @@ class UploadController(UploadControllerPort):
                     file_upload.state,
                 )
 
-        # Retrieve the S3UploadDetails
-        try:
-            s3_upload_details = await self._s3_upload_details_dao.get_by_id(file_id)
-        except ResourceNotFoundError as err:
-            error = self.S3UploadDetailsNotFoundError(file_id=file_id)
-            log.error(error, extra={"file_id": file_id})
-            raise error from err
-
-        await self._remove_completed_file_upload(s3_upload_details=s3_upload_details)
+        await self._remove_completed_file_upload(file_upload=file_upload)
 
     async def process_interrogation_failure(
         self, *, report: InterrogationFailure
@@ -869,7 +781,6 @@ class UploadController(UploadControllerPort):
 
         Raises:
         - `FileUploadNotFound` if the FileUpload isn't found.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         """
@@ -903,15 +814,7 @@ class UploadController(UploadControllerPort):
                     file_upload.state,
                 )
 
-        # Retrieve the S3UploadDetails
-        try:
-            s3_upload_details = await self._s3_upload_details_dao.get_by_id(file_id)
-        except ResourceNotFoundError as err:
-            error = self.S3UploadDetailsNotFoundError(file_id=file_id)
-            log.error(error, extra={"file_id": file_id})
-            raise error from err
-
-        await self._remove_completed_file_upload(s3_upload_details=s3_upload_details)
+        await self._remove_completed_file_upload(file_upload=file_upload)
 
     async def process_internal_file_registration(
         self, *, registration_metadata: FileInternallyRegistered

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -119,8 +119,7 @@ class UploadController(UploadControllerPort):
     ) -> bool:
         """Try to replace an existing FileUpload for a given box and alias.
 
-        If successful, this method will delete any existing S3UploadDetails from the
-        database, delete the old FileUpload, and insert the new one.
+        If successful, this method will delete the old FileUpload and insert the new one.
         This does result in an outbox deletion event for the old FileUpload.
 
         Returns a boolean indicating whether replacement was successful.

--- a/services/ucs/src/ucs/core/models.py
+++ b/services/ucs/src/ucs/core/models.py
@@ -20,16 +20,18 @@ from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import UUID4, BaseModel, Field
 
 
-class S3UploadDetails(BaseModel):
-    """Class for linking a multipart upload to its FileUpload object"""
+class FileUploadBasics(BaseModel):
+    """Holds the fields of a FileUpload that are known before S3 upload initiation."""
 
-    file_id: UUID4  # the id of the corresponding FileUpload
-    bucket_id: str
-    object_id: UUID4  # the S3 object ID (from FileUpload.object_id)
+    id: UUID4
+    box_id: UUID4
+    alias: str
     storage_alias: str
-    s3_upload_id: str
-    initiated: UTCDatetime
-    completed: UTCDatetime | None = None
+    bucket_id: str
+    object_id: UUID4
+    decrypted_size: int
+    encrypted_size: int
+    part_size: int
 
 
 class FileUploadBox(event_schemas.FileUploadBox):
@@ -47,7 +49,17 @@ class FileUpload(event_schemas.FileUpload):
     permanent archival.
     """
 
-    inbox_upload_completed: bool = Field(  # Note: This is a UCS-only field
+    # Note: The following are UCS-only fields
+    inbox_upload_completed: bool = Field(
         default=False,
         description="Indicates whether the file has been completely uploaded to the inbox.",
+    )
+    s3_upload_id: str = Field(
+        default=..., description="The ID of the S3 multipart upload"
+    )
+    initiated: UTCDatetime = Field(
+        default=..., description="When the S3 multipart upload was initiated"
+    )
+    completed: UTCDatetime | None = Field(
+        default=None, description="When the S3 multipart upload was completed"
     )

--- a/services/ucs/src/ucs/core/models.py
+++ b/services/ucs/src/ucs/core/models.py
@@ -23,15 +23,40 @@ from pydantic import UUID4, BaseModel, Field
 class FileUploadBasics(BaseModel):
     """Holds the fields of a FileUpload that are known before S3 upload initiation."""
 
-    id: UUID4
-    box_id: UUID4
-    alias: str
-    storage_alias: str
-    bucket_id: str
-    object_id: UUID4
-    decrypted_size: int
-    encrypted_size: int
-    part_size: int
+    id: UUID4 = Field(default=..., description="Unique identifier for the file upload")
+    box_id: UUID4 = Field(
+        default=...,
+        description="The ID of the FileUploadBox this file is associated with",
+    )
+    alias: str = Field(
+        default=...,
+        description="The submitted alias from the metadata (unique within the box)",
+    )
+    storage_alias: str = Field(
+        default=..., description="The storage alias of the Data Hub housing the file"
+    )
+    bucket_id: str = Field(
+        default=...,
+        description="The name of the bucket where the file is currently stored",
+    )
+    object_id: UUID4 = Field(
+        default=..., description="The ID of the file specific to its S3 bucket"
+    )
+    decrypted_size: int = Field(
+        default=..., description="The size of the unencrypted file"
+    )
+    encrypted_size: int = Field(
+        default=...,
+        description=(
+            "The size of the encrypted file content. When the file is in the inbox, this"
+            + " includes the Crypt4GH envelope. After re-encryption, the file no longer"
+            + " contains an envelope, so the value is slightly smaller."
+        ),
+    )
+    part_size: int = Field(
+        default=...,
+        description="The number of bytes in each file part (last part is likely smaller)",
+    )
 
 
 class FileUploadBox(event_schemas.FileUploadBox):

--- a/services/ucs/src/ucs/inject.py
+++ b/services/ucs/src/ucs/inject.py
@@ -21,7 +21,6 @@ from contextlib import asynccontextmanager, nullcontext
 from fastapi import FastAPI
 from ghga_service_commons.utils.multinode_storage import S3ObjectStorages
 from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
-from hexkit.providers.mongodb import MongoDbDaoFactory
 from hexkit.providers.mongokafka.provider import MongoKafkaDaoPublisherFactory
 
 from ucs.adapters.inbound.event_sub import EventSubTranslator
@@ -30,10 +29,7 @@ from ucs.adapters.inbound.fastapi_.configure import get_configured_app
 from ucs.adapters.inbound.fastapi_.http_authorization import (
     JWTAuthContextProviderBundle,
 )
-from ucs.adapters.outbound.dao import (
-    UploadDaoPublisherFactory,
-    get_s3_upload_details_dao,
-)
+from ucs.adapters.outbound.dao import UploadDaoPublisherFactory
 from ucs.adapters.outbound.s3 import S3Client
 from ucs.config import Config
 from ucs.core.controller import UploadController
@@ -62,22 +58,19 @@ async def prepare_core(
     object_storages = S3ObjectStorages(config=config)
     s3_client = S3Client(config=config, object_storages=object_storages)
 
-    async with (
-        MongoDbDaoFactory.construct(config=config) as dao_factory,
-        MongoKafkaDaoPublisherFactory.construct(config=config) as dao_pub_factory,
-    ):
+    async with MongoKafkaDaoPublisherFactory.construct(
+        config=config
+    ) as dao_pub_factory:
         upload_dao_factory = UploadDaoPublisherFactory(
             config=config, dao_publisher_factory=dao_pub_factory
         )
         file_upload_box_dao = await upload_dao_factory.get_file_upload_box_dao()
         file_upload_dao = await upload_dao_factory.get_file_upload_dao()
-        s3_upload_details_dao = await get_s3_upload_details_dao(dao_factory=dao_factory)
 
         controller = UploadController(
             config=config,
             file_upload_box_dao=file_upload_box_dao,
             file_upload_dao=file_upload_dao,
-            s3_upload_details_dao=s3_upload_details_dao,
             s3_client=s3_client,
         )
         yield controller

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -192,7 +192,7 @@ class UploadControllerPort(ABC):
         the given number of the upload with the given file ID.
 
         Raises:
-        - `S3UploadDetailsNotFoundError` if no upload details are found.
+        - `FileUploadNotFound` if the FileUpload is not found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadSessionNotFoundError` if the upload session can't be found.
         """
@@ -215,7 +215,6 @@ class UploadControllerPort(ABC):
 
         Raises:
         - `FileUploadNotFound` if the FileUpload isn't found.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `BoxNotFoundError` if the FileUploadBox isn't found.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.
@@ -233,7 +232,6 @@ class UploadControllerPort(ABC):
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         """
@@ -256,7 +254,7 @@ class UploadControllerPort(ABC):
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         - `BoxVersionError` if the supplied version doesn't match the current version.
-        - `IncompleteUploadsError` if the box has incomplete FileUploads.
+        - `IncompleteUploadsError` if the FileUploadBox has incomplete FileUploads.
         """
         ...
 
@@ -286,7 +284,7 @@ class UploadControllerPort(ABC):
 
     @abstractmethod
     async def get_box_file_info(self, *, box_id: UUID4) -> list[FileUpload]:
-        """Return the list of FileUploads for a FileUploadBox.
+        """Return the list of FileUploads for a FileUploadBox, sorted by alias.
 
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
@@ -301,7 +299,6 @@ class UploadControllerPort(ABC):
         interrogation report and remove it from the inbox bucket.
 
         Raises:
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `FileUploadNotFound` if the FileUpload isn't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
@@ -316,7 +313,6 @@ class UploadControllerPort(ABC):
 
         Raises:
         - `FileUploadNotFound` if the FileUpload isn't found.
-        - `S3UploadDetailsNotFoundError` if the S3UploadDetails aren't found.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         """

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -49,16 +49,6 @@ class UploadControllerPort(ABC):
     class FileArchivalError(UploadError):
         """Raised when there's a problem that prevents archiving a given FileUpload."""
 
-    class S3UploadDetailsNotFoundError(UploadError):
-        """Raised when the expected S3 upload details aren't found in the local DB.
-
-        This happens when there is a FileUpload object but no matching S3UploadDetails.
-        """
-
-        def __init__(self, *, file_id: UUID4):
-            msg = f"Failed to find S3 multipart upload details for file ID {file_id}."
-            super().__init__(msg)
-
     class UnknownStorageAliasError(UploadError):
         """Raised when the requested storage alias is not configured."""
 

--- a/services/ucs/src/ucs/ports/outbound/dao.py
+++ b/services/ucs/src/ucs/ports/outbound/dao.py
@@ -18,7 +18,7 @@
 # for convenience: forward errors that may be thrown by DAO instances:
 from abc import ABC, abstractmethod
 
-from hexkit.protocols.dao import Dao, ResourceAlreadyExistsError, ResourceNotFoundError
+from hexkit.protocols.dao import ResourceAlreadyExistsError, ResourceNotFoundError
 from hexkit.protocols.daopub import DaoPublisher
 
 from ucs.core import models
@@ -29,11 +29,9 @@ __all__ = [
     "FileUploadDao",
     "ResourceAlreadyExistsError",
     "ResourceNotFoundError",
-    "S3UploadDetailsDao",
     "UploadDaoPublisherFactoryPort",
 ]
 
-S3UploadDetailsDao = Dao[models.S3UploadDetails]
 FileUploadBoxDao = DaoPublisher[FileUploadBox]
 FileUploadDao = DaoPublisher[models.FileUpload]
 

--- a/services/ucs/src/ucs/ports/outbound/storage.py
+++ b/services/ucs/src/ucs/ports/outbound/storage.py
@@ -22,7 +22,7 @@ from hexkit.protocols.objstorage import (  # noqa: F401
 )
 from pydantic import UUID4
 
-from ucs.core.models import FileUpload, S3UploadDetails
+from ucs.core.models import FileUpload, FileUploadBasics
 
 
 class S3ClientPort(ABC):
@@ -85,7 +85,9 @@ class S3ClientPort(ABC):
         """
 
     @abstractmethod
-    async def init_multipart_upload(self, *, file_upload: FileUpload) -> str:
+    async def init_multipart_upload(
+        self, *, file_upload_basics: FileUploadBasics
+    ) -> str:
         """Initiate a new multipart upload for a FileUpload.
 
         Returns a str containing the multipart upload ID.
@@ -97,7 +99,7 @@ class S3ClientPort(ABC):
 
     @abstractmethod
     async def get_part_upload_url(
-        self, *, s3_upload_details: S3UploadDetails, part_no: int
+        self, *, file_upload: FileUpload, part_no: int
     ) -> str:
         """Get a pre-signed URL to upload a specific part of a multipart upload.
 
@@ -107,9 +109,7 @@ class S3ClientPort(ABC):
         """
 
     @abstractmethod
-    async def complete_multipart_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def complete_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Instruct S3 to assemble all uploaded parts into the final object.
 
         Recovers idempotently if the upload was already completed (object exists).
@@ -121,7 +121,7 @@ class S3ClientPort(ABC):
 
     @abstractmethod
     async def get_object_etag(
-        self, *, s3_upload_details: S3UploadDetails, object_id: UUID4
+        self, *, file_upload: FileUpload, object_id: UUID4
     ) -> str:
         """Return the ETag of an object in the inbox bucket (quotes stripped).
 
@@ -130,7 +130,7 @@ class S3ClientPort(ABC):
         """
 
     @abstractmethod
-    async def delete_inbox_file(self, *, s3_upload_details: S3UploadDetails) -> None:
+    async def delete_inbox_file(self, *, file_upload: FileUpload) -> None:
         """Delete a fully uploaded file from the inbox, or abort any stale multipart.
 
         If the object exists it is deleted. If only an in-progress multipart upload
@@ -142,9 +142,7 @@ class S3ClientPort(ABC):
         """
 
     @abstractmethod
-    async def abort_multipart_upload(
-        self, *, s3_upload_details: S3UploadDetails
-    ) -> None:
+    async def abort_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Abort an in-progress multipart upload. Tolerates a missing upload.
 
         Raises:

--- a/services/ucs/tests_ucs/fixtures/joint.py
+++ b/services/ucs/tests_ucs/fixtures/joint.py
@@ -46,7 +46,7 @@ from ucs.adapters.outbound.s3 import S3Client
 from ucs.config import Config
 from ucs.core import models
 from ucs.core.controller import UploadController
-from ucs.core.models import FileUpload, FileUploadBox, S3UploadDetails
+from ucs.core.models import FileUpload, FileUploadBox
 from ucs.inject import prepare_core, prepare_event_subscriber, prepare_rest_app
 from ucs.ports.inbound.controller import UploadControllerPort
 from ucs.ports.outbound.storage import S3ClientPort
@@ -127,7 +127,6 @@ class JointRig:
     config: Config
     file_upload_box_dao: BaseInMemDao[models.FileUploadBox]
     file_upload_dao: BaseInMemDao[models.FileUpload]
-    s3_upload_details_dao: BaseInMemDao[models.S3UploadDetails]
     object_storages: ObjectStorages
     controller: UploadController
     s3_client: S3ClientPort
@@ -135,9 +134,6 @@ class JointRig:
 
 InMemFileUploadBoxDao = new_mock_dao_class(dto_model=FileUploadBox, id_field="id")
 InMemFileUploadDao = new_mock_dao_class(dto_model=FileUpload, id_field="id")
-InMemS3UploadDetailsDao = new_mock_dao_class(
-    dto_model=S3UploadDetails, id_field="file_id"
-)
 
 
 @pytest.fixture()
@@ -155,7 +151,6 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
     _config = config.config
     file_upload_box_dao = InMemFileUploadBoxDao()
     file_upload_dao = InMemFileUploadDao()
-    s3_upload_details_dao = InMemS3UploadDetailsDao()
     object_storages = InMemS3ObjectStorages(config=_config)
     s3_client = S3Client(config=_config, object_storages=object_storages)
 
@@ -163,7 +158,6 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
         config=(_config),
         file_upload_box_dao=(file_upload_box_dao),
         file_upload_dao=(file_upload_dao),
-        s3_upload_details_dao=(s3_upload_details_dao),
         s3_client=s3_client,
     )
 
@@ -171,7 +165,6 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
         config=_config,
         file_upload_box_dao=file_upload_box_dao,
         file_upload_dao=file_upload_dao,
-        s3_upload_details_dao=s3_upload_details_dao,
         object_storages=object_storages,
         controller=controller,
         s3_client=s3_client,

--- a/services/ucs/tests_ucs/fixtures/utils.py
+++ b/services/ucs/tests_ucs/fixtures/utils.py
@@ -148,11 +148,13 @@ def make_file_upload(
     storage_alias: str = TEST_STORAGE_ALIAS,
     bucket_id: str = TEST_BUCKET,
     object_id: UUID4 | None = None,
+    file_id: UUID4 | None = None,
     state: FileUploadState = "init",
+    s3_upload_id: str = "uninitialized",
 ) -> FileUpload:
     """Make a FileUpload instance with sensible defaults."""
     file_upload = FileUpload(
-        id=uuid4(),
+        id=file_id or uuid4(),
         alias="test.bam",
         box_id=uuid4(),
         state=state,
@@ -163,6 +165,8 @@ def make_file_upload(
         decrypted_size=DECRYPTED_SIZE,
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
+        s3_upload_id=s3_upload_id,
+        initiated=now_utc_ms_prec(),
     )
 
     if state != "init":

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -30,6 +30,7 @@ from hexkit.utils import now_utc_ms_prec
 
 from tests_ucs.fixtures import utils
 from tests_ucs.fixtures.joint import JointFixture
+from ucs.adapters.outbound.dao import FIELDS_NOT_PUBLISHED
 from ucs.constants import FILE_UPLOADS_COLLECTION
 from ucs.ports.inbound.controller import UploadControllerPort
 
@@ -167,6 +168,8 @@ async def test_integrated_aspects(joint_fixture: JointFixture):
         events = file_recorder.recorded_events
         assert len(events) == 1
         assert events[0].payload["state"] in ["inbox", "archived"]
+        # Make sure the UCS-only fields are excluded from the outbox event
+        assert not any(field in events[0].payload for field in FIELDS_NOT_PUBLISHED)
 
         # Let's lock the box now and verify that it is reflected in the event.
         # Box version is 1 after completing the file upload (stats changed 0→1 file).

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -30,7 +30,7 @@ from hexkit.utils import now_utc_ms_prec
 
 from tests_ucs.fixtures import utils
 from tests_ucs.fixtures.joint import JointFixture
-from ucs.constants import FILE_UPLOADS_COLLECTION, S3_UPLOAD_DETAILS_COLLECTION
+from ucs.constants import FILE_UPLOADS_COLLECTION
 from ucs.ports.inbound.controller import UploadControllerPort
 
 pytestmark = pytest.mark.asyncio()
@@ -129,12 +129,6 @@ async def test_integrated_aspects(joint_fixture: JointFixture):
         assert events[0].payload["id"] == str(file_id)
         assert events[0].payload["box_id"] == str(box_id)
 
-        # Look up the object_id for S3 operations (independent from file_id)
-        db = joint_fixture.mongodb.client[joint_fixture.config.db_name]
-        s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
-        s3_details = s3_upload_details_collection.find_one({"_id": file_id})
-        assert s3_details is not None
-
         # Get part upload URL for the file (should only require 1 part since file is under 16 MiB)
         upload_token_header = utils.upload_file_token_header(
             jwk=wps_jwk, box_id=box_id, file_id=file_id
@@ -228,7 +222,7 @@ async def test_s3_upload_completed_but_db_not_updated(joint_fixture: JointFixtur
     """Test error handling when the S3 upload is successfully completed but a hard
     crash (simulated) causes the DB to never get updated.
 
-    The FileUpload, S3UploadDetails, and FileUploadBox are not updated, even though
+    The FileUpload and FileUploadBox are not updated, even though
     the S3 operations were finished properly. In this case, the requester would not
     receive a meaningful error message and would have to retry the request. Upon issuing
     the request a second time, the UCS would see that the S3 upload has already been
@@ -253,8 +247,8 @@ async def test_s3_upload_completed_but_db_not_updated(joint_fixture: JointFixtur
     # To simulate the hiccup, we'll manually complete the upload. This will create the
     #  out-of-sync state described above.
     db = joint_fixture.mongodb.client[joint_fixture.config.db_name]
-    s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
-    uploads = s3_upload_details_collection.find().to_list()
+    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
+    uploads = file_upload_collection.find({"__metadata__.deleted": False}).to_list()
     assert len(uploads) == 1
     assert not uploads[0]["completed"]
     upload_id = uploads[0]["s3_upload_id"]
@@ -283,16 +277,12 @@ async def test_s3_upload_completed_but_db_not_updated(joint_fixture: JointFixtur
     assert response.status_code == 204
 
     # DB should now show that everything is complete
-    uploads = s3_upload_details_collection.find().to_list()
-    assert len(uploads) == 1
-    assert uploads[0]["completed"]
-    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
     file_uploads = file_upload_collection.find(
         {"__metadata__.deleted": False}
     ).to_list()
     assert len(file_uploads) == 1
+    assert file_uploads[0]["completed"]
     assert file_uploads[0]["state"] in ["inbox", "archived"]
-    assert uploads[0]["_id"] == file_uploads[0]["_id"]
 
 
 async def test_s3_upload_complete_fails(joint_fixture: JointFixture):
@@ -323,8 +313,8 @@ async def test_s3_upload_complete_fails(joint_fixture: JointFixture):
     # To simulate the hiccup, we'll manually abort the upload. This will create the
     #  out-of-sync state described above.
     db = joint_fixture.mongodb.client[joint_fixture.config.db_name]
-    s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
-    uploads = s3_upload_details_collection.find().to_list()
+    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
+    uploads = file_upload_collection.find({"__metadata__.deleted": False}).to_list()
     assert len(uploads) == 1
     assert not uploads[0]["completed"]
     upload_id = uploads[0]["s3_upload_id"]
@@ -414,22 +404,18 @@ async def test_s3_upload_complete_fails(joint_fixture: JointFixture):
 
     # Check the DB to verify that docs were deleted for the old file upload and that
     #  the new file upload (for the same alias) exists instead, set to completed
-    uploads = s3_upload_details_collection.find().to_list()
-    assert len(uploads) == 1
-    assert uploads[0]["_id"] == file_id2
-    assert uploads[0]["completed"]
-    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
     file_uploads = file_upload_collection.find(
         {"__metadata__.deleted": False}
     ).to_list()
     assert len(file_uploads) == 1
+    assert file_uploads[0]["_id"] == file_id2
+    assert file_uploads[0]["completed"]
     assert file_uploads[0]["state"] in ["inbox", "archived"]
-    assert uploads[0]["_id"] == file_uploads[0]["_id"]
 
 
 async def test_orphaned_s3_upload_in_file_create(joint_fixture: JointFixture, caplog):
     """A test for the scenario where a crash occurs in the `init_file_upload` method
-    between creating the S3 upload and inserting the S3UploadDetails.
+    between creating the S3 upload and inserting the FileUpload.
 
     The expected behavior is that the FileUpload is deleted, a critical error log
     is emitted, and the REST API returns a 409 CONFLICT error.
@@ -490,11 +476,6 @@ async def test_orphaned_s3_upload_in_file_create(joint_fixture: JointFixture, ca
     )
     assert records[0].msg == expected_log_msg
 
-    # Verify that no S3UploadDetails were created
-    s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
-    s3_uploads = s3_upload_details_collection.find({"_id": file_id}).to_list()
-    assert len(s3_uploads) == 0, "No S3UploadDetails should exist for the failed upload"
-
     # Clean up the orphaned S3 upload for this test
     await s3_storage.abort_multipart_upload(
         bucket_id=bucket_id, object_id=str(file_id), upload_id=s3_upload_id
@@ -526,7 +507,7 @@ async def test_file_upload_index(joint_fixture: JointFixture, monkeypatch):
             )
 
 
-async def test_file_upload_report_happy(joint_fixture: JointFixture):
+async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
     """Test the normal path of receiving an InterrogationSuccess event and deleting
     the file from the S3 bucket.
     """
@@ -565,10 +546,12 @@ async def test_file_upload_report_happy(joint_fixture: JointFixture):
 
     # Look up the actual object_id from the DB (independent from file_id)
     db = joint_fixture.mongodb.client[config.db_name]
-    s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
-    s3_details = s3_upload_details_collection.find_one({"_id": file_id})
-    assert s3_details is not None
-    object_id = str(s3_details["object_id"])
+    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
+    file_upload_db = file_upload_collection.find_one(
+        {"_id": file_id, "__metadata__.deleted": False}
+    )
+    assert file_upload_db is not None
+    object_id = str(file_upload_db["object_id"])
 
     # Verify the file exists in S3
     file_exists_before = await s3_storage.does_object_exist(
@@ -577,16 +560,11 @@ async def test_file_upload_report_happy(joint_fixture: JointFixture):
     assert file_exists_before
 
     # Verify the database records exist
-    file_upload_collection = db[FILE_UPLOADS_COLLECTION]
-
-    s3_uploads_before = s3_upload_details_collection.find({"_id": file_id}).to_list()
-    assert len(s3_uploads_before) == 1
-    assert s3_uploads_before[0]["completed"]
-
     file_uploads_before = file_upload_collection.find(
         {"_id": file_id, "__metadata__.deleted": False}
     ).to_list()
     assert len(file_uploads_before) == 1
+    assert file_uploads_before[0]["completed"]
     assert file_uploads_before[0]["state"] == "inbox"
 
     # Create and publish an InterrogationSuccess event
@@ -595,7 +573,7 @@ async def test_file_upload_report_happy(joint_fixture: JointFixture):
         secret_id="test-secret-123",
         storage_alias="test",
         bucket_id=bucket_id,
-        object_id=uuid4(),
+        object_id=UUID(object_id),
         interrogated_at=now_utc_ms_prec(),
         encrypted_parts_md5=["abc123"],
         encrypted_parts_sha256=["def456"],
@@ -634,8 +612,8 @@ async def test_file_upload_report_happy(joint_fixture: JointFixture):
 
 
 async def test_file_deletion_requested_event(joint_fixture: JointFixture, caplog):
-    """Test that consuming a FileDeletionRequested event aborts the S3 multipart upload,
-    removes S3UploadDetails from the DB, and marks the FileUpload as 'cancelled'.
+    """Test that consuming a FileDeletionRequested event aborts the S3 multipart upload
+    and marks the FileUpload as 'cancelled'.
 
     Also verifies behavior for publishing a deletion event for an unknown file ID
     (should be consumed without error).
@@ -644,7 +622,6 @@ async def test_file_deletion_requested_event(joint_fixture: JointFixture, caplog
     config = joint_fixture.config
     db = joint_fixture.mongodb.client[config.db_name]
     file_upload_collection = db[FILE_UPLOADS_COLLECTION]
-    s3_upload_details_collection = db[S3_UPLOAD_DETAILS_COLLECTION]
 
     # Create a FileUpload with an active MPU
     async with set_correlation_id(uuid4()):
@@ -672,7 +649,6 @@ async def test_file_deletion_requested_event(joint_fixture: JointFixture, caplog
     file_uploads_after = file_upload_collection.find({"_id": file_id}).to_list()
     assert len(file_uploads_after) == 1
     assert file_uploads_after[0]["state"] == "cancelled"
-    assert len(s3_upload_details_collection.find({"_id": file_id}).to_list()) == 0
 
     # Consume the same event again
     await joint_fixture.kafka.publish_event(

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -541,10 +541,6 @@ async def test_create_file_upload_endpoint_model_validator(
     "core_error, http_error",
     [
         (
-            UploadControllerPort.S3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-            http_exceptions.HttpS3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-        ),
-        (
             UploadControllerPort.UnknownStorageAliasError(storage_alias="HD01"),
             http_exceptions.HttpUnknownStorageAliasError(),
         ),
@@ -557,7 +553,6 @@ async def test_create_file_upload_endpoint_model_validator(
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
     ids=[
-        "S3UploadDetailsNotFound",
         "UnknownStorageAlias",
         "UploadSessionNotFound",
         "InternalError",
@@ -600,10 +595,6 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
             http_exceptions.HttpFileUploadNotFoundError(file_id=TEST_FILE_ID),
         ),
         (
-            UploadControllerPort.S3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-            http_exceptions.HttpS3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-        ),
-        (
             UploadControllerPort.UploadCompletionError(
                 file_id=TEST_FILE_ID,
                 s3_upload_id="test-upload",
@@ -619,7 +610,6 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
         "BoxNotFound",
         "LockedBox",
         "FileUploadNotFound",
-        "S3UploadDetailsNotFound",
         "UploadCompletionError",
         "InternalError",
     ],
@@ -664,10 +654,6 @@ async def test_complete_file_upload_endpoint_error_handling(
             http_exceptions.HttpBoxStateError(box_id=TEST_BOX_ID, box_state="locked"),
         ),
         (
-            UploadControllerPort.S3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-            http_exceptions.HttpS3UploadDetailsNotFoundError(file_id=TEST_FILE_ID),
-        ),
-        (
             UploadControllerPort.UnknownStorageAliasError(storage_alias="HD01"),
             http_exceptions.HttpUnknownStorageAliasError(),
         ),
@@ -684,7 +670,6 @@ async def test_complete_file_upload_endpoint_error_handling(
     ids=[
         "BoxNotFound",
         "LockedBox",
-        "S3UploadDetailsNotFound",
         "UnknownStorageAlias",
         "UploadAbortError",
         "InternalError",

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -73,18 +73,14 @@ async def test_create_new_file_upload(rig: JointRig):
         part_size=PART_SIZE,
     )
 
-    # Verify the FileUpload was created
+    # Verify the FileUpload was created with S3 fields populated
     assert file_upload_dao.latest.id == file_id
     assert file_upload_dao.latest.alias == "test_file"
     assert file_upload_dao.latest.decrypted_sha256 is None
     assert file_upload_dao.latest.decrypted_size == DECRYPTED_SIZE
-
-    # Verify S3UploadDetails were created
-    upload_details = rig.s3_upload_details_dao.latest
-    assert upload_details.file_id == file_id
-    assert upload_details.storage_alias == "test"
-    assert now_utc_ms_prec() - upload_details.initiated < timedelta(seconds=5)
-    assert not upload_details.completed
+    assert file_upload_dao.latest.storage_alias == "test"
+    assert now_utc_ms_prec() - file_upload_dao.latest.initiated < timedelta(seconds=5)
+    assert not file_upload_dao.latest.completed
 
 
 async def test_get_part_url(rig: JointRig):
@@ -124,7 +120,7 @@ async def test_complete_file_upload(rig: JointRig):
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
     )
-    file1_object_id = rig.s3_upload_details_dao.latest.object_id
+    file1_object_id = rig.file_upload_dao.latest.object_id
 
     # Now complete the file upload
     await controller.complete_file_upload(
@@ -140,13 +136,13 @@ async def test_complete_file_upload(rig: JointRig):
         bucket_id=bucket_id, object_id=str(file1_object_id)
     )
 
-    # Verify that the S3UploadDetails still exist (they should remain for tracking)
+    # Verify that the completed field was set on the FileUpload
     completed = now_utc_ms_prec()
-    s3_upload_details_dao = rig.s3_upload_details_dao
-    assert s3_upload_details_dao.latest.file_id == file_id
-    assert s3_upload_details_dao.latest.completed is not None
-    assert completed - s3_upload_details_dao.latest.completed < timedelta(seconds=5)
-    assert rig.file_upload_dao.latest.inbox_upload_completed
+    file_upload_dao = rig.file_upload_dao
+    assert file_upload_dao.latest.id == file_id
+    assert file_upload_dao.latest.completed is not None
+    assert completed - file_upload_dao.latest.completed < timedelta(seconds=5)
+    assert file_upload_dao.latest.inbox_upload_completed
     file_upload_box_dao = rig.file_upload_box_dao
     assert file_upload_box_dao.latest.size == DECRYPTED_SIZE
     assert file_upload_box_dao.latest.file_count == 1
@@ -162,7 +158,7 @@ async def test_complete_file_upload(rig: JointRig):
         encrypted_size=other_encrypted_size,
         part_size=PART_SIZE,
     )
-    file2_object_id = rig.s3_upload_details_dao.latest.object_id
+    file2_object_id = rig.file_upload_dao.latest.object_id
     await controller.complete_file_upload(
         box_id=box_id,
         file_id=file_id2,
@@ -171,10 +167,10 @@ async def test_complete_file_upload(rig: JointRig):
         encrypted_parts_md5=["abc123"],
         encrypted_parts_sha256=["def456"],
     )
-    latest_s3_details = s3_upload_details_dao.latest
-    assert latest_s3_details.file_id == file_id2
-    assert latest_s3_details.completed
-    assert latest_s3_details.completed > completed
+    latest_file_upload = file_upload_dao.latest
+    assert latest_file_upload.id == file_id2
+    assert latest_file_upload.completed
+    assert latest_file_upload.completed > completed
     assert file_upload_box_dao.latest.file_count == 2
     assert file_upload_box_dao.latest.size == DECRYPTED_SIZE + other_decrypted_size
 
@@ -185,7 +181,6 @@ async def test_delete_file_upload(rig: JointRig, complete_before_delete: bool):
     controller = rig.controller
     file_upload_box_dao = rig.file_upload_box_dao
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
     bucket_id, object_storage = rig.object_storages.for_alias("test")
 
     # First create a FileUploadBox
@@ -199,7 +194,7 @@ async def test_delete_file_upload(rig: JointRig, complete_before_delete: bool):
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
     )
-    object_id = str(rig.s3_upload_details_dao.latest.object_id)
+    object_id = str(rig.file_upload_dao.latest.object_id)
 
     if complete_before_delete:
         await controller.complete_file_upload(
@@ -222,10 +217,9 @@ async def test_delete_file_upload(rig: JointRig, complete_before_delete: bool):
         bucket_id=bucket_id, object_id=object_id
     )
 
-    # FileUpload is set to "cancelled" (not removed from DB); S3UploadDetails are deleted
+    # FileUpload is set to "cancelled" (not removed from DB)
     assert len(file_upload_dao.resources) == 1
     assert file_upload_dao.latest.state == "cancelled"
-    assert not s3_upload_details_dao.resources
     assert file_upload_box_dao.latest.file_count == 0
     assert file_upload_box_dao.latest.size == 0
 
@@ -310,7 +304,7 @@ async def test_get_box_uploads(rig: JointRig):
             encrypted_size=ENCRYPTED_SIZE,
             part_size=PART_SIZE,
         )
-        object_id = rig.s3_upload_details_dao.latest.object_id
+        object_id = rig.file_upload_dao.latest.object_id
         await controller.complete_file_upload(
             box_id=box_id,
             file_id=file_id,
@@ -332,7 +326,7 @@ async def test_get_box_uploads(rig: JointRig):
             encrypted_size=ENCRYPTED_SIZE,
             part_size=PART_SIZE,
         )
-        other_object_id = rig.s3_upload_details_dao.latest.object_id
+        other_object_id = rig.file_upload_dao.latest.object_id
         await controller.complete_file_upload(
             box_id=other_box_id,
             file_id=other_file_id,
@@ -405,7 +399,6 @@ async def test_create_file_upload_when_box_missing(rig: JointRig):
 
     # Verify no FileUpload was created
     assert not rig.file_upload_dao.resources
-    assert not rig.s3_upload_details_dao.resources
 
 
 async def test_create_file_upload_when_box_locked(rig: JointRig):
@@ -435,7 +428,6 @@ async def test_create_file_upload_when_box_locked(rig: JointRig):
 
     # Verify no FileUpload was created
     assert not rig.file_upload_dao.resources
-    assert not rig.s3_upload_details_dao.resources
 
 
 async def test_delete_file_upload_when_box_missing(rig: JointRig):
@@ -460,7 +452,6 @@ async def test_delete_file_upload_when_box_missing(rig: JointRig):
     # Verify no changes were made to DAOs
     assert not rig.file_upload_box_dao.resources
     assert not rig.file_upload_dao.resources
-    assert not rig.s3_upload_details_dao.resources
 
 
 async def test_delete_file_upload_when_box_locked(rig: JointRig):
@@ -470,7 +461,6 @@ async def test_delete_file_upload_when_box_locked(rig: JointRig):
     controller = rig.controller
     file_upload_box_dao = rig.file_upload_box_dao
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
 
     # First create a FileUploadBox and FileUpload
     box_id = await controller.create_file_upload_box(storage_alias="test")
@@ -495,9 +485,8 @@ async def test_delete_file_upload_when_box_locked(rig: JointRig):
     # Verify the exception contains the correct box_id
     assert str(box_id) in str(exc_info.value)
 
-    # Verify the FileUpload and S3UploadDetails still exist (weren't deleted)
+    # Verify the FileUpload still exists (wasn't deleted)
     assert len(file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 1
 
 
 async def test_delete_file_upload_when_upload_missing(rig: JointRig):
@@ -513,54 +502,11 @@ async def test_delete_file_upload_when_upload_missing(rig: JointRig):
     await controller.remove_file_upload(box_id=box_id, file_id=uuid4())
 
 
-async def test_delete_file_upload_with_missing_s3_details(rig: JointRig):
-    """Test error handling in the case where the user tries to delete a FileUpload
-    where the s3 upload details are missing. This would be an unusual case,
-    but we're still testing it.
-    """
-    controller = rig.controller
-    file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
-
-    # Create a FileUploadBox and a FileUpload
-    box_id = await controller.create_file_upload_box(storage_alias="test")
-    file_id, _ = await controller.initiate_file_upload(
-        box_id=box_id,
-        alias="test_file",
-        decrypted_size=DECRYPTED_SIZE,
-        encrypted_size=ENCRYPTED_SIZE,
-        part_size=PART_SIZE,
-    )
-
-    # Verify both FileUpload and S3UploadDetails were created
-    assert len(file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 1
-
-    # Manually delete the S3UploadDetails but leave the FileUpload
-    # This simulates a data inconsistency where S3 details are missing
-    await s3_upload_details_dao.delete(file_id)
-
-    # Verify the FileUpload exists but S3UploadDetails are gone
-    assert len(file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 0
-
-    # Try to delete the file upload - should raise S3UploadDetailsNotFoundError
-    with pytest.raises(UploadControllerPort.S3UploadDetailsNotFoundError) as exc_info:
-        await controller.remove_file_upload(box_id=box_id, file_id=file_id)
-
-    # Verify the exception contains the correct file_id
-    assert str(file_id) in str(exc_info.value)
-
-    # Verify the FileUpload still exists (deletion was aborted due to missing S3 details)
-    assert len(file_upload_dao.resources) == 1
-
-
 async def test_delete_file_upload_with_s3_error(rig: JointRig):
     """Test for error handling when the user tries to delete a FileUpload
     but gets an S3 error in the process of aborting an ongoing upload.
     """
     controller = rig.controller
-    s3_upload_details_dao = rig.s3_upload_details_dao
 
     # Create a FileUploadBox and a FileUpload
     box_id = await controller.create_file_upload_box(storage_alias="test")
@@ -585,12 +531,11 @@ async def test_delete_file_upload_with_s3_error(rig: JointRig):
         await controller.remove_file_upload(box_id=box_id, file_id=file_id)
 
     # Verify the exception contains the S3 upload ID
-    s3_upload_id = s3_upload_details_dao.latest.s3_upload_id
+    s3_upload_id = rig.file_upload_dao.latest.s3_upload_id
     assert s3_upload_id in str(exc_info.value)
 
-    # Verify the FileUpload and S3UploadDetails still exist (deletion failed)
+    # Verify the FileUpload still exists (deletion failed)
     assert len(rig.file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 1
 
 
 async def test_unlock_missing_box(rig: JointRig):
@@ -668,7 +613,6 @@ async def test_complete_file_upload_when_box_missing(rig: JointRig):
     controller = rig.controller
     file_upload_box_dao = rig.file_upload_box_dao
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
 
     # Create a FileUploadBox and a FileUpload
     box_id = await controller.create_file_upload_box(storage_alias="test")
@@ -687,7 +631,6 @@ async def test_complete_file_upload_when_box_missing(rig: JointRig):
     # Verify the box is gone but file upload and S3 details remain
     assert not file_upload_box_dao.resources
     assert len(file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 1
 
     # Try to complete the file upload for the now missing box
     with pytest.raises(UploadControllerPort.BoxNotFoundError) as exc_info:
@@ -703,7 +646,6 @@ async def test_complete_file_upload_when_box_missing(rig: JointRig):
     # Verify the exception contains the correct box_id
     assert str(box_id) in str(exc_info.value)
     assert not file_upload_dao.latest.inbox_upload_completed
-    assert not s3_upload_details_dao.latest.completed
 
 
 async def test_complete_missing_file_upload(rig: JointRig):
@@ -727,51 +669,9 @@ async def test_complete_missing_file_upload(rig: JointRig):
             encrypted_parts_sha256=["def456"],
         )
     assert not rig.file_upload_dao.resources
-    assert not rig.s3_upload_details_dao.resources
 
     # Verify the exception contains the correct file_id
     assert str(non_existent_file_id) in str(exc_info.value)
-
-
-async def test_complete_file_upload_with_missing_s3_details(rig: JointRig):
-    """Test error handling in the case where the user tries to complete a FileUpload
-    where the s3 upload details are missing. This would be an unusual case,
-    but we're still testing it.
-    """
-    controller = rig.controller
-
-    # Create a FileUploadBox and a FileUpload
-    box_id = await controller.create_file_upload_box(storage_alias="test")
-    file_id, _ = await controller.initiate_file_upload(
-        box_id=box_id,
-        alias="test_file",
-        decrypted_size=DECRYPTED_SIZE,
-        encrypted_size=ENCRYPTED_SIZE,
-        part_size=PART_SIZE,
-    )
-
-    # Manually delete the S3UploadDetails but leave the FileUpload
-    # This simulates a data inconsistency where S3 details are missing
-    await rig.s3_upload_details_dao.delete(file_id)
-
-    # Try to complete the file upload - should raise S3UploadDetailsNotFoundError
-    with pytest.raises(UploadControllerPort.S3UploadDetailsNotFoundError) as exc_info:
-        await controller.complete_file_upload(
-            box_id=box_id,
-            file_id=file_id,
-            unencrypted_checksum="sha256:unencrypted_checksum_here",
-            encrypted_checksum="sha256:encrypted_checksum_here",
-            encrypted_parts_md5=["abc123"],
-            encrypted_parts_sha256=["def456"],
-        )
-
-    # Verify the exception contains the correct file_id
-    assert str(file_id) in str(exc_info.value)
-
-    # Verify the FileUpload is still marked as incomplete
-    assert not rig.file_upload_dao.latest.inbox_upload_completed
-    assert rig.file_upload_box_dao.latest.size == 0
-    assert rig.file_upload_box_dao.latest.file_count == 0
 
 
 async def test_complete_file_upload_with_unknown_storage_alias(rig: JointRig):
@@ -779,7 +679,6 @@ async def test_complete_file_upload_with_unknown_storage_alias(rig: JointRig):
     with a storage alias that isn't configured.
     """
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
     controller = rig.controller
 
     # Create a FileUploadBox and a FileUpload with a valid storage alias
@@ -792,15 +691,14 @@ async def test_complete_file_upload_with_unknown_storage_alias(rig: JointRig):
         part_size=PART_SIZE,
     )
 
-    # Verify both FileUpload and S3UploadDetails were created
+    # Verify the FileUpload was created
     assert len(file_upload_dao.resources) == 1
-    assert len(s3_upload_details_dao.resources) == 1
 
-    # Manually modify the S3UploadDetails to have an unknown storage alias
+    # Manually modify the FileUpload to have an unknown storage alias
     # This simulates a scenario where configuration changed or data was corrupted
-    s3_details = s3_upload_details_dao.latest
-    s3_details.storage_alias = "does_not_exist"
-    await s3_upload_details_dao.update(s3_details)
+    file_upload = file_upload_dao.latest
+    file_upload.storage_alias = "does_not_exist"
+    await file_upload_dao.update(file_upload)
 
     # Try to complete the file upload - should raise UnknownStorageAliasError
     with pytest.raises(UploadControllerPort.UnknownStorageAliasError) as exc_info:
@@ -825,7 +723,7 @@ async def test_complete_file_upload_with_s3_error(rig: JointRig):
     but gets an S3 error in the process.
     """
     file_upload_box_dao = rig.file_upload_box_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
+    file_upload_dao = rig.file_upload_dao
     controller = rig.controller
 
     # Create a FileUploadBox and a FileUpload
@@ -858,10 +756,10 @@ async def test_complete_file_upload_with_s3_error(rig: JointRig):
         )
 
     # Verify the exception contains the S3 upload ID
-    s3_upload_id = s3_upload_details_dao.latest.s3_upload_id
+    s3_upload_id = file_upload_dao.latest.s3_upload_id
     assert s3_upload_id in str(exc_info.value)
     assert not rig.file_upload_dao.latest.inbox_upload_completed
-    assert not s3_upload_details_dao.latest.completed
+    assert not file_upload_dao.latest.completed
     assert file_upload_box_dao.latest.size == 0
     assert file_upload_box_dao.latest.file_count == 0
 
@@ -871,7 +769,6 @@ async def test_complete_file_upload_checksum_mismatch(rig: JointRig):
     raises a ChecksumMismatchError.
     """
     file_upload_box_dao = rig.file_upload_box_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
     controller = rig.controller
 
     # Create a FileUploadBox and a FileUpload
@@ -905,45 +802,17 @@ async def test_complete_file_upload_checksum_mismatch(rig: JointRig):
     assert file_upload.state == "failed"
     assert file_upload.state_updated > state_updated
     assert not file_upload.inbox_upload_completed
-    assert not s3_upload_details_dao.latest.completed
+    assert not file_upload.completed
     assert file_upload_box_dao.latest.size == 0
     assert file_upload_box_dao.latest.file_count == 0
 
 
-async def test_get_part_upload_url_with_missing_file_id(rig: JointRig):
-    """Test for error handling when getting a part URL but there's no S3UploadDetails
-    document with a matching file_id.
-    """
-    # Create a FileUploadBox and a FileUpload
-    controller = rig.controller
-    box_id = await controller.create_file_upload_box(storage_alias="test")
-    file_id, _ = await controller.initiate_file_upload(
-        box_id=box_id,
-        alias="test_file",
-        decrypted_size=DECRYPTED_SIZE,
-        encrypted_size=ENCRYPTED_SIZE,
-        part_size=PART_SIZE,
-    )
-
-    # Manually delete the S3UploadDetails but leave the FileUpload
-    await rig.s3_upload_details_dao.delete(file_id)
-
-    # Try to get a part upload URL - should raise S3UploadDetailsNotFoundError
-    with pytest.raises(UploadControllerPort.S3UploadDetailsNotFoundError) as exc_info:
-        await controller.get_part_upload_url(file_id=file_id, part_no=1)
-
-    # Verify the exception contains the correct file_id
-    assert str(file_id) in str(exc_info.value)
-
-
 async def test_get_part_upload_url_with_unknown_storage_alias(rig: JointRig):
     """Test for error handling when getting a part URL but the storage alias found in
-    the relevant S3UploadDetails document is unknown (maybe configuration changed or
-    data was migrated improperly).
+    the FileUpload is unknown (maybe configuration changed or data was migrated wrong).
     """
     # Create a FileUploadBox and a FileUpload with a valid storage alias
     controller = rig.controller
-    s3_upload_details_dao = rig.s3_upload_details_dao
     box_id = await controller.create_file_upload_box(storage_alias="test")
     file_id, _ = await controller.initiate_file_upload(
         box_id=box_id,
@@ -953,11 +822,11 @@ async def test_get_part_upload_url_with_unknown_storage_alias(rig: JointRig):
         part_size=PART_SIZE,
     )
 
-    # Manually modify the S3UploadDetails to have an unknown storage alias
+    # Manually modify the FileUpload to have an unknown storage alias
     # This simulates a scenario where configuration changed or data was corrupted
-    s3_details = s3_upload_details_dao.latest
-    s3_details.storage_alias = "unknown_storage_alias"
-    await s3_upload_details_dao.update(s3_details)
+    file_upload = rig.file_upload_dao.latest
+    file_upload.storage_alias = "unknown_storage_alias"
+    await rig.file_upload_dao.update(file_upload)
 
     # Try to get a part upload URL - should raise UnknownStorageAliasError
     with pytest.raises(UploadControllerPort.UnknownStorageAliasError) as exc_info:
@@ -995,7 +864,7 @@ async def test_get_part_upload_url_when_s3_upload_not_found(rig: JointRig):
         await controller.get_part_upload_url(file_id=file_id, part_no=1)
 
     # Verify the exception contains the S3 upload ID
-    s3_upload_id = rig.s3_upload_details_dao.latest.s3_upload_id
+    s3_upload_id = rig.file_upload_dao.latest.s3_upload_id
     assert s3_upload_id in str(exc_info.value)
 
 
@@ -1026,11 +895,10 @@ async def test_process_interrogation_success_no_file_upload(rig: JointRig):
 
 async def test_initiate_upload_after_failed(rig: JointRig):
     """Re-initiating an upload with the same alias is allowed when the existing
-    FileUpload is in 'failed' state (S3UploadDetails remain in DB for that state).
+    FileUpload is in 'failed' state.
     """
     controller = rig.controller
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
 
     box_id = await controller.create_file_upload_box(storage_alias="test")
     file_id_1, _ = await controller.initiate_file_upload(
@@ -1041,13 +909,10 @@ async def test_initiate_upload_after_failed(rig: JointRig):
         part_size=PART_SIZE,
     )
 
-    # Simulate the "failed" state directly (process_interrogation_failure would also
-    # clean up the S3 object, but we want to verify S3UploadDetails remain in DB)
+    # Simulate the "failed" state directly
     file_upload = await file_upload_dao.get_by_id(file_id_1)
     file_upload.state = "failed"
     await file_upload_dao.update(file_upload)
-
-    assert len(s3_upload_details_dao.resources) == 1
 
     # Patch insert to simulate the MongoDB compound-index constraint violation
     original_insert = file_upload_dao.insert
@@ -1077,18 +942,14 @@ async def test_initiate_upload_after_failed(rig: JointRig):
     new_upload = await file_upload_dao.get_by_id(file_id_2)
     assert new_upload.state == "init"
     assert new_upload.alias == "test_file"
-    # Old S3UploadDetails deleted; new one created for file_id_2
-    assert len(s3_upload_details_dao.resources) == 1
-    assert s3_upload_details_dao.latest.file_id == file_id_2
 
 
 async def test_initiate_upload_after_cancelled(rig: JointRig):
     """Re-initiating an upload with the same alias is allowed when the existing
-    FileUpload is in 'cancelled' state (S3UploadDetails already deleted for that state).
+    FileUpload is in 'cancelled' state.
     """
     controller = rig.controller
     file_upload_dao = rig.file_upload_dao
-    s3_upload_details_dao = rig.s3_upload_details_dao
 
     box_id = await controller.create_file_upload_box(storage_alias="test")
     file_id_1, _ = await controller.initiate_file_upload(
@@ -1102,7 +963,6 @@ async def test_initiate_upload_after_cancelled(rig: JointRig):
 
     cancelled = await file_upload_dao.get_by_id(file_id_1)
     assert cancelled.state == "cancelled"
-    assert len(s3_upload_details_dao.resources) == 0
 
     original_insert = file_upload_dao.insert
     call_count = 0
@@ -1130,8 +990,7 @@ async def test_initiate_upload_after_cancelled(rig: JointRig):
     assert len(file_upload_dao.resources) == 1
     new_upload = await file_upload_dao.get_by_id(file_id_2)
     assert new_upload.state == "init"
-    assert len(s3_upload_details_dao.resources) == 1
-    assert s3_upload_details_dao.latest.file_id == file_id_2
+    assert new_upload.s3_upload_id != cancelled.s3_upload_id
 
 
 async def test_initiate_upload_blocked_for_inbox_state(rig: JointRig):
@@ -1149,7 +1008,7 @@ async def test_initiate_upload_blocked_for_inbox_state(rig: JointRig):
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
     )
-    object_id_1 = rig.s3_upload_details_dao.latest.object_id
+    object_id_1 = rig.file_upload_dao.latest.object_id
     await controller.complete_file_upload(
         box_id=box_id,
         file_id=file_id_1,

--- a/services/ucs/tests_ucs/unit/test_s3client.py
+++ b/services/ucs/tests_ucs/unit/test_s3client.py
@@ -34,7 +34,10 @@ pytestmark = pytest.mark.asyncio
 def _to_basics(file_upload: FileUpload) -> FileUploadBasics:
     """Extract a FileUploadBasics from a FileUpload."""
     return FileUploadBasics(
-        **{k: getattr(file_upload, k) for k in FileUploadBasics.model_fields}
+        **{
+            field: getattr(file_upload, field)
+            for field in FileUploadBasics.model_fields
+        }
     )
 
 

--- a/services/ucs/tests_ucs/unit/test_s3client.py
+++ b/services/ucs/tests_ucs/unit/test_s3client.py
@@ -15,42 +15,26 @@
 
 """Unit tests for the S3Client"""
 
-from uuid import uuid4
-
 import pytest
 import pytest_asyncio
 from ghga_service_commons.utils.multinode_storage import ObjectStorages
 from hexkit.protocols.objstorage import ObjectStorageProtocol
 from hexkit.providers.testing.s3 import InMemObjectStorage
-from hexkit.utils import now_utc_ms_prec
-from pydantic import UUID4
 
 from tests_ucs.fixtures import ConfigFixture
 from tests_ucs.fixtures.in_mem_obj_storage import InMemS3ObjectStorages
 from tests_ucs.fixtures.utils import TEST_BUCKET, TEST_STORAGE_ALIAS, make_file_upload
 from ucs.adapters.outbound.s3 import S3Client
-from ucs.core.models import S3UploadDetails
+from ucs.core.models import FileUpload, FileUploadBasics
 from ucs.ports.outbound.storage import S3ClientPort
 
 pytestmark = pytest.mark.asyncio
 
 
-def make_s3_upload_details(
-    *,
-    file_id: UUID4 | None = None,
-    s3_upload_id: str = "uninitialized",
-    object_id: UUID4 | None = None,
-) -> S3UploadDetails:
-    """Make an instance of S3UploadDetails."""
-    file_id = file_id or uuid4()
-    object_id = object_id or uuid4()
-    return S3UploadDetails(
-        file_id=file_id,
-        storage_alias=TEST_STORAGE_ALIAS,
-        bucket_id=TEST_BUCKET,
-        object_id=object_id,
-        s3_upload_id=s3_upload_id,
-        initiated=now_utc_ms_prec(),
+def _to_basics(file_upload: FileUpload) -> FileUploadBasics:
+    """Extract a FileUploadBasics from a FileUpload."""
+    return FileUploadBasics(
+        **{k: getattr(file_upload, k) for k in FileUploadBasics.model_fields}
     )
 
 
@@ -83,7 +67,9 @@ async def create_default_bucket(object_storages: ObjectStorages):
 async def test_init_upload(s3_client: S3ClientPort):
     """Test the happy case of starting a new multipart upload."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
+    )
     assert isinstance(upload_id, str)
     assert upload_id
 
@@ -91,34 +77,32 @@ async def test_init_upload(s3_client: S3ClientPort):
 async def test_init_upload_with_existing_upload_in_progress(s3_client: S3ClientPort):
     """Make sure the appropriate error is raised if there's already an upload in progress."""
     file_upload = make_file_upload()
-    await s3_client.init_multipart_upload(file_upload=file_upload)
+    await s3_client.init_multipart_upload(file_upload_basics=_to_basics(file_upload))
 
     with pytest.raises(S3ClientPort.OrphanedMultipartUploadError):
-        await s3_client.init_multipart_upload(file_upload=file_upload)
+        await s3_client.init_multipart_upload(
+            file_upload_basics=_to_basics(file_upload)
+        )
 
 
 async def test_get_part_upload_url(s3_client: S3ClientPort):
     """Test the happy case of generating an upload url for a file part."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
-    url = await s3_client.get_part_upload_url(
-        s3_upload_details=s3_upload_details, part_no=1
-    )
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
+    url = await s3_client.get_part_upload_url(file_upload=file_upload, part_no=1)
     assert str(file_upload.object_id) in url
     assert "part_no_1" in url
 
 
 async def test_get_part_upload_url_when_s3_upload_not_found(s3_client: S3ClientPort):
     """Test for error handling when S3 can't find the multipart upload."""
-    s3_upload_details = make_s3_upload_details(s3_upload_id="not-real")
+    file_upload = make_file_upload(s3_upload_id="not-real")
 
     with pytest.raises(S3ClientPort.S3UploadNotFoundError):
-        await s3_client.get_part_upload_url(
-            s3_upload_details=s3_upload_details, part_no=123
-        )
+        await s3_client.get_part_upload_url(file_upload=file_upload, part_no=123)
 
 
 async def test_complete_multipart_upload(
@@ -126,12 +110,12 @@ async def test_complete_multipart_upload(
 ):
     """Test the happy case of completing a multipart upload."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
 
-    await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
 
     bucket_id, storage = object_storages.for_alias(TEST_STORAGE_ALIAS)
     assert await storage.does_object_exist(
@@ -144,14 +128,14 @@ async def test_complete_multipart_upload_idempotent(
 ):
     """Completing an already-completed upload should recover silently (object exists)."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
-    await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
 
     # Second call: upload ID is gone but object exists — should recover silently
-    await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
 
     bucket_id, storage = object_storages.for_alias(TEST_STORAGE_ALIAS)
     assert await storage.does_object_exist(
@@ -161,23 +145,23 @@ async def test_complete_multipart_upload_idempotent(
 
 async def test_complete_multipart_upload_not_found(s3_client: S3ClientPort):
     """Completing a non-existent upload with no object present raises UploadCompletionError."""
-    s3_upload_details = make_s3_upload_details(s3_upload_id="not-real")
+    file_upload = make_file_upload(s3_upload_id="not-real")
 
     with pytest.raises(S3ClientPort.S3UploadCompletionError):
-        await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.complete_multipart_upload(file_upload=file_upload)
 
 
 async def test_get_object_etag(s3_client: S3ClientPort):
     """Test that the ETag of a completed upload matches the expected value."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
-    await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
 
     etag = await s3_client.get_object_etag(
-        s3_upload_details=s3_upload_details, object_id=file_upload.object_id
+        file_upload=file_upload, object_id=file_upload.object_id
     )
     assert etag == f"etag_for_{file_upload.object_id}"
 
@@ -187,13 +171,13 @@ async def test_delete_inbox_file_completed(
 ):
     """Deleting a completed upload removes the object from the bucket."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
-    await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
 
-    await s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+    await s3_client.delete_inbox_file(file_upload=file_upload)
 
     bucket_id, storage = object_storages.for_alias(TEST_STORAGE_ALIAS)
     assert not await storage.does_object_exist(
@@ -204,43 +188,43 @@ async def test_delete_inbox_file_completed(
 async def test_delete_inbox_file_incomplete(s3_client: S3ClientPort):
     """Deleting an incomplete upload aborts the multipart upload."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
 
-    await s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+    await s3_client.delete_inbox_file(file_upload=file_upload)
 
     # The multipart upload is gone — completing it should now fail
     with pytest.raises(S3ClientPort.S3UploadCompletionError):
-        await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.complete_multipart_upload(file_upload=file_upload)
 
 
 async def test_delete_inbox_file_nothing_exists(s3_client: S3ClientPort):
     """Deleting when neither the object nor the multipart upload exist succeeds silently."""
-    s3_upload_details = make_s3_upload_details(s3_upload_id="not-real")
-    await s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+    file_upload = make_file_upload(s3_upload_id="not-real")
+    await s3_client.delete_inbox_file(file_upload=file_upload)
 
 
 async def test_abort_multipart_upload(s3_client: S3ClientPort):
     """Test the happy case of aborting an in-progress multipart upload."""
     file_upload = make_file_upload()
-    upload_id = await s3_client.init_multipart_upload(file_upload=file_upload)
-    s3_upload_details = make_s3_upload_details(
-        file_id=file_upload.id, s3_upload_id=upload_id, object_id=file_upload.object_id
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
     )
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
 
-    await s3_client.abort_multipart_upload(s3_upload_details=s3_upload_details)
+    await s3_client.abort_multipart_upload(file_upload=file_upload)
 
     # The multipart upload is gone — completing it should now fail
     with pytest.raises(S3ClientPort.S3UploadCompletionError):
-        await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.complete_multipart_upload(file_upload=file_upload)
 
 
 async def test_abort_multipart_upload_already_gone(s3_client: S3ClientPort):
     """Aborting a non-existent upload (already aborted or never started) succeeds silently."""
-    s3_upload_details = make_s3_upload_details(s3_upload_id="not-real")
-    await s3_client.abort_multipart_upload(s3_upload_details=s3_upload_details)
+    file_upload = make_file_upload(s3_upload_id="not-real")
+    await s3_client.abort_multipart_upload(file_upload=file_upload)
 
 
 async def test_abort_and_delete_raise_s3_upload_abort_error(
@@ -249,7 +233,7 @@ async def test_abort_and_delete_raise_s3_upload_abort_error(
     """S3UploadAbortError is raised by both abort and delete methods when
     the underlying abort fails.
     """
-    s3_upload_details = make_s3_upload_details(s3_upload_id="some-upload-id")
+    file_upload = make_file_upload(s3_upload_id="some-upload-id")
     _, storage = object_storages.for_alias(TEST_STORAGE_ALIAS)
 
     async def do_error(*args, **kwargs):
@@ -258,36 +242,34 @@ async def test_abort_and_delete_raise_s3_upload_abort_error(
     storage.abort_multipart_upload = do_error  # type: ignore[method-assign]
 
     with pytest.raises(S3ClientPort.S3UploadAbortError):
-        await s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+        await s3_client.delete_inbox_file(file_upload=file_upload)
 
     with pytest.raises(S3ClientPort.S3UploadAbortError):
-        await s3_client.abort_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.abort_multipart_upload(file_upload=file_upload)
 
 
 async def test_unknown_storage_alias_raises_error(s3_client: S3ClientPort):
     """All S3Client methods raise UnknownStorageAliasError for unknown storage aliases."""
     file_upload = make_file_upload(storage_alias="unknown_storage_alias")
-    s3_upload_details = make_s3_upload_details()
-    s3_upload_details.storage_alias = "unknown_storage_alias"
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
-        await s3_client.init_multipart_upload(file_upload=file_upload)
-
-    with pytest.raises(S3ClientPort.UnknownStorageAliasError):
-        await s3_client.get_part_upload_url(
-            s3_upload_details=s3_upload_details, part_no=1
+        await s3_client.init_multipart_upload(
+            file_upload_basics=_to_basics(file_upload)
         )
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
-        await s3_client.complete_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.get_part_upload_url(file_upload=file_upload, part_no=1)
+
+    with pytest.raises(S3ClientPort.UnknownStorageAliasError):
+        await s3_client.complete_multipart_upload(file_upload=file_upload)
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
         await s3_client.get_object_etag(
-            s3_upload_details=s3_upload_details, object_id=s3_upload_details.object_id
+            file_upload=file_upload, object_id=file_upload.object_id
         )
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
-        await s3_client.delete_inbox_file(s3_upload_details=s3_upload_details)
+        await s3_client.delete_inbox_file(file_upload=file_upload)
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
-        await s3_client.abort_multipart_upload(s3_upload_details=s3_upload_details)
+        await s3_client.abort_multipart_upload(file_upload=file_upload)


### PR DESCRIPTION
Removes the `S3UploadDetails` model completely from UCS, folding the important fields instead into the `FileUpload` model (mainly upload_id).
This simplifies some of the code (one less DAO), reduces the number of different failure points, consolidates some error handling, and is more in line with best practices for NoSQL data modeling.
Bumps the minor version so UCS is now at `11.1.0` and the monorepo itself goes to `10.1.0`