### PR TITLE
UCS: Verify object size during mpu completion (GSI-2364)

### DIFF
--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -392,36 +392,6 @@ components:
       - box_state
       title: HttpBoxStateErrorData
       type: object
-    HttpChecksumMismatchError:
-      additionalProperties: false
-      properties:
-        data:
-          $ref: '#/components/schemas/HttpChecksumMismatchErrorData'
-        description:
-          description: A human readable message to the client explaining the cause
-            of the exception.
-          title: Description
-          type: string
-        exception_id:
-          const: checksumMismatch
-          title: Exception Id
-          type: string
-      required:
-      - data
-      - description
-      - exception_id
-      title: HttpChecksumMismatchError
-      type: object
-    HttpChecksumMismatchErrorData:
-      properties:
-        file_id:
-          format: uuid4
-          title: File Id
-          type: string
-      required:
-      - file_id
-      title: HttpChecksumMismatchErrorData
-      type: object
     HttpFileUploadNotFoundError:
       additionalProperties: false
       properties:
@@ -695,6 +665,36 @@ components:
       - box_id
       - file_id
       title: HttpUploadCompletionErrorData
+      type: object
+    HttpUploadSizeMismatchError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpUploadSizeMismatchErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: uploadSizeMismatch
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpUploadSizeMismatchError
+      type: object
+    HttpUploadSizeMismatchErrorData:
+      properties:
+        file_id:
+          format: uuid4
+          title: File Id
+          type: string
+      required:
+      - file_id
+      title: HttpUploadSizeMismatchErrorData
       type: object
     ValidationError:
       properties:
@@ -1094,11 +1094,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpChecksumMismatchError'
+                $ref: '#/components/schemas/HttpUploadSizeMismatchError'
           description: 'Exceptions by ID:
 
-            - checksumMismatch: The user-supplied encrypted checksum doesn''t match
-            S3.'
+            - uploadSizeMismatch: The actual object size doesn''t match the declared
+            encrypted_size.'
         '404':
           content:
             application/json:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -234,6 +234,28 @@ class HttpChecksumMismatchError(HttpCustomExceptionBase):
         )
 
 
+class HttpUploadSizeMismatchError(HttpCustomExceptionBase):
+    """Thrown when the actual uploaded object size doesn't match the declared encrypted_size."""
+
+    exception_id = "uploadSizeMismatch"
+
+    class DataModel(BaseModel):
+        """Model for exception data"""
+
+        file_id: UUID4
+
+    def __init__(self, *, file_id: UUID4, status_code: int = 400):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=(
+                f"The actual size of the uploaded object for file {file_id}"
+                + " doesn't match the declared encrypted_size."
+            ),
+            data={"file_id": str(file_id)},
+        )
+
+
 class HttpMaxSizeTooLowError(HttpCustomExceptionBase):
     """Thrown when the requested max_size is less than the box's current committed size."""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -117,6 +117,13 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpChecksumMismatchError.get_body_model(),
     },
