### PR TITLE
UCS: Concurrent upload cap (GSI-2337)

### DIFF
--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -612,6 +612,8 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/max_concurrent_uploads_per_box"></a>**`max_concurrent_uploads_per_box`** *(integer)*: Maximum number of in-progress FileUploads allowed per box at any one time. When a new upload would exceed this count, the request is rejected with 429 Too Many Requests. Exclusive minimum: `0`. Default: `5`.
+
 ## Definitions
 
 

--- a/services/ucs/config_schema.json
+++ b/services/ucs/config_schema.json
@@ -670,6 +670,13 @@
         []
       ],
       "title": "Cors Exposed Headers"
+    },
+    "max_concurrent_uploads_per_box": {
+      "default": 5,
+      "description": "Maximum number of in-progress FileUploads allowed per box at any one time. When a new upload would exceed this count, the request is rejected with 429 Too Many Requests.",
+      "exclusiveMinimum": 0,
+      "title": "Max Concurrent Uploads Per Box",
+      "type": "integer"
     }
   },
   "required": [

--- a/services/ucs/example_config.yaml
+++ b/services/ucs/example_config.yaml
@@ -36,6 +36,7 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+max_concurrent_uploads_per_box: 5
 migration_max_wait_sec: null
 migration_wait_sec: 10
 mongo_dsn: '**********'

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -542,6 +542,40 @@ components:
       properties: {}
       title: HttpS3UploadNotFoundErrorData
       type: object
+    HttpTooManyOpenUploadsError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpTooManyOpenUploadsErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: tooManyOpenUploads
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpTooManyOpenUploadsError
+      type: object
+    HttpTooManyOpenUploadsErrorData:
+      properties:
+        box_id:
+          format: uuid4
+          title: Box Id
+          type: string
+        max_concurrent:
+          title: Max Concurrent
+          type: integer
+      required:
+      - box_id
+      - max_concurrent
+      title: HttpTooManyOpenUploadsErrorData
+      type: object
     HttpUnknownStorageAliasError:
       additionalProperties: false
       properties:
@@ -893,6 +927,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpTooManyOpenUploadsError'
+          description: 'Exceptions by ID:
+
+            - tooManyOpenUploads: The box already has the maximum number of concurrent
+            in-progress uploads.'
         '507':
           content:
             application/json:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -307,6 +307,35 @@ class HttpBoxMaxSizeExceededError(HttpCustomExceptionBase):
         )
 
 
+class HttpTooManyOpenUploadsError(HttpCustomExceptionBase):
+    """Thrown when a box already has the maximum number of concurrent in-progress uploads."""
+
+    exception_id = "tooManyOpenUploads"
+
+    class DataModel(BaseModel):
+        """Model for exception data"""
+
+        box_id: UUID4
+        max_concurrent: int
+
+    def __init__(
+        self,
+        *,
+        box_id: UUID4,
+        max_concurrent: int,
+        status_code: int = 429,
+    ):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=(
+                f"Box {box_id} already has {max_concurrent} in-progress upload(s)."
+                " Cancel or complete an existing upload before starting another."
+            ),
+            data={"box_id": str(box_id), "max_concurrent": max_concurrent},
+        )
+
+
 class HttpNotAuthorizedError(HttpCustomExceptionBase):
     """Thrown when the user is not authorized to perform the requested action."""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -132,6 +132,14 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpMaxSizeTooLowError.get_body_model(),
     },
+    "tooManyOpenUploads": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- tooManyOpenUploads: The box already has the maximum number"
+            + " of concurrent in-progress uploads."
+        ),
+        "model": http_exceptions.HttpTooManyOpenUploadsError.get_body_model(),
+    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -315,6 +323,7 @@ async def get_box_uploads(
         | ERROR_RESPONSES["fileUploadAlreadyExists"]
         | ERROR_RESPONSES["orphanedMultipartUpload"],
         status.HTTP_507_INSUFFICIENT_STORAGE: ERROR_RESPONSES["boxMaxSizeExceeded"],
+        status.HTTP_429_TOO_MANY_REQUESTS: ERROR_RESPONSES["tooManyOpenUploads"],
     },
 )
 @TRACER.start_as_current_span("routes.create_file_upload")
