### PR TITLE
FIS: Update to expect correct EKSS response format

### DIFF
--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:10.0.1
+docker pull ghga/file-ingest-service:11.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:10.0.1 .
+docker build -t ghga/file-ingest-service:11.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:10.0.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:11.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -179,7 +179,7 @@ info:
   description: A service to liaise between Central File Services and Data Hubs for
     file inspection.
   title: File Ingest Service
-  version: 10.0.1
+  version: 11.0.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "10.0.1"
+version = "11.0.0"
 description = "File Ingest Service - A service to liaise between Central File Services and Data Hubs for file inspection."
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/adapters/outbound/secrets.py
+++ b/services/fis/src/fis/adapters/outbound/secrets.py
@@ -79,7 +79,12 @@ class SecretsClient(SecretsClientPort):
             )
             raise self.SecretsApiError()
 
-        return response.json()
+        try:
+            secret_id = response.json().get("secret_id")
+        except Exception as err:
+            raise self.SecretsApiError() from err
+        else:
+            return secret_id
 
     async def delete_secret(self, *, secret_id: str) -> None:
         """Delete a file encryption secret from the Secrets API"""

--- a/services/fis/src/fis/adapters/outbound/secrets.py
+++ b/services/fis/src/fis/adapters/outbound/secrets.py
@@ -82,9 +82,9 @@ class SecretsClient(SecretsClientPort):
         try:
             secret_id = response.json().get("secret_id")
         except Exception as err:
+            log.error("Failed to retrieve secret_id from response body.")
             raise self.SecretsApiError() from err
-        else:
-            return secret_id
+        return secret_id
 
     async def delete_secret(self, *, secret_id: str) -> None:
         """Delete a file encryption secret from the Secrets API"""

--- a/services/fis/tests_fis/integration/test_core.py
+++ b/services/fis/tests_fis/integration/test_core.py
@@ -57,7 +57,7 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
     ekss_url = f"{joint_fixture.config.ekss_api_url}/secrets"
     secret_id = "some-secret-id"
     httpx_mock.add_response(
-        url=ekss_url, method="POST", status_code=201, json=secret_id
+        url=ekss_url, method="POST", status_code=201, json={"secret_id": secret_id}
     )
 
     # Submit a successful interrogation report and check for the published event

--- a/services/fis/tests_fis/unit/test_secrets.py
+++ b/services/fis/tests_fis/unit/test_secrets.py
@@ -48,7 +48,7 @@ async def test_happy_deposition(httpx_mock: HTTPXMock, client: SecretsClient):
         url=f"{BASE_URL}/secrets",
         method="POST",
         status_code=201,
-        json=SECRET_ID,
+        json={"secret_id": SECRET_ID},
     )
 
     result = await client.deposit_secret(secret=SECRET_BYTES)
@@ -77,6 +77,17 @@ async def test_deposition_errors(httpx_mock: HTTPXMock, client: SecretsClient):
         httpx.ConnectError("Connection refused"),
         url=f"{BASE_URL}/secrets",
         method="POST",
+    )
+
+    with pytest.raises(SecretsClient.SecretsApiError):
+        await client.deposit_secret(secret=SECRET_BYTES)
+
+    # Invalid JSON response body should raise SecretsApiError
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/secrets",
+        method="POST",
+        status_code=201,
+        content=b"not valid json",
     )
 
     with pytest.raises(SecretsClient.SecretsApiError):


### PR DESCRIPTION
Goes along with the [EKSS PR](https://github.com/ghga-de/file-services-backend/pull/165).

Bumps FIS version to `11.0.0`

Monorepo version was bumped in the EKSS PR.