### PR TITLE
DCS V3 Migration: Handle mixed data type for target_object_id

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.0.0"
+version = "13.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.0.0"
+version = "13.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:10.0.0
+docker pull ghga/download-controller-service:10.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:10.0.0 .
+docker build -t ghga/download-controller-service:10.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:10.0.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:10.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -211,7 +211,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 10.0.0
+  version: 10.0.1
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dcs"
-version = "10.0.0"
+version = "10.0.1"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 readme = "README.md"
 authors = [

--- a/services/dcs/src/dcs/migrations/definitions/v3.py
+++ b/services/dcs/src/dcs/migrations/definitions/v3.py
@@ -81,7 +81,8 @@ async def update_event(doc: Document) -> Document:
     # There are only two event types in the collection at this time:
     # FileDownloadServed event:
     if "target_object_id" in payload:
-        payload["target_object_id"] = UUID(payload["target_object_id"])
+        if isinstance(payload["target_object_id"], str):
+            payload["target_object_id"] = UUID(payload["target_object_id"])
         payload["storage_alias"] = payload.pop("s3_endpoint_alias")
     else:
         # FileRegisteredForDownload event:

--- a/services/dcs/tests_dcs/migrations/v3_test_data.py
+++ b/services/dcs/tests_dcs/migrations/v3_test_data.py
@@ -72,7 +72,7 @@ EXPECTED_MIGRATED_DRS_OBJECTS: list[dict[str, Any]] = [
 ]
 
 OLD_PERSISTED_EVENTS: list[dict[str, Any]] = [
-    {
+    {  # FileDownloadServed
         "_id": "staging-downloads:GHGAF62145458747015",
         "topic": "staging-downloads",
         "type_": "drs_object_registered",
@@ -89,7 +89,7 @@ OLD_PERSISTED_EVENTS: list[dict[str, Any]] = [
         "published": True,
         "event_id": UUID("5b04fe60-1436-46ca-aeec-a7fc6aaaf33f"),
     },
-    {
+    {  # FileRegisteredForDownload with old str-value target_object_id
         "_id": "staging-downloads:GHGAF91819066635026",
         "topic": "staging-downloads",
         "type_": "drs_object_served",
@@ -107,6 +107,25 @@ OLD_PERSISTED_EVENTS: list[dict[str, Any]] = [
         "created": TEST_DATETIME,
         "published": True,
         "event_id": UUID("a5343581-25c8-45d2-ac53-f850c02bcea9"),
+    },
+    {  # FileRegisteredForDownload with newer UUID-value target_object_id
+        "_id": "staging-downloads:GHGAF92819066635026",
+        "topic": "staging-downloads",
+        "type_": "drs_object_served",
+        "payload": {
+            "file_id": "GHGAF92819066635026",
+            "target_object_id": UUID("a6370254-3555-4f77-b939-572452770aa5"),
+            "target_bucket_id": "outbox-staging",
+            "s3_endpoint_alias": "B01",
+            "decrypted_sha256": "e5b844cc57f57094ea4585e235f36c78c1cd222262bb89d53c94dcb4d6b3e55d",
+            "context": "unknown",
+        },
+        "key": "GHGAF92819066635026",
+        "headers": {},
+        "correlation_id": UUID("7a0f695a-f91c-4acd-91c3-ea2a52cfceff"),
+        "created": TEST_DATETIME,
+        "published": True,
+        "event_id": UUID("61788c24-de12-44a7-8367-60398cdd907b"),
     },
 ]
 
@@ -145,5 +164,24 @@ EXPECTED_MIGRATED_PERSISTED_EVENTS: list[dict[str, Any]] = [
         "created": TEST_DATETIME,
         "published": False,
         "event_id": UUID("a5343581-25c8-45d2-ac53-f850c02bcea9"),
+    },
+    {
+        "_id": "staging-downloads:bb4262e4-1d12-4313-ac21-c2b16fb5e7aa",
+        "topic": "staging-downloads",
+        "type_": "drs_object_served",
+        "payload": {
+            "file_id": UUID("bb4262e4-1d12-4313-ac21-c2b16fb5e7aa"),
+            "target_object_id": UUID("a6370254-3555-4f77-b939-572452770aa5"),
+            "target_bucket_id": "outbox-staging",
+            "storage_alias": "B01",
+            "decrypted_sha256": "e5b844cc57f57094ea4585e235f36c78c1cd222262bb89d53c94dcb4d6b3e55d",
+            "context": "unknown",
+        },
+        "key": "bb4262e4-1d12-4313-ac21-c2b16fb5e7aa",
+        "headers": {},
+        "correlation_id": UUID("7a0f695a-f91c-4acd-91c3-ea2a52cfceff"),
+        "created": TEST_DATETIME,
+        "published": False,
+        "event_id": UUID("61788c24-de12-44a7-8367-60398cdd907b"),
     },
 ]


### PR DESCRIPTION
For FileDownloadServed events, the `"target_object_id"` field was not converted to a UUID in the V2 migration, even though the schema itself was. So after the switch, new instances had that field with a UUID value while older instances had the string value. This never caused a production error because of the way pydantic handles UUIDs represented as strings. 

The DCS v3 migration encountered an error because it assumed that all old rows were strings that needed to be converted to UUIDs.

Bumps DCS version to `10.0.1` and the monorepo version to `13.0.1`