### PR TITLE
Validate part size (GSI-2353)

### DIFF
--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -238,7 +238,9 @@ components:
           type: integer
         part_size:
           description: The number of bytes in each file part (last part may be smaller)
-          minimum: 1.0
+          exclusiveMinimum: 0.0
+          maximum: 5368709120.0
+          minimum: 5242880.0
           title: Part Size
           type: integer
       required:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -517,6 +517,39 @@ components:
       - file_alias
       title: HttpOrphanedMultipartUploadErrorData
       type: object
+    HttpPartSizeError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpPartSizeErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: invalidPartSize
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpPartSizeError
+      type: object
+    HttpPartSizeErrorData:
+      properties:
+        file_alias:
+          title: File Alias
+          type: string
+        part_size:
+          title: Part Size
+          type: integer
+      required:
+      - file_alias
+      - part_size
+      title: HttpPartSizeErrorData
+      type: object
     HttpS3UploadNotFoundError:
       additionalProperties: false
       properties:
@@ -899,10 +932,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpUnknownStorageAliasError'
+                $ref: '#/components/schemas/HttpPartSizeError'
           description: 'Exceptions by ID:
 
-            - noSuchStorage: The storage node for the given alias does not exist.'
+            - invalidPartSize: The specified part size is invalid (too small, too
+            large, or would result in too many parts).'
         '404':
           content:
             application/json:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -330,9 +330,33 @@ class HttpTooManyOpenUploadsError(HttpCustomExceptionBase):
             status_code=status_code,
             description=(
                 f"Box {box_id} already has {max_concurrent} in-progress upload(s)."
-                " Cancel or complete an existing upload before starting another."
+                + " Cancel or complete an existing upload before starting another."
             ),
             data={"box_id": str(box_id), "max_concurrent": max_concurrent},
+        )
+
+
+class HttpPartSizeError(HttpCustomExceptionBase):
+    """Thrown when the specified part size is invalid."""
+
+    exception_id = "invalidPartSize"
+
+    class DataModel(BaseModel):
+        """Model for exception data"""
+
+        file_alias: str
+        part_size: int
+
+    def __init__(self, *, file_alias: str, part_size: int, status_code: int = 400):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=(
+                f"The part size {part_size} for file '{file_alias}' is invalid."
+                + " It must be between 5 MiB and 5 GiB and no less than 1/10000th of"
+                + " the total part size."
+            ),
+            data={"file_alias": file_alias, "part_size": part_size},
         )
 
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -354,7 +354,7 @@ class HttpPartSizeError(HttpCustomExceptionBase):
             description=(
                 f"The part size {part_size} for file '{file_alias}' is invalid."
                 + " It must be between 5 MiB and 5 GiB and no less than 1/10000th of"
-                + " the total part size."
+                + " the total file size."
             ),
             data={"file_alias": file_alias, "part_size": part_size},
         )

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -20,6 +20,8 @@ from typing import Literal, TypeVar
 from ghga_event_schemas.pydantic_ import UploadBoxState
 from pydantic import UUID4, BaseModel, ConfigDict, Field, PositiveInt, model_validator
 
+from ucs.constants import MAX_PART_SIZE, MIN_PART_SIZE
+
 
 class BoxCreationRequest(BaseModel):
     """Request body for creating a new FileUploadBox."""
@@ -71,10 +73,11 @@ class FileUploadCreationRequest(BaseModel):
     encrypted_size: int = Field(
         ..., description="The size of the encrypted file in bytes", ge=1
     )
-    part_size: int = Field(
+    part_size: PositiveInt = Field(
         ...,
         description="The number of bytes in each file part (last part may be smaller)",
-        ge=1,
+        ge=MIN_PART_SIZE,
+        le=MAX_PART_SIZE,
     )
 
     @model_validator(mode="after")

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -140,6 +140,14 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpTooManyOpenUploadsError.get_body_model(),
     },
