### PR TITLE
IFRS: Remove unused config (GSI-2343)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "11.0.1"
+version = "11.0.2"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "11.0.1"
+version = "11.0.2"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.19",

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -192,26 +192,6 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/file_interrogations_topic"></a>**`file_interrogations_topic`** *(string, required)*: The name of the topic use to publish file interrogation outcome events.
-
-
-  Examples:
-
-  ```json
-  "file-interrogations"
-  ```
-
-
-- <a id="properties/interrogation_success_type"></a>**`interrogation_success_type`** *(string, required)*: The type used for events informing about successful file validations.
-
-
-  Examples:
-
-  ```json
-  "interrogation_success"
-  ```
-
-
 - <a id="properties/file_deletion_request_topic"></a>**`file_deletion_request_topic`** *(string, required)*: The name of the topic to receive events informing about files to delete.
 
 

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:7.0.0
+docker pull ghga/internal-file-registry-service:7.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:7.0.0 .
+docker build -t ghga/internal-file-registry-service:7.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:7.0.0 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:7.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/config_schema.json
+++ b/services/ifrs/config_schema.json
@@ -226,22 +226,6 @@
       "title": "File Staged Type",
       "type": "string"
     },
-    "file_interrogations_topic": {
-      "description": "The name of the topic use to publish file interrogation outcome events.",
-      "examples": [
-        "file-interrogations"
-      ],
-      "title": "File Interrogations Topic",
-      "type": "string"
-    },
-    "interrogation_success_type": {
-      "description": "The type used for events informing about successful file validations.",
-      "examples": [
-        "interrogation_success"
-      ],
-      "title": "Interrogation Success Type",
-      "type": "string"
-    },
     "file_deletion_request_topic": {
       "description": "The name of the topic to receive events informing about files to delete.",
       "examples": [
@@ -502,8 +486,6 @@
     "file_deleted_type",
     "file_staged_topic",
     "file_staged_type",
-    "file_interrogations_topic",
-    "interrogation_success_type",
     "file_deletion_request_topic",
     "file_deletion_request_type",
     "files_to_stage_topic",

--- a/services/ifrs/dev_config.yaml
+++ b/services/ifrs/dev_config.yaml
@@ -10,8 +10,6 @@ object_storages:
 service_instance_id: "001"
 kafka_servers: ["kafka:9092"]
 kafka_enable_dlq: True
-file_interrogations_topic: file-interrogations
-interrogation_success_type: file_interrogation_success
 files_to_stage_topic: file-downloads
 files_to_stage_type: file_staging_requested
 file_deletion_request_topic: file-deletion-requests

--- a/services/ifrs/example_config.yaml
+++ b/services/ifrs/example_config.yaml
@@ -7,14 +7,12 @@ file_deletion_request_topic: file-deletion-requests
 file_deletion_request_type: file_deletion_requested
 file_internally_registered_topic: internal-file-registry
 file_internally_registered_type: file_registered
-file_interrogations_topic: file-interrogations
 file_staged_topic: file-stagings
 file_staged_type: file_staged_for_download
 file_upload_topic: file-uploads
 files_to_stage_topic: file-downloads
 files_to_stage_type: file_staging_requested
 generate_correlation_id: true
-interrogation_success_type: file_interrogation_success
 kafka_compression_type: null
 kafka_dlq_topic: dlq
 kafka_enable_dlq: true

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "7.0.0"
+version = "7.0.1"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
+++ b/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
@@ -19,7 +19,6 @@ import logging
 
 from ghga_event_schemas.configs import (
     FileDeletionRequestEventsConfig,
-    FileInterrogationSuccessEventsConfig,
     FileStagingRequestedEventsConfig,
     FileUploadEventsConfig,
 )
@@ -38,9 +37,7 @@ log = logging.getLogger(__name__)
 
 
 class EventSubTranslatorConfig(
-    FileStagingRequestedEventsConfig,
-    FileDeletionRequestEventsConfig,
-    FileInterrogationSuccessEventsConfig,
+    FileStagingRequestedEventsConfig, FileDeletionRequestEventsConfig
 ):
     """Config for the event subscriber"""
 
@@ -56,12 +53,10 @@ class EventSubTranslator(EventSubscriberProtocol):
         self.topics_of_interest = [
             config.files_to_stage_topic,
             config.file_deletion_request_topic,
-            config.file_interrogations_topic,
         ]
         self.types_of_interest = [
             config.files_to_stage_type,
             config.file_deletion_request_type,
-            config.interrogation_success_type,
         ]
 
     @TRACER.start_as_current_span("EventSubTranslator._consume_file_staging_request")

--- a/services/ifrs/tests_ifrs/fixtures/test_config.yaml
+++ b/services/ifrs/tests_ifrs/fixtures/test_config.yaml
@@ -23,8 +23,6 @@ db_name: "dev"
 service_instance_id: "001"
 kafka_servers: ["kafka:9092"]
 kafka_enable_dlq: True
-file_interrogations_topic: file-interrogations
-interrogation_success_type: file_interrogation_success
 files_to_stage_topic: file-downloads
 files_to_stage_type: file_staging_requested
 file_deletion_request_topic: file-deletion-requests


### PR DESCRIPTION
The file interrogations event config was still present from an earlier design of the upload path. Took it out.