### PR TITLE
FIS: Filter DHFS versions (GSI-2377)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -10,6 +10,7 @@ dependencies = [
     "crypt4gh >= 1.7",
     "hvac >= 2",
     "httpx >= 0.28",
+    "packaging >= 26",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "crypt4gh >= 1.7",
     "hvac >= 2",
     "httpx >= 0.28",
+    "packaging >= 26",
 ]
 readme = "README.md"
 authors = [

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -593,6 +593,21 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/supported_dhfs_versions"></a>**`supported_dhfs_versions`** *(string, required)*: A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 400 error.
+
+
+  Examples:
+
+  ```json
+  ">=1.0.0,<2.0.0"
+  ```
+
+
+  ```json
+  "~=2.0"
+  ```
+
+
 
 ### Usage:
 

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -593,7 +593,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/supported_dhfs_versions"></a>**`supported_dhfs_versions`** *(string, required)*: A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 426 error.
+- <a id="properties/dhfs_version_constraint"></a>**`dhfs_version_constraint`** *(string, required)*: A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 426 error.
 
 
   Examples:

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:11.0.1
+docker pull ghga/file-ingest-service:11.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:11.0.1 .
+docker build -t ghga/file-ingest-service:11.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:11.0.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:11.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -593,7 +593,7 @@ The service requires the following configuration parameters:
   ```
 
 
-- <a id="properties/supported_dhfs_versions"></a>**`supported_dhfs_versions`** *(string, required)*: A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 400 error.
+- <a id="properties/supported_dhfs_versions"></a>**`supported_dhfs_versions`** *(string, required)*: A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 426 error.
 
 
   Examples:

--- a/services/fis/config_schema.json
+++ b/services/fis/config_schema.json
@@ -577,13 +577,13 @@
       "title": "Data Hub Auth Keys",
       "type": "object"
     },
-    "supported_dhfs_versions": {
+    "dhfs_version_constraint": {
       "description": "A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 426 error.",
       "examples": [
         ">=1.0.0,<2.0.0",
         "~=2.0"
       ],
-      "title": "Supported Dhfs Versions",
+      "title": "Dhfs Version Constraint",
       "type": "string"
     }
   },
@@ -600,7 +600,7 @@
     "db_version_collection",
     "migration_wait_sec",
     "data_hub_auth_keys",
-    "supported_dhfs_versions"
+    "dhfs_version_constraint"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/fis/config_schema.json
+++ b/services/fis/config_schema.json
@@ -578,7 +578,7 @@
       "type": "object"
     },
     "supported_dhfs_versions": {
-      "description": "A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 400 error.",
+      "description": "A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 426 error.",
       "examples": [
         ">=1.0.0,<2.0.0",
         "~=2.0"

--- a/services/fis/config_schema.json
+++ b/services/fis/config_schema.json
@@ -576,6 +576,15 @@
       ],
       "title": "Data Hub Auth Keys",
       "type": "object"
+    },
+    "supported_dhfs_versions": {
+      "description": "A PEP 440 version specifier controlling which DHFS client versions are accepted. Requests where the reported version does not satisfy this specifier will be rejected with a 400 error.",
+      "examples": [
+        ">=1.0.0,<2.0.0",
+        "~=2.0"
+      ],
+      "title": "Supported Dhfs Versions",
+      "type": "string"
     }
   },
   "required": [
@@ -590,7 +599,8 @@
     "db_name",
     "db_version_collection",
     "migration_wait_sec",
-    "data_hub_auth_keys"
+    "data_hub_auth_keys",
+    "supported_dhfs_versions"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/services/fis/dev_config.yaml
+++ b/services/fis/dev_config.yaml
@@ -14,3 +14,4 @@ ekss_api_url: http://127.0.0.1/ekss
 data_hub_auth_keys:
   HD: '{"crv":"P-256","kty":"EC","x":"nix0eRNBLpSOQqEa63MB48FwKinZYpPL2G9QZEEAFGQ","y":"UEQBvFFSJmS95tBZCR1paF97jnwOZUyjKaE4aY6aaCk"}'
   TU: '{"crv":"P-256","kty":"EC","x":"1XAs84RlUVBlMlE8l_4rTTlSYWDeQiLH21iTDLKTIM8","y":"cySDIURnb35Z6kv5FaidwIiwMcpFCnwKVausc9o8BRs"}'
+supported_dhfs_versions: ~=2.0

--- a/services/fis/dev_config.yaml
+++ b/services/fis/dev_config.yaml
@@ -14,4 +14,4 @@ ekss_api_url: http://127.0.0.1/ekss
 data_hub_auth_keys:
   HD: '{"crv":"P-256","kty":"EC","x":"nix0eRNBLpSOQqEa63MB48FwKinZYpPL2G9QZEEAFGQ","y":"UEQBvFFSJmS95tBZCR1paF97jnwOZUyjKaE4aY6aaCk"}'
   TU: '{"crv":"P-256","kty":"EC","x":"1XAs84RlUVBlMlE8l_4rTTlSYWDeQiLH21iTDLKTIM8","y":"cySDIURnb35Z6kv5FaidwIiwMcpFCnwKVausc9o8BRs"}'
-supported_dhfs_versions: ~=2.0
+dhfs_version_constraint: ~=2.0

--- a/services/fis/example_config.yaml
+++ b/services/fis/example_config.yaml
@@ -62,5 +62,6 @@ port: 8080
 retry_after_applicable_for_num_requests: 1
 service_instance_id: '1'
 service_name: fis
+supported_dhfs_versions: ~=2.0
 timeout_keep_alive: 90
 workers: 1

--- a/services/fis/example_config.yaml
+++ b/services/fis/example_config.yaml
@@ -25,6 +25,7 @@ data_hub_auth_keys:
   TU: '{"crv":"P-256","kty":"EC","x":"1XAs84RlUVBlMlE8l_4rTTlSYWDeQiLH21iTDLKTIM8","y":"cySDIURnb35Z6kv5FaidwIiwMcpFCnwKVausc9o8BRs"}'
 db_name: dev
 db_version_collection: fisDbVersions
+dhfs_version_constraint: ~=2.0
 docs_url: /docs
 ekss_api_url: http://127.0.0.1/ekss
 enable_opentelemetry: false
@@ -62,6 +63,5 @@ port: 8080
 retry_after_applicable_for_num_requests: 1
 service_instance_id: '1'
 service_name: fis
-supported_dhfs_versions: ~=2.0
 timeout_keep_alive: 90
 workers: 1

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -179,7 +179,7 @@ info:
   description: A service to liaise between Central File Services and Data Hubs for
     file inspection.
   title: File Ingest Service
-  version: 11.0.1
+  version: 11.1.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "11.0.1"
+version = "11.1.0"
 description = "File Ingest Service - A service to liaise between Central File Services and Data Hubs for file inspection."
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
@@ -26,7 +26,7 @@ from fis.ports.inbound.interrogation import InterrogationHandlerPort
 
 interrogator_dummy = DependencyDummy("interrogator_port")
 auth_providers_dummy = DependencyDummy("auth_providers_dummy")
-supported_dhfs_versions_dummy = DependencyDummy("dhfs_version_filter_dummy")
+supported_dhfs_versions_dummy = DependencyDummy("supported_dhfs_versions_dummy")
 
 InterrogatorPort = Annotated[InterrogationHandlerPort, Depends(interrogator_dummy)]
 SupportedDhfsVersions = Annotated[str, Depends(supported_dhfs_versions_dummy)]

--- a/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
@@ -26,5 +26,7 @@ from fis.ports.inbound.interrogation import InterrogationHandlerPort
 
 interrogator_dummy = DependencyDummy("interrogator_port")
 auth_providers_dummy = DependencyDummy("auth_providers_dummy")
+supported_dhfs_versions_dummy = DependencyDummy("dhfs_version_filter_dummy")
 
 InterrogatorPort = Annotated[InterrogationHandlerPort, Depends(interrogator_dummy)]
+SupportedDhfsVersions = Annotated[str, Depends(supported_dhfs_versions_dummy)]

--- a/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/dummies.py
@@ -26,7 +26,7 @@ from fis.ports.inbound.interrogation import InterrogationHandlerPort
 
 interrogator_dummy = DependencyDummy("interrogator_port")
 auth_providers_dummy = DependencyDummy("auth_providers_dummy")
-supported_dhfs_versions_dummy = DependencyDummy("supported_dhfs_versions_dummy")
+dhfs_version_constraint_dummy = DependencyDummy("dhfs_version_constraint_dummy")
 
 InterrogatorPort = Annotated[InterrogationHandlerPort, Depends(interrogator_dummy)]
-SupportedDhfsVersions = Annotated[str, Depends(supported_dhfs_versions_dummy)]
+DhfsVersionConstraint = Annotated[str, Depends(dhfs_version_constraint_dummy)]

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -36,7 +36,7 @@ def check_and_log_user_agent_header(
     *,
     request: Request,
     endpoint_description: str,
-    supported_dhfs_versions: str,
+    dhfs_version_constraint: str,
     storage_alias: str = "",
 ) -> None:
     """Log a structured message from the User-Agent header.
@@ -49,12 +49,18 @@ def check_and_log_user_agent_header(
     in a 426 Upgrade Required response.
     """
     raw_user_agent = request.headers.get("user-agent")
-    extra = {"user_agent": raw_user_agent, "storage_alias": storage_alias}
+    extra = {
+        "user_agent": raw_user_agent,
+        "storage_alias": storage_alias,
+        "dhfs_version_constraint": dhfs_version_constraint,
+    }
     alias_part = f", originating from {storage_alias}" if storage_alias else ""
     client_part = raw_user_agent
 
     accepted = True
     parts = (raw_user_agent or "").split("/")
+
+    # Note: this is a naive implementation and we might want/need to use regex later
     if (len(parts) == 2) and all(parts):
         extra["client_name"] = parts[0]
         extra["client_version"] = parts[1]
@@ -65,9 +71,11 @@ def check_and_log_user_agent_header(
         if parts[0] == DHFS_USER_AGENT_PREFIX:
             try:
                 accepted = Version(version_part) in SpecifierSet(
-                    supported_dhfs_versions
+                    dhfs_version_constraint
                 )
             except InvalidVersion:
+                # Invalid version would come from version_part, not dhfs_version_constraint
+                #  as the latter is already screened during config instantiation.
                 accepted = False
 
     # Log all requests either way
@@ -81,15 +89,16 @@ def check_and_log_user_agent_header(
         )
     else:
         log.warning(
-            "Rejected request from unsupported DHFS version %s.",
+            "Rejected request from DHFS version %s, which doesn't satisfy constraint %s.",
             version_part,
+            dhfs_version_constraint,
             extra=extra,
         )
         raise HTTPException(
             status_code=status.HTTP_426_UPGRADE_REQUIRED,
             detail=(
                 "Data Hub File Service must satisfy the following version"
-                + f" constraint(s): {supported_dhfs_versions}"
+                + f" constraint(s): {dhfs_version_constraint}"
             ),
         )
 
@@ -103,13 +112,13 @@ def check_and_log_user_agent_header(
 @TRACER.start_as_current_span("routes.health")
 async def health(
     request: Request,
-    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
+    _dhfs_version_constraint: dummies.DhfsVersionConstraint,
 ):
     """Used to test if this service is alive"""
     check_and_log_user_agent_header(
         request=request,
         endpoint_description="health",
-        supported_dhfs_versions=_supported_dhfs_versions,
+        dhfs_version_constraint=_dhfs_version_constraint,
     )
     return {"status": "OK"}
 
@@ -127,12 +136,12 @@ async def list_uploads(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
-    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
+    _dhfs_version_constraint: dummies.DhfsVersionConstraint,
 ) -> list[models.BaseFileInformation]:
     """Return a list of not-yet-interrogated files for a Data Hub (storage_alias)"""
     check_and_log_user_agent_header(
         request=request,
-        supported_dhfs_versions=_supported_dhfs_versions,
+        dhfs_version_constraint=_dhfs_version_constraint,
         endpoint_description="list_uploads",
         storage_alias=storage_alias,
     )
@@ -159,7 +168,7 @@ async def get_removable_files(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
-    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
+    _dhfs_version_constraint: dummies.DhfsVersionConstraint,
     object_ids: list[UUID4] = Body(),
 ) -> list[UUID4]:
     """Returns a subset of the provided object ID list containing the IDs of all S3
@@ -167,7 +176,7 @@ async def get_removable_files(
     """
     check_and_log_user_agent_header(
         request=request,
-        supported_dhfs_versions=_supported_dhfs_versions,
+        dhfs_version_constraint=_dhfs_version_constraint,
         endpoint_description="get_removable_files",
         storage_alias=storage_alias,
     )
@@ -198,13 +207,13 @@ async def post_interrogation_report(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
-    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
+    _dhfs_version_constraint: dummies.DhfsVersionConstraint,
     report: models.InterrogationReportWithSecret = Body(),
 ) -> None:
     """Post an InterrogationReport"""
     check_and_log_user_agent_header(
         request=request,
-        supported_dhfs_versions=_supported_dhfs_versions,
+        dhfs_version_constraint=_dhfs_version_constraint,
         endpoint_description="post_interrogation_report",
         storage_alias=storage_alias,
     )

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -18,11 +18,13 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Body, HTTPException, Request, status
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
 from pydantic import UUID4
 
 from fis.adapters.inbound.fastapi_ import dummies
 from fis.adapters.inbound.fastapi_.http_authorization import JWT, require_data_hub_jwt
-from fis.constants import TRACER
+from fis.constants import DHFS_USER_AGENT_PREFIX, TRACER
 from fis.core import models
 from fis.ports.inbound.interrogation import InterrogationHandlerPort
 
@@ -30,33 +32,66 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def log_user_agent_header(
-    request: Request, endpoint_description: str, storage_alias: str = ""
+def check_and_log_user_agent_header(
+    *,
+    request: Request,
+    endpoint_description: str,
+    supported_dhfs_versions: str,
+    storage_alias: str = "",
 ) -> None:
     """Log a structured message from the User-Agent header.
 
     Expects the format 'ClientName/1.0.0'. Adapts the message for a missing or
     malformed header, or a missing storage alias.
+
+    If the User-Agent indicates the request comes from a DHFS instance, the DHFS version
+    is evaluated against the configured allowable range. Disallowed versions result
+    in a 426 Upgrade Required response.
     """
-    raw_user_agent_header = request.headers.get("user-agent")
-    extra = {"user_agent": raw_user_agent_header}
+    raw_user_agent = request.headers.get("user-agent")
+    extra = {"user_agent": raw_user_agent, "storage_alias": storage_alias}
+    alias_part = f", originating from {storage_alias}" if storage_alias else ""
+    client_part = raw_user_agent
 
-    parts = (raw_user_agent_header or "").split("/")
-
-    client_part = raw_user_agent_header
+    accepted = True
+    parts = (raw_user_agent or "").split("/")
     if (len(parts) == 2) and all(parts):
         extra["client_name"] = parts[0]
         extra["client_version"] = parts[1]
-        client_part = f"from {parts[0]}, version {parts[1]}"
+        version_part = parts[1]
+        client_part = f"from {parts[0]}, version {version_part}"
 
-    alias_part = f", originating from {storage_alias}" if storage_alias else ""
-    log.info(
-        "Received request %s for the %s endpoint%s.",
-        client_part,
-        endpoint_description,
-        alias_part,
-        extra=extra,
-    )
+        # If the User Agent specifies DHFS, enforce the version requirement
+        if parts[0] == DHFS_USER_AGENT_PREFIX:
+            try:
+                accepted = Version(version_part) in SpecifierSet(
+                    supported_dhfs_versions
+                )
+            except InvalidVersion:
+                accepted = False
+
+    # Log all requests either way
+    if accepted:
+        log.info(
+            "Received request %s for the %s endpoint%s.",
+            client_part,
+            endpoint_description,
+            alias_part,
+            extra=extra,
+        )
+    else:
+        log.warning(
+            "Rejected request from unsupported DHFS version %s.",
+            version_part,
+            extra=extra,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_426_UPGRADE_REQUIRED,
+            detail=(
+                "Data Hub File Service must satisfy the following version"
+                + f" constraint(s): {supported_dhfs_versions}"
+            ),
+        )
 
 
 @router.get(
@@ -66,9 +101,16 @@ def log_user_agent_header(
     status_code=200,
 )
 @TRACER.start_as_current_span("routes.health")
-async def health(request: Request):
+async def health(
+    request: Request,
+    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
+):
     """Used to test if this service is alive"""
-    log_user_agent_header(request, "health")
+    check_and_log_user_agent_header(
+        request=request,
+        endpoint_description="health",
+        supported_dhfs_versions=_supported_dhfs_versions,
+    )
     return {"status": "OK"}
 
 
@@ -85,9 +127,15 @@ async def list_uploads(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
+    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
 ) -> list[models.BaseFileInformation]:
     """Return a list of not-yet-interrogated files for a Data Hub (storage_alias)"""
-    log_user_agent_header(request, "list_uploads", storage_alias)
+    check_and_log_user_agent_header(
+        request=request,
+        supported_dhfs_versions=_supported_dhfs_versions,
+        endpoint_description="list_uploads",
+        storage_alias=storage_alias,
+    )
     try:
         return await interrogator.get_files_not_yet_interrogated(
             storage_alias=storage_alias
@@ -111,12 +159,18 @@ async def get_removable_files(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
+    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
     object_ids: list[UUID4] = Body(),
 ) -> list[UUID4]:
     """Returns a subset of the provided object ID list containing the IDs of all S3
     objects which may be now removed from the interrogation bucket.
     """
-    log_user_agent_header(request, "get_removable_files", storage_alias)
+    check_and_log_user_agent_header(
+        request=request,
+        supported_dhfs_versions=_supported_dhfs_versions,
+        endpoint_description="get_removable_files",
+        storage_alias=storage_alias,
+    )
     try:
         return [
             o for o in object_ids if await interrogator.check_if_removable(object_id=o)
@@ -144,10 +198,16 @@ async def post_interrogation_report(
     request: Request,
     interrogator: dummies.InterrogatorPort,
     _token: Annotated[JWT, require_data_hub_jwt],
+    _supported_dhfs_versions: dummies.SupportedDhfsVersions,
     report: models.InterrogationReportWithSecret = Body(),
 ) -> None:
     """Post an InterrogationReport"""
-    log_user_agent_header(request, "post_interrogation_report", storage_alias)
+    check_and_log_user_agent_header(
+        request=request,
+        supported_dhfs_versions=_supported_dhfs_versions,
+        endpoint_description="post_interrogation_report",
+        storage_alias=storage_alias,
+    )
     try:
         await interrogator.handle_interrogation_report(report=report)
     except InterrogationHandlerPort.FileNotFoundError as err:

--- a/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/services/fis/src/fis/adapters/inbound/fastapi_/routes.py
@@ -24,7 +24,7 @@ from pydantic import UUID4
 
 from fis.adapters.inbound.fastapi_ import dummies
 from fis.adapters.inbound.fastapi_.http_authorization import JWT, require_data_hub_jwt
-from fis.constants import DHFS_USER_AGENT_PREFIX, TRACER
+from fis.constants import DHFS_USER_AGENT_PREFIX, OLD_DHFS_USER_AGENT_PREFIX, TRACER
 from fis.core import models
 from fis.ports.inbound.interrogation import InterrogationHandlerPort
 
@@ -68,7 +68,7 @@ def check_and_log_user_agent_header(
         client_part = f"from {parts[0]}, version {version_part}"
 
         # If the User Agent specifies DHFS, enforce the version requirement
-        if parts[0] == DHFS_USER_AGENT_PREFIX:
+        if parts[0] in [DHFS_USER_AGENT_PREFIX, OLD_DHFS_USER_AGENT_PREFIX]:
             try:
                 accepted = Version(version_part) in SpecifierSet(
                     dhfs_version_constraint

--- a/services/fis/src/fis/config.py
+++ b/services/fis/src/fis/config.py
@@ -65,7 +65,7 @@ class Config(
         description=(
             "A PEP 440 version specifier controlling which DHFS client versions are"
             + " accepted. Requests where the reported version does not satisfy this"
-            + " specifier will be rejected with a 400 error."
+            + " specifier will be rejected with a 426 error."
         ),
         examples=[">=1.0.0,<2.0.0", "~=2.0"],
     )

--- a/services/fis/src/fis/config.py
+++ b/services/fis/src/fis/config.py
@@ -60,7 +60,7 @@ class Config(
         ],
     )
 
-    supported_dhfs_versions: str = Field(
+    dhfs_version_constraint: str = Field(
         default=...,
         description=(
             "A PEP 440 version specifier controlling which DHFS client versions are"
@@ -70,14 +70,14 @@ class Config(
         examples=[">=1.0.0,<2.0.0", "~=2.0"],
     )
 
-    @field_validator("supported_dhfs_versions")
+    @field_validator("dhfs_version_constraint")
     @classmethod
-    def validate_supported_dhfs_versions(cls, value: str) -> str:
-        """Ensure supported_dhfs_versions is a valid PEP 440 version specifier."""
+    def validate_dhfs_version_constraint(cls, value: str) -> str:
+        """Ensure dhfs_version_constraint is a valid PEP 440 version specifier."""
         try:
             SpecifierSet(value)
         except InvalidSpecifier as err:
             raise ValueError(
-                f"Invalid version specifier for supported_dhfs_versions: {err}"
+                f"Invalid version specifier for dhfs_version_constraint: {err}"
             ) from err
         return value

--- a/services/fis/src/fis/config.py
+++ b/services/fis/src/fis/config.py
@@ -20,7 +20,8 @@ from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.mongodb.migrations import MigrationConfig
 from hexkit.providers.mongokafka import MongoKafkaConfig
-from pydantic import Field
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from pydantic import Field, field_validator
 
 from fis.adapters.inbound.event_sub import OutboxSubConfig
 from fis.adapters.outbound.event_pub import EventPubConfig
@@ -58,3 +59,25 @@ class Config(
             }
         ],
     )
+
+    supported_dhfs_versions: str = Field(
+        default=...,
+        description=(
+            "A PEP 440 version specifier controlling which DHFS client versions are"
+            + " accepted. Requests where the reported version does not satisfy this"
+            + " specifier will be rejected with a 400 error."
+        ),
+        examples=[">=1.0.0,<2.0.0", "~=2.0"],
+    )
+
+    @field_validator("supported_dhfs_versions")
+    @classmethod
+    def validate_supported_dhfs_versions(cls, value: str) -> str:
+        """Ensure supported_dhfs_versions is a valid PEP 440 version specifier."""
+        try:
+            SpecifierSet(value)
+        except InvalidSpecifier as err:
+            raise ValueError(
+                f"Invalid version specifier for supported_dhfs_versions: {err}"
+            ) from err
+        return value

--- a/services/fis/src/fis/constants.py
+++ b/services/fis/src/fis/constants.py
@@ -20,4 +20,4 @@ SERVICE_NAME = "fis"
 TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
 AUTH_CHECK_CLAIMS = ["iss", "aud", "iat", "exp", "sub"]
 GHGA = "GHGA"
-DHFS_USER_AGENT_PREFIX = "DataHubFileService"
+DHFS_USER_AGENT_PREFIX = "GHGA DataHubFileService"

--- a/services/fis/src/fis/constants.py
+++ b/services/fis/src/fis/constants.py
@@ -21,3 +21,4 @@ TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
 AUTH_CHECK_CLAIMS = ["iss", "aud", "iat", "exp", "sub"]
 GHGA = "GHGA"
 DHFS_USER_AGENT_PREFIX = "GHGA DataHubFileService"
+OLD_DHFS_USER_AGENT_PREFIX = "DataHubFileService"

--- a/services/fis/src/fis/constants.py
+++ b/services/fis/src/fis/constants.py
@@ -20,3 +20,4 @@ SERVICE_NAME = "fis"
 TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
 AUTH_CHECK_CLAIMS = ["iss", "aud", "iat", "exp", "sub"]
 GHGA = "GHGA"
+DHFS_USER_AGENT_PREFIX = "DataHubFileService"

--- a/services/fis/src/fis/inject.py
+++ b/services/fis/src/fis/inject.py
@@ -127,6 +127,9 @@ async def prepare_rest_app(
             auth_providers[hub] = provider
 
         app.dependency_overrides[dummies.auth_providers_dummy] = lambda: auth_providers
+        app.dependency_overrides[dummies.supported_dhfs_versions_dummy] = lambda: (
+            config.supported_dhfs_versions
+        )
 
         yield app
 

--- a/services/fis/src/fis/inject.py
+++ b/services/fis/src/fis/inject.py
@@ -127,8 +127,8 @@ async def prepare_rest_app(
             auth_providers[hub] = provider
 
         app.dependency_overrides[dummies.auth_providers_dummy] = lambda: auth_providers
-        app.dependency_overrides[dummies.supported_dhfs_versions_dummy] = lambda: (
-            config.supported_dhfs_versions
+        app.dependency_overrides[dummies.dhfs_version_constraint_dummy] = lambda: (
+            config.dhfs_version_constraint
         )
 
         yield app

--- a/services/fis/tests_fis/fixtures/test_config.yaml
+++ b/services/fis/tests_fis/fixtures/test_config.yaml
@@ -14,4 +14,4 @@ ekss_api_url: http://127.0.0.1/ekss
 data_hub_auth_keys:  # overridden by config fixture
   HD: '{"crv":"P-256","kty":"EC","x":"nix0eRNBLpSOQqEa63MB48FwKinZYpPL2G9QZEEAFGQ","y":"UEQBvFFSJmS95tBZCR1paF97jnwOZUyjKaE4aY6aaCk"}'
   TU: '{"crv":"P-256","kty":"EC","x":"1XAs84RlUVBlMlE8l_4rTTlSYWDeQiLH21iTDLKTIM8","y":"cySDIURnb35Z6kv5FaidwIiwMcpFCnwKVausc9o8BRs"}'
-supported_dhfs_versions: ~=2.0
+dhfs_version_constraint: ~=2.0

--- a/services/fis/tests_fis/fixtures/test_config.yaml
+++ b/services/fis/tests_fis/fixtures/test_config.yaml
@@ -14,3 +14,4 @@ ekss_api_url: http://127.0.0.1/ekss
 data_hub_auth_keys:  # overridden by config fixture
   HD: '{"crv":"P-256","kty":"EC","x":"nix0eRNBLpSOQqEa63MB48FwKinZYpPL2G9QZEEAFGQ","y":"UEQBvFFSJmS95tBZCR1paF97jnwOZUyjKaE4aY6aaCk"}'
   TU: '{"crv":"P-256","kty":"EC","x":"1XAs84RlUVBlMlE8l_4rTTlSYWDeQiLH21iTDLKTIM8","y":"cySDIURnb35Z6kv5FaidwIiwMcpFCnwKVausc9o8BRs"}'
+supported_dhfs_versions: ~=2.0

--- a/services/fis/tests_fis/unit/test_api.py
+++ b/services/fis/tests_fis/unit/test_api.py
@@ -24,7 +24,7 @@ from ghga_service_commons.utils.jwt_helpers import sign_and_serialize_token
 from hexkit.utils import now_utc_ms_prec
 from jwcrypto.jwk import JWK
 
-from fis.constants import GHGA
+from fis.constants import DHFS_USER_AGENT_PREFIX, GHGA
 from fis.core import models
 from tests_fis.fixtures.joint import JointRig
 from tests_fis.fixtures.utils import create_file_under_interrogation
@@ -65,12 +65,11 @@ def jwt_factory(data_hub_jwks):
 
 
 ROUTES_LOGGER = "fis.adapters.inbound.fastapi_.routes"
-TEST_USER_AGENT = "DataHubFileService/1.0.0"
+TEST_USER_AGENT = f"{DHFS_USER_AGENT_PREFIX}/2.0.0"
+WRONG_USER_AGENT = f"{DHFS_USER_AGENT_PREFIX}/1.0.4"
 
 
-async def test_health(
-    rest_client: AsyncTestClient, rig: JointRig, caplog: pytest.LogCaptureFixture
-):
+async def test_health(rest_client: AsyncTestClient, caplog: pytest.LogCaptureFixture):
     """Test the GET /health endpoint"""
     url = "/health"
     response = await rest_client.get(url)
@@ -78,7 +77,10 @@ async def test_health(
 
     # No User-Agent header → logged as unknown client, no storage alias
     with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
-        await rest_client.get(url, headers={"User-Agent": "Boto3/1.2.3 Python/3.12"})
+        response = await rest_client.get(
+            url, headers={"User-Agent": "Boto3/1.2.3 Python/3.12"}
+        )
+        assert response.status_code == 200
     assert "Boto3/1.2.3 Python/3.12" in caplog.text
     assert "health endpoint" in caplog.text
     assert "originating from" not in caplog.text
@@ -86,11 +88,28 @@ async def test_health(
 
     # With User-Agent header → client name and version logged, still no storage alias
     with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
-        await rest_client.get(url, headers={"User-Agent": TEST_USER_AGENT})
-    assert "DataHubFileService" in caplog.text
-    assert "1.0.0" in caplog.text
+        response = await rest_client.get(url, headers={"User-Agent": TEST_USER_AGENT})
+        assert response.status_code == 200
+    assert DHFS_USER_AGENT_PREFIX in caplog.text
+    assert "2.0.0" in caplog.text
     assert "health endpoint" in caplog.text
     assert "originating from" not in caplog.text
+
+    # Non-DHFS client in proper Name/version format is not version-filtered
+    response = await rest_client.get(
+        url, headers={"User-Agent": "SomeOtherClient/1.0.4"}
+    )
+    assert response.status_code == 200
+
+    # DHFS with an unparsable version string is rejected
+    response = await rest_client.get(
+        url, headers={"User-Agent": f"{DHFS_USER_AGENT_PREFIX}/not-a-version"}
+    )
+    assert response.status_code == 426
+
+    # With unaccepted DHFS version, 426
+    response = await rest_client.get(url, headers={"User-Agent": WRONG_USER_AGENT})
+    assert response.status_code == 426
 
 
 async def test_list_uploads(
@@ -111,8 +130,15 @@ async def test_list_uploads(
     response = await rest_client.get(url, headers=wrong_hub_headers)
     assert response.status_code == 403
 
-    # Verify that this works:
-    correct_headers = jwt_factory.auth_header(HUB1)
+    # Verify wrong DHFS version but right auth header returns 426
+    right_auth_headers = jwt_factory.auth_header(HUB1)
+    right_auth_headers["user-agent"] = WRONG_USER_AGENT
+    response = await rest_client.get(url, headers=right_auth_headers)
+    assert response.status_code == 426
+
+    # Verify that right auth header and right DHFS version result in success
+    correct_headers = right_auth_headers
+    correct_headers["user-agent"] = TEST_USER_AGENT
     response = await rest_client.get(url, headers=correct_headers)
     assert response.status_code == 200
     assert response.json() == []
@@ -139,8 +165,8 @@ async def test_list_uploads(
             url,
             headers={**jwt_factory.auth_header(HUB1), "User-Agent": TEST_USER_AGENT},
         )
-    assert "DataHubFileService" in caplog.text
-    assert "1.0.0" in caplog.text
+    assert DHFS_USER_AGENT_PREFIX in caplog.text
+    assert "2.0.0" in caplog.text
     assert HUB1 in caplog.text
 
 
@@ -181,8 +207,17 @@ async def test_get_removable_files(
     )
     assert response.status_code == 403
 
-    # Verify that this works with correct auth
+    # Verify wrong DHFS version but right auth header returns 426
+    right_auth_headers = jwt_factory.auth_header(HUB1)
+    right_auth_headers["user-agent"] = WRONG_USER_AGENT
+    response = await rest_client.post(
+        url, json=[str(id) for id in file_ids], headers=right_auth_headers
+    )
+    assert response.status_code == 426
+
+    # Verify that this works with correct auth and correct DHFS version
     correct_headers = jwt_factory.auth_header(HUB1)
+    correct_headers["user-agent"] = TEST_USER_AGENT
     response = await rest_client.post(
         url, json=[str(id) for id in file_ids], headers=correct_headers
     )
@@ -211,8 +246,8 @@ async def test_get_removable_files(
             json=[],
             headers={**correct_headers, "User-Agent": TEST_USER_AGENT},
         )
-    assert "DataHubFileService" in caplog.text
-    assert "1.0.0" in caplog.text
+    assert DHFS_USER_AGENT_PREFIX in caplog.text
+    assert "2.0.0" in caplog.text
     assert HUB1 in caplog.text
 
 
@@ -256,6 +291,7 @@ async def test_post_interrogation_report(
 
     # Submit interrogation report with valid token
     correct_headers = jwt_factory.auth_header(HUB1)
+    correct_headers["user-agent"] = TEST_USER_AGENT
     response = await rest_client.post(url, json=success_report, headers=correct_headers)
     assert response.status_code == 201
 
@@ -322,13 +358,15 @@ async def test_post_interrogation_report(
     )
     assert response.status_code == 422
 
-    # Verify user agent logging includes client name and storage alias
+    # Verify wrong DHFS version but right auth header returns 426
+    correct_headers["user-agent"] = WRONG_USER_AGENT  # temporarily override
+    response = await rest_client.post(url, json=success_report, headers=correct_headers)
+    assert response.status_code == 426
+
+    # Now the happy case: check user agent logging includes client name and storage alias
+    correct_headers["user-agent"] = TEST_USER_AGENT  # restore correct value
     with caplog.at_level(logging.INFO, logger=ROUTES_LOGGER):
-        await rest_client.post(
-            url,
-            json=success_report,
-            headers={**correct_headers, "User-Agent": TEST_USER_AGENT},
-        )
-    assert "DataHubFileService" in caplog.text
-    assert "1.0.0" in caplog.text
+        await rest_client.post(url, json=success_report, headers=correct_headers)
+    assert DHFS_USER_AGENT_PREFIX in caplog.text
+    assert "2.0.0" in caplog.text
     assert HUB1 in caplog.text

--- a/services/fis/tests_fis/unit/test_api.py
+++ b/services/fis/tests_fis/unit/test_api.py
@@ -24,7 +24,7 @@ from ghga_service_commons.utils.jwt_helpers import sign_and_serialize_token
 from hexkit.utils import now_utc_ms_prec
 from jwcrypto.jwk import JWK
 
-from fis.constants import DHFS_USER_AGENT_PREFIX, GHGA
+from fis.constants import DHFS_USER_AGENT_PREFIX, GHGA, OLD_DHFS_USER_AGENT_PREFIX
 from fis.core import models
 from tests_fis.fixtures.joint import JointRig
 from tests_fis.fixtures.utils import create_file_under_interrogation
@@ -109,6 +109,11 @@ async def test_health(rest_client: AsyncTestClient, caplog: pytest.LogCaptureFix
 
     # With unaccepted DHFS version, 426
     response = await rest_client.get(url, headers={"User-Agent": WRONG_USER_AGENT})
+    assert response.status_code == 426
+
+    # DHFS pre-v2 User Agent string should get rejected
+    prev2_header = {"User-Agent": f"{OLD_DHFS_USER_AGENT_PREFIX}/1.0.4"}
+    response = await rest_client.get(url, headers=prev2_header)
     assert response.status_code == 426
 
 

--- a/services/fis/tests_fis/unit/test_config.py
+++ b/services/fis/tests_fis/unit/test_config.py
@@ -31,10 +31,10 @@ from tests_fis.fixtures.config import get_config
         "!=1.5.0",
     ],
 )
-def test_supported_dhfs_versions_valid(specifier: str):
+def test_dhfs_version_constraint_valid(specifier: str):
     """Valid PEP 440 specifiers should be accepted without error."""
-    config = get_config(supported_dhfs_versions=specifier)
-    assert config.supported_dhfs_versions == specifier
+    config = get_config(dhfs_version_constraint=specifier)
+    assert config.dhfs_version_constraint == specifier
 
 
 @pytest.mark.parametrize(
@@ -45,7 +45,7 @@ def test_supported_dhfs_versions_valid(specifier: str):
         "1.0.0",  # bare version without operator is invalid as a specifier
     ],
 )
-def test_supported_dhfs_versions_invalid(specifier: str):
+def test_dhfs_version_constraint_invalid(specifier: str):
     """Invalid PEP 440 specifiers should raise a ValidationError at config load time."""
     with pytest.raises(ValidationError):
-        get_config(supported_dhfs_versions=specifier)
+        get_config(dhfs_version_constraint=specifier)

--- a/services/fis/tests_fis/unit/test_config.py
+++ b/services/fis/tests_fis/unit/test_config.py
@@ -1,0 +1,51 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Config validators"""
+
+import pytest
+from pydantic import ValidationError
+
+from tests_fis.fixtures.config import get_config
+
+
+@pytest.mark.parametrize(
+    "specifier",
+    [
+        ">=1.0.0,<2.0.0",
+        "~=2.0",
+        "==1.*",
+        ">=1.0",
+        "!=1.5.0",
+    ],
+)
+def test_supported_dhfs_versions_valid(specifier: str):
+    """Valid PEP 440 specifiers should be accepted without error."""
+    config = get_config(supported_dhfs_versions=specifier)
+    assert config.supported_dhfs_versions == specifier
+
+
+@pytest.mark.parametrize(
+    "specifier",
+    [
+        "not-a-specifier",
+        ">>1.0.0",
+        "1.0.0",  # bare version without operator is invalid as a specifier
+    ],
+)
+def test_supported_dhfs_versions_invalid(specifier: str):
+    """Invalid PEP 440 specifiers should raise a ValidationError at config load time."""
+    with pytest.raises(ValidationError):
+        get_config(supported_dhfs_versions=specifier)


### PR DESCRIPTION
This adds a way to set the allowed DHFS versions through configuration using the `supported_dhfs_versions` parameter.

Bumps the FIS version to `11.1.0`. The monorepo version is not bumped because the currently set version (`12.0.0`) hasn't been released yet.