+    "uploadSizeMismatch": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- uploadSizeMismatch: The actual object size doesn't match the declared encrypted_size."
+        ),
+        "model": http_exceptions.HttpUploadSizeMismatchError.get_body_model(),
+    },
     "boxMaxSizeExceeded": {
         "description": (
             "Exceptions by ID:"
@@ -469,7 +476,8 @@ async def get_part_upload_url(
     status_code=status.HTTP_204_NO_CONTENT,
     response_description="File upload completed successfully",
     responses={
-        status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["checksumMismatch"],
+        status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["checksumMismatch"]
+        | ERROR_RESPONSES["uploadSizeMismatch"],
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"]
         | ERROR_RESPONSES["fileUploadNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"],
@@ -521,6 +529,8 @@ async def complete_file_upload(
         ) from error
     except UploadControllerPort.ChecksumMismatchError as error:
         raise http_exceptions.HttpChecksumMismatchError(file_id=file_id) from error
+    except UploadControllerPort.UploadSizeMismatchError as error:
+        raise http_exceptions.HttpUploadSizeMismatchError(file_id=file_id) from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -261,6 +261,20 @@ class S3Client(S3ClientPort):
                 )
                 raise error from err
 
+    async def get_object_size(
+        self, *, file_upload: FileUpload, object_id: UUID4
+    ) -> int:
+        """Return the size in bytes of an object in the inbox bucket.
+
+        Raises:
+            `UnknownStorageAliasError` if the storage alias is not known.
+        """
+        bucket_id = file_upload.bucket_id
+        _, object_storage = self._get_bucket_and_storage(file_upload.storage_alias)
+        return await object_storage.get_object_size(
+            bucket_id=bucket_id, object_id=str(object_id)
+        )
+
     async def abort_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Abort an in-progress multipart upload. Tolerates a missing upload.
 

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -450,6 +450,42 @@ class UploadController(UploadControllerPort):
             log.error(error, extra=extra)
             raise error
 
+    async def _verify_object_size(self, *, file_upload: FileUpload) -> None:
+        """Verify that the S3 object size matches the declared encrypted_size.
+
+        If the sizes don't match, marks the FileUpload as failed and raises
+        UploadSizeMismatchError.
+        """
+        file_id = file_upload.id
+        object_id = file_upload.object_id
+        try:
+            actual_size = await self._s3_client.get_object_size(
+                file_upload=file_upload, object_id=object_id
+            )
+        except S3ClientPort.UnknownStorageAliasError as err:
+            raise self.UnknownStorageAliasError(
+                storage_alias=file_upload.storage_alias
+            ) from err
+
+        if actual_size != file_upload.encrypted_size:
+            file_upload.state = "failed"
+            file_upload.state_updated = now_utc_ms_prec()
+            file_upload.failure_reason = "Actual object size didn't match expected size"
+            await self._file_upload_dao.update(file_upload)
+            log.info("Marked FileUpload %s as 'failed' due to size mismatch.", file_id)
+            error = self.UploadSizeMismatchError(file_id=file_id)
+            log.error(
+                error,
+                extra={
+                    "bucket_id": file_upload.bucket_id,
+                    "file_id": file_id,
+                    "object_id": object_id,
+                    "expected_size": file_upload.encrypted_size,
+                    "actual_size": actual_size,
+                },
+            )
+            raise error
+
     async def complete_file_upload(  # noqa: PLR0913
         self,
         *,
@@ -471,6 +507,7 @@ class UploadController(UploadControllerPort):
         - `BoxVersionError` if the box version changed before stats could be updated.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadCompletionError` if there's an error while telling S3 to complete the upload.
+        - `UploadSizeMismatchError` if the object size doesn't match the declared encrypted_size.
         - `ChecksumMismatchError` if the checksums don't match.
         """
         # Get the FileUploadBox instance and verify that it is unlocked
@@ -509,6 +546,9 @@ class UploadController(UploadControllerPort):
             file_upload=file_upload,
             expected_checksum=encrypted_checksum,
         )
+
+        # Verify that the actual object size matches the declared encrypted_size
+        await self._verify_object_size(file_upload=file_upload)
 
         # Update local collections now that S3 upload is successfully completed
         file_upload.state = "inbox"

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -472,7 +472,6 @@ class UploadController(UploadControllerPort):
             file_upload.state_updated = now_utc_ms_prec()
             file_upload.failure_reason = "Actual object size didn't match expected size"
             await self._file_upload_dao.update(file_upload)
-            log.info("Marked FileUpload %s as 'failed' due to size mismatch.", file_id)
             error = self.UploadSizeMismatchError(file_id=file_id)
             log.error(
                 error,

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -208,6 +208,16 @@ class UploadControllerPort(ABC):
             )
             super().__init__(msg)
 
+    class UploadSizeMismatchError(RuntimeError):
+        """Raised when the actual S3 object size doesn't match the declared encrypted_size."""
+
+        def __init__(self, *, file_id: UUID4):
+            msg = (
+                f"The actual size of the uploaded object for file {file_id}"
+                + " doesn't match the declared encrypted_size."
+            )
+            super().__init__(msg)
+
     @abstractmethod
     async def initiate_file_upload(
         self,

--- a/services/ucs/src/ucs/ports/outbound/storage.py
+++ b/services/ucs/src/ucs/ports/outbound/storage.py
@@ -142,6 +142,16 @@ class S3ClientPort(ABC):
         """
 
     @abstractmethod
+    async def get_object_size(
+        self, *, file_upload: FileUpload, object_id: UUID4
+    ) -> int:
+        """Return the size in bytes of an object in the inbox bucket.
+
+        Raises:
+            `UnknownStorageAliasError` if the storage alias is not known.
+        """
+
+    @abstractmethod
     async def abort_multipart_upload(self, *, file_upload: FileUpload) -> None:
         """Abort an in-progress multipart upload. Tolerates a missing upload.
 

--- a/services/ucs/tests_ucs/fixtures/joint.py
+++ b/services/ucs/tests_ucs/fixtures/joint.py
@@ -174,7 +174,7 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
                 return resource.encrypted_size
         return 1024  # The value that the InMem fixture otherwise returns
 
-    storage.get_object_size = mock_get_object_size  # type: ignore[method-assign]
+    storage.get_object_size = mock_get_object_size
 
     controller = UploadController(
         config=(_config),

--- a/services/ucs/tests_ucs/fixtures/joint.py
+++ b/services/ucs/tests_ucs/fixtures/joint.py
@@ -162,6 +162,20 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
     object_storages = InMemS3ObjectStorages(config=_config)
     s3_client = S3Client(config=_config, object_storages=object_storages)
 
+    # Patch get_object_size to return the encrypted_size stored in the FileUpload
+    # record for the given object_id. This lets controller tests pass the size check
+    # without needing to know what value InMemObjectStorage would otherwise return.
+    _, storage = object_storages.for_alias("test")
+
+    async def mock_get_object_size(*, bucket_id: str, object_id: str) -> int:
+        for doc in file_upload_dao.resources.values():
+            resource = file_upload_dao._deserialize(doc)
+            if str(resource.object_id) == object_id:
+                return resource.encrypted_size
+        return 1024  # The value that the InMem fixture otherwise returns
+
+    storage.get_object_size = mock_get_object_size  # type: ignore[method-assign]
+
     controller = UploadController(
         config=(_config),
         file_upload_box_dao=(file_upload_box_dao),

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -35,7 +35,9 @@ from ucs.constants import FILE_UPLOADS_COLLECTION
 from ucs.ports.inbound.controller import UploadControllerPort
 
 pytestmark = pytest.mark.asyncio()
-CONTENT = "a" * 1024
+CONTENT = "a" * 10 * 1024 * 1024  # 10 MiB
+ENCRYPTED_SIZE = len(CONTENT)
+DECRYPTED_SIZE = ENCRYPTED_SIZE - 124
 
 
 def calc_expected_encrypted_checksum(content: str) -> str:
@@ -92,12 +94,10 @@ async def test_integrated_aspects(joint_fixture: JointFixture):
         }, "Payload was wrong for new file upload box event"
 
         # Make the temp test file
-        temp_file.write(("abcdefghij" * (1024 * 1024)).encode())
+        temp_file.write(CONTENT.encode())
         temp_file.flush()
 
-        expected_encrypted_checksum = calc_expected_encrypted_checksum(
-            "abcdefghij" * (1024 * 1024)
-        )
+        expected_encrypted_checksum = calc_expected_encrypted_checksum(CONTENT)
 
         # Create a FileUpload
         async with kafka.record_events(
@@ -108,8 +108,8 @@ async def test_integrated_aspects(joint_fixture: JointFixture):
             )
             file_creation_body = {
                 "alias": "test_file",
-                "decrypted_size": utils.DECRYPTED_SIZE,
-                "encrypted_size": utils.ENCRYPTED_SIZE,
+                "decrypted_size": DECRYPTED_SIZE,
+                "encrypted_size": ENCRYPTED_SIZE,
                 "part_size": utils.PART_SIZE,
             }
             response = await rest_client.post(
@@ -243,8 +243,8 @@ async def test_s3_upload_completed_but_db_not_updated(joint_fixture: JointFixtur
         file_id, _ = await controller.initiate_file_upload(
             box_id=box_id,
             alias="test-file",
-            decrypted_size=utils.DECRYPTED_SIZE,
-            encrypted_size=utils.ENCRYPTED_SIZE,
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
             part_size=utils.PART_SIZE,
         )
     url = await controller.get_part_upload_url(file_id=file_id, part_no=1)
@@ -311,8 +311,8 @@ async def test_s3_upload_complete_fails(joint_fixture: JointFixture):
         file_id, _ = await controller.initiate_file_upload(
             box_id=box_id,
             alias="test-file",
-            decrypted_size=utils.DECRYPTED_SIZE,
-            encrypted_size=utils.ENCRYPTED_SIZE,
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
             part_size=utils.PART_SIZE,
         )
     url = await controller.get_part_upload_url(file_id=file_id, part_no=1)
@@ -368,8 +368,8 @@ async def test_s3_upload_complete_fails(joint_fixture: JointFixture):
     )
     body = {
         "alias": "test-file",
-        "decrypted_size": utils.DECRYPTED_SIZE,
-        "encrypted_size": utils.ENCRYPTED_SIZE,
+        "decrypted_size": DECRYPTED_SIZE,
+        "encrypted_size": ENCRYPTED_SIZE,
         "part_size": utils.PART_SIZE,
     }
     response = await rest_client.post(
@@ -457,8 +457,8 @@ async def test_orphaned_s3_upload_in_file_create(joint_fixture: JointFixture, ca
     )
     body = {
         "alias": "test-file",
-        "decrypted_size": utils.DECRYPTED_SIZE,
-        "encrypted_size": utils.ENCRYPTED_SIZE,
+        "decrypted_size": DECRYPTED_SIZE,
+        "encrypted_size": ENCRYPTED_SIZE,
         "part_size": utils.PART_SIZE,
     }
     with (
@@ -506,16 +506,16 @@ async def test_file_upload_index(joint_fixture: JointFixture, monkeypatch):
         _ = await joint_fixture.upload_controller.initiate_file_upload(
             box_id=box_id,
             alias="file1",
-            decrypted_size=utils.DECRYPTED_SIZE,
-            encrypted_size=utils.ENCRYPTED_SIZE,
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
             part_size=utils.PART_SIZE,
         )
         with pytest.raises(UploadControllerPort.FileUploadAlreadyExists):
             _ = await joint_fixture.upload_controller.initiate_file_upload(
                 box_id=box_id,
                 alias="file1",
-                decrypted_size=utils.DECRYPTED_SIZE,
-                encrypted_size=utils.ENCRYPTED_SIZE,
+                decrypted_size=DECRYPTED_SIZE,
+                encrypted_size=ENCRYPTED_SIZE,
                 part_size=utils.PART_SIZE,
             )
 
@@ -540,8 +540,8 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
         file_id, _ = await controller.initiate_file_upload(
             box_id=box_id,
             alias="test-file",
-            decrypted_size=utils.DECRYPTED_SIZE,
-            encrypted_size=utils.ENCRYPTED_SIZE,
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
             part_size=utils.PART_SIZE,
         )
 
@@ -597,7 +597,7 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
         interrogated_at=now_utc_ms_prec(),
         encrypted_parts_md5=["abc123"],
         encrypted_parts_sha256=["def456"],
-        encrypted_size=utils.ENCRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
     )
 
     # Put an object into the interrogation bucket to simulated DHFS's work
@@ -682,8 +682,8 @@ async def test_file_deletion_requested_event(joint_fixture: JointFixture, caplog
         file_id, _ = await controller.initiate_file_upload(
             box_id=box_id,
             alias="test-file",
-            decrypted_size=utils.DECRYPTED_SIZE,
-            encrypted_size=utils.ENCRYPTED_SIZE,
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
             part_size=utils.PART_SIZE,
         )
 

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -717,6 +717,10 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
                 box_id=TEST_BOX_ID, file_id=TEST_FILE_ID
             ),
         ),
+        (
+            UploadControllerPort.UploadSizeMismatchError(file_id=TEST_FILE_ID),
+            http_exceptions.HttpUploadSizeMismatchError(file_id=TEST_FILE_ID),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
     ids=[
@@ -724,10 +728,11 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
         "LockedBox",
         "FileUploadNotFound",
         "UploadCompletionError",
+        "UploadSizeMismatchError",
         "InternalError",
     ],
 )
-async def test_complete_file_upload_endpoint_error_handling(
+async def test_complete_file_upload_endpoint_error_translation(
     config: ConfigFixture,
     core_error: Exception,
     http_error: Exception,

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -43,6 +43,8 @@ from ucs.constants import MAX_PART_COUNT, MAX_PART_SIZE, MIN_PART_SIZE
 from ucs.core.models import FileUpload
 from ucs.ports.inbound.controller import UploadControllerPort
 
+MIN_SLEEP = 0.001
+
 pytestmark = pytest.mark.asyncio()
 
 
@@ -151,7 +153,7 @@ async def test_complete_file_upload(rig: JointRig):
     assert file_upload_box_dao.latest.file_count == 1
 
     # Now repeat the process to ensure the box stats are incremented, not overwritten
-    await sleep(0.1)
+    await sleep(MIN_SLEEP)
     other_decrypted_size = DECRYPTED_SIZE * 2  # this file is bigger
     other_encrypted_size = int(other_decrypted_size * 1.05)
     file_id2, _ = await controller.initiate_file_upload(
@@ -836,7 +838,7 @@ async def test_complete_file_upload_size_mismatch(rig: JointRig):
     state_updated = file_upload.state_updated
 
     # Sleep so we can check for the timestamp difference
-    await sleep(0.1)
+    await sleep(MIN_SLEEP)
 
     # Patch get_object_size to return a wrong size for this object
     _, storage = rig.object_storages.for_alias("test")
@@ -889,7 +891,7 @@ async def test_complete_file_upload_checksum_mismatch(rig: JointRig):
     assert file_upload.state == "init"
     state_updated = file_upload.state_updated
 
-    await sleep(0.1)  # short sleep for differentiating timestamps
+    await sleep(MIN_SLEEP)  # short sleep for differentiating timestamps
 
     # Provide a wrong checksum to trigger a ChecksumMismatchError
     with pytest.raises(UploadControllerPort.ChecksumMismatchError):
@@ -1394,14 +1396,14 @@ async def test_handle_internal_file_registration(rig: JointRig):
     # Now insert the FileUpload and run the event handling function
     await rig.file_upload_dao.insert(file_upload)
 
-    await sleep(0.1)  # sleep so that timestamp comparisons are valid
+    await sleep(MIN_SLEEP)  # sleep so that timestamp comparisons are valid
     await rig.controller.process_internal_file_registration(registration_metadata=event)
     updated_file_upload = await rig.file_upload_dao.get_by_id(file_upload.id)
     assert updated_file_upload.state == "archived"
     assert updated_file_upload.state_updated > file_upload.state_updated
 
     # Now reprocess the event - should get no errors and timestamp should be unchanged
-    await sleep(0.1)  # sleep so that timestamp comparisons are valid
+    await sleep(MIN_SLEEP)  # sleep so that timestamp comparisons are valid
     await rig.controller.process_internal_file_registration(registration_metadata=event)
     final_file_upload = await rig.file_upload_dao.get_by_id(file_upload.id)
     assert final_file_upload.state == "archived"

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -818,6 +818,56 @@ async def test_complete_file_upload_with_s3_error(rig: JointRig):
     assert file_upload_box_dao.latest.file_count == 0
 
 
+async def test_complete_file_upload_size_mismatch(rig: JointRig):
+    """Test that UploadSizeMismatchError is raised and the FileUpload is marked 'failed'
+    when the actual S3 object size doesn't match the declared encrypted_size.
+    """
+    box_id = await rig.create_default_box()
+    file_id, _ = await rig.controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+
+    file_upload = rig.file_upload_dao.latest
+    assert file_upload.state == "init"
+    state_updated = file_upload.state_updated
+
+    # Sleep so we can check for the timestamp difference
+    await sleep(0.1)
+
+    # Patch get_object_size to return a wrong size for this object
+    _, storage = rig.object_storages.for_alias("test")
+
+    async def wrong_size(*args, **kwargs):
+        return ENCRYPTED_SIZE + 1
+
+    storage.get_object_size = wrong_size  # type: ignore[method-assign]
+
+    # Now try to complete the upload. Should get the UploadSizeMismatchError.
+    object_id = rig.file_upload_dao.latest.object_id
+    with pytest.raises(UploadControllerPort.UploadSizeMismatchError):
+        await rig.controller.complete_file_upload(
+            box_id=box_id,
+            file_id=file_id,
+            unencrypted_checksum="sha256:unencrypted_checksum_here",
+            encrypted_checksum=f"etag_for_{object_id}",
+            encrypted_parts_md5=["abc123"],
+            encrypted_parts_sha256=["def456"],
+        )
+
+    # Make sure the FileUpload attributes are updated
+    file_upload = rig.file_upload_dao.latest
+    assert file_upload.state == "failed"
+    assert file_upload.state_updated > state_updated
+    assert not file_upload.inbox_upload_completed
+    assert not file_upload.completed
+    assert rig.file_upload_box_dao.latest.size == 0
+    assert rig.file_upload_box_dao.latest.file_count == 0
+
+
 async def test_complete_file_upload_checksum_mismatch(rig: JointRig):
     """Test to make sure the FileUpload is marked as 'failed' if the UploadController
     raises a ChecksumMismatchError.

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -844,7 +844,7 @@ async def test_complete_file_upload_size_mismatch(rig: JointRig):
     async def wrong_size(*args, **kwargs):
         return ENCRYPTED_SIZE + 1
 
-    storage.get_object_size = wrong_size  # type: ignore[method-assign]
+    storage.get_object_size = wrong_size
 
     # Now try to complete the upload. Should get the UploadSizeMismatchError.
     object_id = rig.file_upload_dao.latest.object_id

--- a/services/ucs/tests_ucs/unit/test_s3client.py
+++ b/services/ucs/tests_ucs/unit/test_s3client.py
@@ -169,6 +169,21 @@ async def test_get_object_etag(s3_client: S3ClientPort):
     assert etag == f"etag_for_{file_upload.object_id}"
 
 
+async def test_get_object_size(s3_client: S3ClientPort):
+    """Test that the size of a completed upload is returned."""
+    file_upload = make_file_upload()
+    upload_id = await s3_client.init_multipart_upload(
+        file_upload_basics=_to_basics(file_upload)
+    )
+    file_upload = file_upload.model_copy(update={"s3_upload_id": upload_id})
+    await s3_client.complete_multipart_upload(file_upload=file_upload)
+
+    size = await s3_client.get_object_size(
+        file_upload=file_upload, object_id=file_upload.object_id
+    )
+    assert size == 1024  # the dummy value returned by the InMem S3 fixture
+
+
 async def test_delete_inbox_file_completed(
     s3_client: S3ClientPort, object_storages: ObjectStorages
 ):
@@ -268,6 +283,11 @@ async def test_unknown_storage_alias_raises_error(s3_client: S3ClientPort):
 
     with pytest.raises(S3ClientPort.UnknownStorageAliasError):
         await s3_client.get_object_etag(
+            file_upload=file_upload, object_id=file_upload.object_id
+        )
+
+    with pytest.raises(S3ClientPort.UnknownStorageAliasError):
+        await s3_client.get_object_size(
             file_upload=file_upload, object_id=file_upload.object_id
         )
 


### PR DESCRIPTION
This adds a check during upload completion which verifies the actual object size reported by S3 against the expected object size reported by the submitter at creation time. Mismatches result in a 400 response to the user. Mirroring the error flow for checksum mismatches, the file is left in place for the user to delete. If the user neglects to delete the rejected file themselves, the UCS cleanup job can delete it later (not yet implemented).