### PR TITLE
FIS: Fix FileUpload event handling (GSI-2394)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.1.0"
+version = "13.2.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.1.0"
+version = "13.2.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:11.2.0
+docker pull ghga/file-ingest-service:11.2.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:11.2.0 .
+docker build -t ghga/file-ingest-service:11.2.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:11.2.0 --help
+docker run -p 8080:8080 ghga/file-ingest-service:11.2.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -179,7 +179,7 @@ info:
   description: A service to liaise between Central File Services and Data Hubs for
     file inspection.
   title: File Ingest Service
-  version: 11.2.0
+  version: 11.2.1
 openapi: 3.1.0
 paths:
   /health:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "11.2.0"
+version = "11.2.1"
 description = "File Ingest Service - A service to liaise between Central File Services and Data Hubs for file inspection."
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/core/interrogation.py
+++ b/services/fis/src/fis/core/interrogation.py
@@ -272,20 +272,21 @@ class InterrogationHandler(InterrogationHandlerPort):
             )
 
     async def process_file_upload(self, *, file: models.FileUnderInterrogation) -> None:
-        """Process a newly received file upload.
+        """Process a newly received file upload event.
 
-        Make sure we don't already have this file. If we don't, then add it to the DB.
-        If we do, see if this information is old or new. If old, ignore it.
-        If the received information is newer than what we have, and the state is
-        different, *and* the new state represents one of the end states, then update our
-        copy.
+        State-by-state behavior:
 