@@ -360,6 +369,11 @@ async def create_file_upload(
             max_size=error.max_size,
             current_size=error.current_size,
             file_alias=file_alias,
+        ) from error
+    except UploadControllerPort.TooManyOpenUploadsError as error:
+        raise http_exceptions.HttpTooManyOpenUploadsError(
+            box_id=box_id,
+            max_concurrent=error.max_concurrent,
         ) from error
     except UploadControllerPort.FileUploadAlreadyExists as error:
         raise http_exceptions.HttpFileUploadAlreadyExistsError(

--- a/services/ucs/src/ucs/config.py
+++ b/services/ucs/src/ucs/config.py
@@ -23,6 +23,7 @@ from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.mongodb.migrations import MigrationConfig
 from hexkit.providers.mongokafka import MongoKafkaConfig
+from pydantic import Field, PositiveInt
 from pydantic_settings import BaseSettings
 
 from ucs.adapters.inbound.event_sub import EventSubConfig
@@ -52,3 +53,11 @@ class Config(
     """Config parameters and their defaults."""
 
     service_name: str = SERVICE_NAME
+    max_concurrent_uploads_per_box: PositiveInt = Field(
+        default=5,
+        description=(
+            "Maximum number of in-progress FileUploads allowed per box"
+            " at any one time. When a new upload would exceed this count, the request is"
+            " rejected with 429 Too Many Requests."
+        ),
+    )

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -265,12 +265,25 @@ class UploadController(UploadControllerPort):
         extra["storage_alias"] = storage_alias
         extra["bucket_id"] = bucket_id
 
+        # Get both box size + in progress size and the number of in progress files
         current_size = box.size
+        in_progress_count = 0
         async for upload in self._file_upload_dao.find_all(
             mapping={"box_id": box.id, "state": "init"}
         ):
             current_size += upload.decrypted_size
+            in_progress_count += 1
 
+        # Ensure that another upload is allowed at the moment
+        max_concurrent = self._config.max_concurrent_uploads_per_box
+        if max_concurrent > 0 and in_progress_count >= max_concurrent:
+            error = self.TooManyOpenUploadsError(
+                box_id=box.id, max_concurrent=max_concurrent
+            )
+            log.error(error, extra=extra)
+            raise error
+
+        # Ensure file size doesn't exceed box limit
         if current_size + decrypted_size > box.max_size:
             error = self.BoxMaxSizeExceededError(
                 box_id=box.id, max_size=box.max_size, current_size=current_size

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -276,7 +276,7 @@ class UploadController(UploadControllerPort):
 
         # Ensure that another upload is allowed at the moment
         max_concurrent = self._config.max_concurrent_uploads_per_box
-        if max_concurrent > 0 and in_progress_count >= max_concurrent:
+        if in_progress_count >= max_concurrent:
             error = self.TooManyOpenUploadsError(
                 box_id=box.id, max_concurrent=max_concurrent
             )

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -141,6 +141,17 @@ class UploadControllerPort(ABC):
             )
             super().__init__(msg)
 
+    class TooManyOpenUploadsError(UploadError):
+        """Raised when a box already has the configured maximum number of in-progress uploads."""
+
+        def __init__(self, *, box_id: UUID4, max_concurrent: int):
+            self.max_concurrent = max_concurrent
+            msg = (
+                f"Box {box_id} already has {max_concurrent} in-progress upload(s)."
+                " Cancel or complete an existing upload before starting another."
+            )
+            super().__init__(msg)
+
     class FileUploadAlreadyExists(UploadError):
         """Raised when a FileUpload can't be created for a given box ID and file alias
         because one already exists.
@@ -205,6 +216,7 @@ class UploadControllerPort(ABC):
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxMaxSizeExceededError` if adding the file would exceed the box's size limit.
+        - `TooManyOpenUploadsError` if the box is already at the concurrent upload limit.
         - `FileUploadAlreadyExists` if there's already a FileUpload for this alias.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAlreadyInProgressError` if an upload is already in progress.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -537,6 +537,14 @@ async def test_view_box_endpoint_error_handling(
                 file_alias="test_file",
             ),
         ),
+        (
+            UploadControllerPort.TooManyOpenUploadsError(
+                box_id=TEST_BOX_ID, max_concurrent=3
+            ),
+            http_exceptions.HttpTooManyOpenUploadsError(
+                box_id=TEST_BOX_ID, max_concurrent=3
+            ),
+        ),
     ],
     ids=[
         "BoxNotFound",
@@ -546,6 +554,7 @@ async def test_view_box_endpoint_error_handling(
         "UploadAlreadyInProgressError",
         "InternalError",
         "BoxMaxSizeExceededError",
+        "TooManyOpenUploadsError",
     ],
 )
 async def test_create_file_upload_endpoint_error_handling(

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1216,6 +1216,54 @@ async def test_finished_uploads_count_toward_limit(rig: JointRig):
     assert rig.file_upload_dao.latest.id == file_id3
 
 
+async def test_concurrent_upload_cap(rig: JointRig):
+    """Concurrent upload cap by trying to create a new FileUpload when the current
+    file count is below the limit and at the limit.
+    """
+    limit = rig.config.max_concurrent_uploads_per_box
+    box_id = await rig.controller.create_file_upload_box(
+        storage_alias="test", max_size=TEST_MAX_BOX_SIZE
+    )
+    # Use all of our in-flight quota
+    for i in range(limit):
+        await rig.controller.initiate_file_upload(
+            box_id=box_id,
+            alias=f"existing_{i}",
+            decrypted_size=1,
+            encrypted_size=1,
+            part_size=PART_SIZE,
+        )
+
+    # Trigger the new error by trying to start another upload
+    with pytest.raises(UploadControllerPort.TooManyOpenUploadsError):
+        await rig.controller.initiate_file_upload(
+            box_id=box_id,
+            alias="new_file",
+            decrypted_size=1,
+            encrypted_size=1,
+            part_size=PART_SIZE,
+        )
+
+    # Now complete a file to free up a slot
+    await rig.controller.complete_file_upload(
+        box_id=box_id,
+        file_id=rig.file_upload_dao.latest.id,
+        unencrypted_checksum="abc",
+        encrypted_checksum=f"etag_for_{rig.file_upload_dao.latest.object_id}",
+        encrypted_parts_md5=["a1", "b2"],
+        encrypted_parts_sha256=["a1", "b2"],
+    )
+
+    # Test that we can now upload a file again
+    _ = await rig.controller.initiate_file_upload(
+        box_id=box_id,
+        alias="new_file",
+        decrypted_size=1,
+        encrypted_size=1,
+        part_size=PART_SIZE,
+    )
+
+
 def _make_matching_event(file_upload: FileUpload) -> FileInternallyRegistered:
     """Create a FileInternallyRegistered event that matches the given FileUpload."""
     return FileInternallyRegistered(

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1226,7 +1226,7 @@ async def test_concurrent_upload_cap(rig: JointRig):
     )
     # Use all of our in-flight quota
     for i in range(limit):
-        await rig.controller.initiate_file_upload(
+        _ = await rig.controller.initiate_file_upload(
             box_id=box_id,
             alias=f"existing_{i}",
             decrypted_size=1,
@@ -1236,7 +1236,7 @@ async def test_concurrent_upload_cap(rig: JointRig):
 
     # Trigger the new error by trying to start another upload
     with pytest.raises(UploadControllerPort.TooManyOpenUploadsError):
-        await rig.controller.initiate_file_upload(
+        _ = await rig.controller.initiate_file_upload(
             box_id=box_id,
             alias="new_file",
             decrypted_size=1,
@@ -1262,6 +1262,17 @@ async def test_concurrent_upload_cap(rig: JointRig):
         encrypted_size=1,
         part_size=PART_SIZE,
     )
+
+    # And finally check that crossing the limit once again triggers the error
+    # Trigger the new error by trying to start another upload
+    with pytest.raises(UploadControllerPort.TooManyOpenUploadsError):
+        _ = await rig.controller.initiate_file_upload(
+            box_id=box_id,
+            alias="new_file",
+            decrypted_size=1,
+            encrypted_size=1,
+            part_size=PART_SIZE,
+        )
 
 
 def _make_matching_event(file_upload: FileUpload) -> FileInternallyRegistered:


### PR DESCRIPTION
This adds the config option `max_concurrent_uploads_per_box` with a default of 5. Unlike in the epic spec, this cannot be disabled - I don't see an operational reason to do that.

The core gains a `TooManyOpenUploadsError`, which is translated at the API layer to `HttpTooManyOpenUploadsError`, status code 429.

There's a test that verifies the error translation and another one that verifies the cap functions as expected.

In the core, the in-progress file uploads are counted by looking for `state="init"`, which occurs at the same time as we're tallying up the current box size. (The core first checks if the concurrent upload cap is exceeded before checking if file size would exceeded remaining box space. This order is arbitrary since both items are available at the same time.)
