### PR TITLE
FIS: Don't require decrypted_sha256 during init state

### DIFF
--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:10.0.0
+docker pull ghga/file-ingest-service:10.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:10.0.0 .
+docker build -t ghga/file-ingest-service:10.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:10.0.0 --help
+docker run -p 8080:8080 ghga/file-ingest-service:10.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -8,9 +8,12 @@ components:
           title: Bucket Id
           type: string
         decrypted_sha256:
-          description: SHA-256 checksum of the entire unencrypted file content
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: SHA-256 checksum of the entire unencrypted file content. This
+            will be None when the FileUpload is still in the init state.
           title: Decrypted Sha256
-          type: string
         decrypted_size:
           description: The size of the unencrypted file
           title: Decrypted Size
@@ -43,7 +46,6 @@ components:
       - storage_alias
       - bucket_id
       - object_id
-      - decrypted_sha256
       - decrypted_size
       - encrypted_size
       - part_size
@@ -177,7 +179,7 @@ info:
   description: A service to liaise between Central File Services and Data Hubs for
     file inspection.
   title: File Ingest Service
-  version: 10.0.0
+  version: 10.0.1
 openapi: 3.1.0
 paths:
   /health:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "10.0.0"
+version = "10.0.1"
 description = "File Ingest Service - A service to liaise between Central File Services and Data Hubs for file inspection."
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/core/models.py
+++ b/services/fis/src/fis/core/models.py
@@ -33,9 +33,12 @@ class BaseFileInformation(BaseModel):
     object_id: UUID4 = Field(
         default=..., description="The ID of the file specific to its S3 bucket."
     )
-    decrypted_sha256: str = Field(
-        default=...,
-        description="SHA-256 checksum of the entire unencrypted file content",
+    decrypted_sha256: str | None = Field(
+        default=None,
+        description=(
+            "SHA-256 checksum of the entire unencrypted file content. This will be"
+            + " None when the FileUpload is still in the init state."
+        ),
     )
     decrypted_size: int = Field(
         default=..., description="The size of the unencrypted file"
@@ -65,6 +68,19 @@ class FileUnderInterrogation(BaseFileInformation):
         default=False,
         description="Indicates whether the file can be deleted from the interrogation bucket",
     )
+
+    @model_validator(mode="after")
+    def validate_conditional_fields(self) -> "FileUnderInterrogation":
+        """Validate that conditional fields are set based on passed status."""
+        if not self.decrypted_sha256 and self.state not in [
+            "init",
+            "failed",
+            "cancelled",
+        ]:
+            raise ValueError(
+                f"The field decrypted_sha256 cannot be empty when state is {self.state}."
+            )
+        return self
 
 
 class InterrogationReport(BaseModel):

--- a/services/fis/tests_fis/fixtures/utils.py
+++ b/services/fis/tests_fis/fixtures/utils.py
@@ -32,7 +32,7 @@ def create_file_under_interrogation(storage_alias: str):
         storage_alias=storage_alias,
         bucket_id="inbox1",
         object_id=uuid4(),
-        decrypted_sha256="",
+        decrypted_sha256="38d141b35057bbb691b9756c20a6c31a0ab0bbf2076538a7fb6d9ee8835096d7",
         decrypted_size=123456789,
         encrypted_size=123466789,
         part_size=12345,

--- a/services/fis/tests_fis/unit/test_models.py
+++ b/services/fis/tests_fis/unit/test_models.py
@@ -15,13 +15,15 @@
 
 """Unit tests for models"""
 
+from contextlib import nullcontext
 from uuid import uuid4
 
 import pytest
+from ghga_event_schemas.pydantic_ import FileUploadState
 from hexkit.utils import now_utc_ms_prec
 from pydantic import SecretBytes, ValidationError
 
-from fis.core.models import InterrogationReportWithSecret
+from fis.core.models import FileUnderInterrogation, InterrogationReportWithSecret
 
 
 def test_interrogation_report_validator():
@@ -121,3 +123,44 @@ def test_interrogation_report_validator():
             passed=False,
             reason=None,
         )
+
+
+@pytest.mark.parametrize("decrypted_sha256", [None, "", "bigchecksum"])
+@pytest.mark.parametrize(
+    "state",
+    [
+        "init",
+        "inbox",
+        "failed",
+        "cancelled",
+        "interrogated",
+        "awaiting_archival",
+        "archived",
+    ],
+)
+def test_file_under_interrogation(decrypted_sha256: str | None, state: FileUploadState):
+    """Test for the model validator on FileUnderInterrogation"""
+    payload = {
+        "id": "dc1f885b-fddf-4b84-9f1c-0219d568eefa",
+        "box_id": "1e6683b1-65e4-45d6-8423-69f86c1ddd04",
+        "alias": "INDV_SF_1",
+        "state": state,
+        "state_updated": "2026-04-21T09:04:37.349000+00:00",
+        "storage_alias": "primary",
+        "bucket_id": "hub1-inbox",
+        "object_id": "1d366477-6a1c-4208-a2d7-6c5923aa39d9",
+        "secret_id": None,
+        "decrypted_size": 3,
+        "encrypted_size": 155,
+        "decrypted_sha256": decrypted_sha256,
+        "encrypted_parts_md5": None,
+        "encrypted_parts_sha256": None,
+        "part_size": 5368708140,
+        "failure_reason": None,
+    }
+
+    # Should get an error when state is not one of these and the checksum is also blank
+    should_error = not (state in ["init", "failed", "cancelled"] or decrypted_sha256)
+
+    with pytest.raises(ValidationError) if should_error else nullcontext():
+        _ = FileUnderInterrogation(**payload)


### PR DESCRIPTION
 Set `BaseFileInformation.decrypted_sha256` to optional when state is either `"init"`, `"failed"`, or `"cancelled"`.

Bumps version to `10.0.1`