+    "invalidPartSize": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- invalidPartSize: The specified part size is invalid (too small,"
+            + " too large, or would result in too many parts)."
+        ),
+        "model": http_exceptions.HttpPartSizeError.get_body_model(),
+    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -317,7 +325,8 @@ async def get_box_uploads(
     response_model=rest_models.FileUploadCreationResponse,
     response_description="The file_id of the newly created FileUpload",
     responses={
-        status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["noSuchStorage"],
+        status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["noSuchStorage"]
+        | ERROR_RESPONSES["invalidPartSize"],
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"]
         | ERROR_RESPONSES["fileUploadAlreadyExists"]
@@ -327,7 +336,7 @@ async def get_box_uploads(
     },
 )
 @TRACER.start_as_current_span("routes.create_file_upload")
-async def create_file_upload(
+async def create_file_upload(  # noqa: C901
     box_id: UUID4,
     file_upload_creation: rest_models.FileUploadCreationRequest,
     work_order: Annotated[
@@ -386,6 +395,10 @@ async def create_file_upload(
     except UploadControllerPort.UploadAlreadyInProgressError as error:
         raise http_exceptions.HttpOrphanedMultipartUploadError(
             file_alias=file_alias
+        ) from error
+    except UploadControllerPort.PartSizeError as error:
+        raise http_exceptions.HttpPartSizeError(
+            file_alias=file_alias, part_size=error.part_size
         ) from error
     except Exception as error:
         log.error(error, exc_info=True)

--- a/services/ucs/src/ucs/constants.py
+++ b/services/ucs/src/ucs/constants.py
@@ -20,3 +20,6 @@ SERVICE_NAME = "ucs"
 TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
 FILE_UPLOAD_BOXES_COLLECTION = "fileUploadBoxes"
 FILE_UPLOADS_COLLECTION = "fileUploads"
+MIN_PART_SIZE = 5 * 1024**2
+MAX_PART_SIZE = 5 * 1024**3
+MAX_PART_COUNT = 10000

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -16,6 +16,7 @@
 """Implements the UploadController class to manage file uploads"""
 
 import logging
+from math import ceil
 from typing import Any
 from uuid import uuid4
 
@@ -29,6 +30,7 @@ from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4
 
 from ucs.config import Config
+from ucs.constants import MAX_PART_COUNT, MAX_PART_SIZE, MIN_PART_SIZE
 from ucs.core.models import FileUpload, FileUploadBasics, FileUploadBox
 from ucs.ports.inbound.controller import UploadControllerPort
 from ucs.ports.outbound.dao import (
@@ -248,9 +250,13 @@ class UploadController(UploadControllerPort):
         Raises:
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
+        - `BoxMaxSizeExceededError` if adding the file would exceed the box's size limit.
+        - `TooManyOpenUploadsError` if the box is already at the concurrent upload limit.
         - `FileUploadAlreadyExists` if there's already a FileUpload for this alias.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAlreadyInProgressError` if an upload is already in progress.
+        - `PartSizeError` if the specified part size would results in more
+            parts than S3 allows, or is smaller or larger than what S3 allows.
         """
         extra: dict[str, Any] = {"box_id": box_id, "alias": alias}
         # Get the box and resolve S3 storage details
@@ -290,6 +296,14 @@ class UploadController(UploadControllerPort):
             )
             log.error(error, extra=extra)
             raise error
+
+        # Ensure part size is okay - verify size & implied part count
+        implied_part_count = ceil(encrypted_size / part_size)
+        if (
+            not (MIN_PART_SIZE <= part_size <= MAX_PART_SIZE)
+            or implied_part_count > MAX_PART_COUNT
+        ):
+            raise self.PartSizeError(file_alias=alias, part_size=part_size)
 
         file_id = uuid4()
         object_id = uuid4()

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -297,11 +297,11 @@ class UploadController(UploadControllerPort):
             log.error(error, extra=extra)
             raise error
 
-        # Ensure part size is okay - verify size & implied part count
-        implied_part_count = ceil(encrypted_size / part_size)
+        # Ensure part size is okay - verify size & implied part count. Min and Max part
+        #  size are enforced by the pydantic model at ingress, but double-checked here
         if (
             not (MIN_PART_SIZE <= part_size <= MAX_PART_SIZE)
-            or implied_part_count > MAX_PART_COUNT
+            or ceil(encrypted_size / part_size) > MAX_PART_COUNT
         ):
             raise self.PartSizeError(file_alias=alias, part_size=part_size)
 

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -152,6 +152,16 @@ class UploadControllerPort(ABC):
             )
             super().__init__(msg)
 
+    class PartSizeError(UploadError):
+        """Raised when the specified part size is invalid: too small, too large,
+        or would result in more parts than S3 allows.
+        """
+
+        def __init__(self, *, file_alias: str, part_size: int):
+            self.part_size = part_size
+            msg = f"The part size {part_size} for file '{file_alias}' is invalid."
+            super().__init__(msg)
+
     class FileUploadAlreadyExists(UploadError):
         """Raised when a FileUpload can't be created for a given box ID and file alias
         because one already exists.
@@ -220,6 +230,8 @@ class UploadControllerPort(ABC):
         - `FileUploadAlreadyExists` if there's already a FileUpload for this alias.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAlreadyInProgressError` if an upload is already in progress.
+        - `PartSizeError` if the specified part size would results in more
+            parts than S3 allows, or is smaller or larger than what S3 allows.
         """
         ...
 

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -25,6 +25,7 @@ from ghga_service_commons.api.testing import AsyncTestClient
 
 from tests_ucs.fixtures import ConfigFixture, utils
 from ucs.adapters.inbound.fastapi_ import http_exceptions
+from ucs.constants import MAX_PART_SIZE, MIN_PART_SIZE
 from ucs.inject import prepare_rest_app
 from ucs.ports.inbound.controller import UploadControllerPort
 
@@ -562,7 +563,7 @@ async def test_view_box_endpoint_error_handling(
         "PartSizeError",
     ],
 )
-async def test_create_file_upload_endpoint_error_handling(
+async def test_create_file_upload_endpoint_error_translation(
     config: ConfigFixture,
     core_error: Exception,
     http_error: Exception,
@@ -608,6 +609,36 @@ async def test_create_file_upload_endpoint_model_validator(
         "part_size": utils.PART_SIZE,
     }
     rest_client = app_fixture.rest_client
+    token_header = utils.create_file_token_header(
+        box_id=TEST_BOX_ID, alias="test_file", jwk=wps_jwk
+    )
+    response = await rest_client.post(
+        f"/boxes/{TEST_BOX_ID}/uploads",
+        json=body,
+        headers=token_header,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "part_size",
+    [0, MIN_PART_SIZE - 1, MAX_PART_SIZE + 1],
+    ids=["zero", "too_small", "too_large"],
+)
+async def test_create_file_upload_endpoint_part_size_validation(
+    config: ConfigFixture, app_fixture: AppFixture, part_size: int
+):
+    """Test the validation for part_size"""
+    wps_jwk = config.wps_jwk
+    body = {
+        "alias": "test_file",
+        "decrypted_size": utils.DECRYPTED_SIZE,
+        "encrypted_size": utils.ENCRYPTED_SIZE,
+        "part_size": part_size,
+    }
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.initiate_file_upload.side_effect = RuntimeError("Shouldn't call the core")
     token_header = utils.create_file_token_header(
         box_id=TEST_BOX_ID, alias="test_file", jwk=wps_jwk
     )

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -545,6 +545,10 @@ async def test_view_box_endpoint_error_handling(
                 box_id=TEST_BOX_ID, max_concurrent=3
             ),
         ),
+        (
+            UploadControllerPort.PartSizeError(file_alias="test_file", part_size=1000),
+            http_exceptions.HttpPartSizeError(file_alias="test_file", part_size=1000),
+        ),
     ],
     ids=[
         "BoxNotFound",
@@ -555,6 +559,7 @@ async def test_view_box_endpoint_error_handling(
         "InternalError",
         "BoxMaxSizeExceededError",
         "TooManyOpenUploadsError",
+        "PartSizeError",
     ],
 )
 async def test_create_file_upload_endpoint_error_handling(

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -39,6 +39,7 @@ from tests_ucs.fixtures.utils import (
     TEST_MAX_BOX_SIZE,
     make_file_upload,
 )
+from ucs.constants import MAX_PART_COUNT, MAX_PART_SIZE, MIN_PART_SIZE
 from ucs.core.models import FileUpload
 from ucs.ports.inbound.controller import UploadControllerPort
 
@@ -1272,6 +1273,38 @@ async def test_concurrent_upload_cap(rig: JointRig):
             decrypted_size=1,
             encrypted_size=1,
             part_size=PART_SIZE,
+        )
+
+
+@pytest.mark.parametrize(
+    "part_size, encrypted_size, expect_error",
+    [
+        (PART_SIZE, ENCRYPTED_SIZE, False),
+        (MIN_PART_SIZE - 1, ENCRYPTED_SIZE, True),
+        (MAX_PART_SIZE + 1, ENCRYPTED_SIZE, True),
+        (MIN_PART_SIZE, MIN_PART_SIZE * (MAX_PART_COUNT + 1), True),
+    ],
+    ids=["valid", "too_small", "too_large", "too_many_parts"],
+)
+async def test_part_size_validation(
+    rig: JointRig,
+    part_size: int,
+    encrypted_size: int,
+    expect_error: bool,
+):
+    """Test the part size validation with the happy path and the failure modes."""
+    box_id = await rig.create_default_box()
+    with (
+        pytest.raises(UploadControllerPort.PartSizeError)
+        if expect_error
+        else nullcontext()
+    ):
+        _, _ = await rig.controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test_file",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=encrypted_size,
+            part_size=part_size,
         )
 
 

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1280,11 +1280,12 @@ async def test_concurrent_upload_cap(rig: JointRig):
     "part_size, encrypted_size, expect_error",
     [
         (PART_SIZE, ENCRYPTED_SIZE, False),
+        (0, ENCRYPTED_SIZE, True),
         (MIN_PART_SIZE - 1, ENCRYPTED_SIZE, True),
         (MAX_PART_SIZE + 1, ENCRYPTED_SIZE, True),
         (MIN_PART_SIZE, MIN_PART_SIZE * (MAX_PART_COUNT + 1), True),
     ],
-    ids=["valid", "too_small", "too_large", "too_many_parts"],
+    ids=["valid", "zero", "too_small", "too_large", "too_many_parts"],
 )
 async def test_part_size_validation(
     rig: JointRig,


### PR DESCRIPTION
Enforces part size constraints: `5 MiB <= part_size <= 5 GiB` and the implied part count must be no greater than 10,000. If any of these constraints are not met, the API returns `400 Bad Request`.