-        We don't track files that are only in the 'init' state, we only track them once
-        they reach 'inbox'. The transition from 'inbox' to 'interrogated' or from 'inbox'
-        to 'failed' is performed by the FIS in `.handle_interrogation_report()`. The
-        state 'awaiting_archival' is not of interest of the FIS and has no functional
-        difference from 'interrogated' from the perspective of the FIS. Therefore, the
-        only states of interest in this method are 'cancelled', 'failed', and 'archived'.
+        - 'init': ignored; FIS does not track files until they reach 'inbox'.
+        - 'inbox': insert into the DB if not already present (idempotent).
+        - 'cancelled' / 'failed': if the file is known, set can_remove=True and update.
+          If not known (i.e., it reached this terminal state before ever hitting 'inbox'),
+          log at INFO and ignore since this is a known possibility.
+        - 'archived': same update path as cancelled/failed (set can_remove=True). If the
+          file is unknown, log a warning and ignore.
+        - 'interrogated' / 'awaiting_archival': these transitions are owned by
+          handle_interrogation_report(), not by this method. If the file is known and
+          the incoming timestamp is newer, no update is performed here. If the file is
+          unknown (should not happen in normal operation), log a warning and ignore.
         """
         if file.state == "init":
             return
@@ -295,7 +296,26 @@ class InterrogationHandler(InterrogationHandlerPort):
                 return
 
         # If we make it past that block, then it is not new and we must compare.
-        local_file = await self._file_dao.get_by_id(file.id)
+        try:
+            local_file = await self._file_dao.get_by_id(file.id)
+        except ResourceNotFoundError:
+            if file.state in ["cancelled", "failed"]:
+                log.info(
+                    "Received event data for a %s FileUpload that FIS doesn't have."
+                    + " This means it probably reached that state before the upload"
+                    + " was finished. Ignoring.",
+                    file.state,
+                    extra={"file_id": file.id},
+                )
+                return
+            log.warning(
+                "Received event for a %s FileUpload that FIS never tracked."
+                + " This is unexpected. Ignoring since there wouldn't be anything"
+                + " for FIS to do anyway.",
+                file.state,
+                extra={"file_id": file.id},
+            )
+            return
 
         # Ignore if outdated
         if local_file.state_updated >= file.state_updated:

--- a/services/fis/tests_fis/integration/test_core.py
+++ b/services/fis/tests_fis/integration/test_core.py
@@ -15,16 +15,20 @@
 
 """Integration tests for the core"""
 
+import logging
+
 import pytest
 from hexkit.utils import now_utc_ms_prec
 from pytest_httpx import HTTPXMock
 
 from fis.core import models
+from fis.ports.outbound.dao import ResourceNotFoundError
 from tests_fis.fixtures.joint import JointFixture
 from tests_fis.fixtures.utils import create_file_under_interrogation
 
+pytestmark = pytest.mark.asyncio
 
-@pytest.mark.asyncio()
+
 async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMock):
     """Test the typical path of receiving a FileUpload event through archival."""
     # Create a FileUnderInterrogation and publish it to the file uploads topic
@@ -125,3 +129,67 @@ async def test_typical_journey(joint_fixture: JointFixture, httpx_mock: HTTPXMoc
         object_id=file.object_id
     )
     assert can_remove is True
+
+
+@pytest.mark.parametrize(
+    "state,expected_log_level,expected_msg_fragment",
+    [
+        ("cancelled", logging.INFO, "before the upload was finished"),
+        ("failed", logging.INFO, "before the upload was finished"),
+        ("interrogated", logging.WARNING, "This is unexpected"),
+        ("awaiting_archival", logging.WARNING, "This is unexpected"),
+        ("archived", logging.WARNING, "This is unexpected"),
+    ],
+)
+async def test_failure_before_inbox(
+    joint_fixture: JointFixture,
+    caplog,
+    state,
+    expected_log_level,
+    expected_msg_fragment,
+):
+    """Ensure FIS properly handles FileUpload events whose state skipped 'inbox'.
+
+    For 'cancelled' and 'failed', this is an expected edge case (the upload failed
+    before it was ever staged). For 'interrogated', 'awaiting_archival', and
+    'archived', it is unexpected but should still be handled gracefully (log +
+    ignore rather than raise).
+
+    The test publishes an 'init' event (which FIS ignores and does not store) and
+    then a second event with the target state. It verifies that:
+    - no record was ever written to the DB for the file
+    - the appropriate log message was emitted at the correct level
+    """
+    file = create_file_under_interrogation("HUB1")
+    file.state = "init"
+    topic = joint_fixture.config.file_upload_topic
+    await joint_fixture.kafka.publish_event(
+        payload=file.model_dump(),
+        type_="upserted",
+        topic=topic,
+        key=str(file.id),
+    )
+
+    # Consume the init file upload event — FIS should ignore it
+    await joint_fixture.outbox_consumer.run(forever=False)
+
+    file.state = state
+    await joint_fixture.kafka.publish_event(
+        payload=file.model_dump(),
+        type_="upserted",
+        topic=topic,
+        key=str(file.id),
+    )
+
+    with caplog.at_level(expected_log_level, logger="fis.core.interrogation"):
+        await joint_fixture.outbox_consumer.run(forever=False)
+
+    # The file should never have been written to the DB
+    with pytest.raises(ResourceNotFoundError):
+        await joint_fixture.file_dao.get_by_id(file.id)
+
+    # Verify the expected log message was emitted at the right level
+    assert any(
+        record.levelno == expected_log_level and expected_msg_fragment in record.message
+        for record in caplog.records
+    )

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:12.1.0
+docker pull ghga/upload-controller-service:12.2.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:12.1.0 .
+docker build -t ghga/upload-controller-service:12.2.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:12.1.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:12.2.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -730,7 +730,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 12.1.0
+  version: 12.2.0
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "12.1.0"
+version = "12.2.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
FIS doesn't store a local copy of FileUploads until they finish uploading and reach the "inbox" state. However, a file can be cancelled or failed without ever reaching the "inbox" state, and the current implementation will always error in that case.

The fix here adds handling for `ResourceNotFoundError`. In that error handling, if the state is `failed` or `cancelled`, we just write an INFO log. If it's `archived`, `interrogated`, or `awaiting_archival`, then we write a WARNING log, but keep processing (it won't error/go to DLQ).

A test was added to mimic the scenario which triggered the original error seen in staging. 

Bumps the patch version of FIS.

Bumps the minor version of UCS because I didn't do that in the previous UCS PR. 

Bumps the monorepo minor version accordingly.