### PR TITLE
IFRS - fix v3 migration wrt bucket IDs

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "12.0.0"
+version = "12.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "12.0.0"
+version = "12.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:7.1.0
+docker pull ghga/internal-file-registry-service:7.1.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:7.1.0 .
+docker build -t ghga/internal-file-registry-service:7.1.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:7.1.0 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:7.1.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/dev_config.yaml
+++ b/services/ifrs/dev_config.yaml
@@ -1,7 +1,19 @@
 mongo_dsn: "mongodb://mongodb:27017"
 db_name: "dev"
 object_storages:
-  test:
+  HD01:
+    bucket: permanent
+    credentials:
+      s3_endpoint_url: http://ifrs:4566
+      s3_access_key_id: test
+      s3_secret_access_key: test
+  TUE01:
+    bucket: permanent
+    credentials:
+      s3_endpoint_url: http://ifrs:4566
+      s3_access_key_id: test
+      s3_secret_access_key: test
+  KL01:
     bucket: permanent
     credentials:
       s3_endpoint_url: http://ifrs:4566

--- a/services/ifrs/example_config.yaml
+++ b/services/ifrs/example_config.yaml
@@ -34,7 +34,23 @@ migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 object_storages:
-  test:
+  HD01:
+    bucket: permanent
+    credentials:
+      aws_config_ini: null
+      s3_access_key_id: test
+      s3_endpoint_url: http://ifrs:4566
+      s3_secret_access_key: '**********'
+      s3_session_token: null
+  KL01:
+    bucket: permanent
+    credentials:
+      aws_config_ini: null
+      s3_access_key_id: test
+      s3_endpoint_url: http://ifrs:4566
+      s3_secret_access_key: '**********'
+      s3_session_token: null
+  TUE01:
     bucket: permanent
     credentials:
       aws_config_ini: null

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "7.1.0"
+version = "7.1.1"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/migrations/definitions/v3.py
+++ b/services/ifrs/src/ifrs/migrations/definitions/v3.py
@@ -22,11 +22,19 @@ from uuid import UUID
 from hexkit.providers.mongodb.migrations import Document, MigrationDefinition
 from hexkit.providers.mongokafka.provider.persistent_pub import PersistentKafkaEvent
 
+from ifrs.config import Config
 from ifrs.core.models import FileMetadata
 
 # Collection names defined as constants
 IFRS_PERSISTED_EVENTS = "ifrsPersistedEvents"
 FILE_METADATA = "file_metadata"
+
+# Get permanent bucket names for each storage alias
+CONFIG = Config()
+BUCKET_IDS: dict[str, str] = {
+    storage_alias: content.bucket
+    for storage_alias, content in CONFIG.object_storages.items()
+}
 
 
 def derive_file_id_from_accession(accession: str) -> UUID:
@@ -39,13 +47,14 @@ def derive_file_id_from_accession(accession: str) -> UUID:
 async def update_file_metadata(doc: Document) -> Document:
     """Update file metadata, skipping already updated docs.
 
-    If a doc has the `archive_date` field, it has already been updated.
+    If a doc has the `archive_date` and `bucket_id` fields, it has already been updated.
     """
-    if "archive_date" in doc:
+    if "archive_date" in doc and "bucket_id" in doc:
         return doc
 
     doc["_id"] = derive_file_id_from_accession(doc["_id"])
     doc["archive_date"] = doc.pop("upload_date")
+    doc["bucket_id"] = BUCKET_IDS[doc["storage_alias"]]  # Allow KeyError here
     doc["secret_id"] = doc.pop("decryption_secret_id")
     doc["part_size"] = doc.pop("encrypted_part_size")
     doc["encrypted_size"] = doc.pop("object_size")

--- a/services/ifrs/tests_ifrs/fixtures/test_config.yaml
+++ b/services/ifrs/tests_ifrs/fixtures/test_config.yaml
@@ -6,13 +6,13 @@ object_storages:
       s3_access_key_id: test
       s3_secret_access_key: test
   TUE01:
-    bucket: interrogation
+    bucket: permanent
     credentials:
       s3_endpoint_url: http://ifrs:4566
       s3_access_key_id: test
       s3_secret_access_key: test
   KL01:
-    bucket: interrogation
+    bucket: permanent
     credentials:
       s3_endpoint_url: http://ifrs:4566
       s3_access_key_id: test

--- a/services/ifrs/tests_ifrs/migrations/test_v3.py
+++ b/services/ifrs/tests_ifrs/migrations/test_v3.py
@@ -33,6 +33,10 @@ async def test_v3_migration(mongodb: MongoDbFixture):
     and ifrsPersistedEvents collections for the Sarcastic Fringehead epic.
     """
     config = get_config(sources=[mongodb.config])
+    bucket_ids: dict[str, str] = {
+        storage_alias: content.bucket
+        for storage_alias, content in config.object_storages.items()
+    }
     db = mongodb.client[config.db_name]
     events_collection = db["ifrsPersistedEvents"]
     metadata_collection = db["file_metadata"]
@@ -42,8 +46,7 @@ async def test_v3_migration(mongodb: MongoDbFixture):
         {
             "_id": f"GHGA00{i}",
             "upload_date": now_utc_ms_prec(),
-            "storage_alias": "test-storage",
-            "bucket_id": "test-bucket",
+            "storage_alias": list(bucket_ids)[i],
             "object_id": uuid4(),
             "decryption_secret_id": f"secret-{i}",
             "content_offset": 0,
@@ -63,7 +66,7 @@ async def test_v3_migration(mongodb: MongoDbFixture):
             "_id": derive_file_id_from_accession(old_doc["_id"]),
             "archive_date": old_doc["upload_date"],
             "storage_alias": old_doc["storage_alias"],
-            "bucket_id": old_doc["bucket_id"],
+            "bucket_id": bucket_ids[old_doc["storage_alias"]],
             "object_id": old_doc["object_id"],
             "secret_id": old_doc["decryption_secret_id"],
             "decrypted_size": old_doc["decrypted_size"],

--- a/services/ifrs/tests_ifrs/migrations/test_v3.py
+++ b/services/ifrs/tests_ifrs/migrations/test_v3.py
@@ -66,7 +66,7 @@ async def test_v3_migration(mongodb: MongoDbFixture):
             "_id": derive_file_id_from_accession(old_doc["_id"]),
             "archive_date": old_doc["upload_date"],
             "storage_alias": old_doc["storage_alias"],
-            "bucket_id": bucket_ids[old_doc["storage_alias"]],
+            "bucket_id": bucket_ids[str(old_doc["storage_alias"])],
             "object_id": old_doc["object_id"],
             "secret_id": old_doc["decryption_secret_id"],
             "decrypted_size": old_doc["decrypted_size"],


### PR DESCRIPTION
The v3 migration did not account for the fact that old events lack `bucket_id`, and the test missed it because the mock event _did_ have that field. This patch pulls the bucket name from configuration for each storage alias and uses that in the migration to assign the correct value. 