### PR TITLE
IFRS: Only log deletions (GSI-2398)

### DIFF
--- a/services/ifrs/README.md
+++ b/services/ifrs/README.md
@@ -36,13 +36,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:7.2.0
+docker pull ghga/internal-file-registry-service:7.2.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:7.2.0 .
+docker build -t ghga/internal-file-registry-service:7.2.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -50,7 +50,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:7.2.0 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:7.2.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ifrs/pyproject.toml
+++ b/services/ifrs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifrs"
-version = "7.2.0"
+version = "7.2.1"
 description = "Internal File Registry Service - This service acts as a registry for the internal location and representation of files."
 readme = "README.md"
 authors = [

--- a/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
+++ b/services/ifrs/src/ifrs/adapters/inbound/event_sub.py
@@ -118,12 +118,17 @@ class FileUploadOutboxTranslator(DaoSubscriberProtocol[FileUpload]):
 
     @TRACER.start_as_current_span("FileUploadOutboxTranslator.deleted")
     async def deleted(self, resource_id: str) -> None:
-        """This should not be hit.
+        """Log occurrence and ignore event.
 
-        FileUploads are not deleted. Instead, their state is set to 'cancelled' or
-        'failed'. If we receive a deletion event for a FileUpload, there is an
-        inconsistency in implementation between services. The event should be sent
-        to the DLQ.
+        FileUploads are usually set to "cancelled" or "failed" rather than outright
+        deleted, but it can happen if a new upload is created for an alias in a box
+        which already had a previously associated FileUpload. The first FileUpload would
+        be deleted to allow the second one to be created. Then we would see a "deleted"
+        type event for the first item. IFRS does not act on these deletions, because
+        once archival has occurred, deletions should be triggered through the Purge
+        Controller Service and not the Upload Controller. And anything that hasn't been
+        archived yet is obviously not relevant to IFRS.
         """
-        log.error("Received deletion outbox event for FileUpload %s.", resource_id)
-        raise RuntimeError(f"Unexpected deletion event for FileUpload {resource_id}.")
+        log.info(
+            "Received deletion outbox event for FileUpload %s. Ignoring.", resource_id
+        )

--- a/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
+++ b/services/ifrs/tests_ifrs/test_ifrs_edge_cases.py
@@ -324,6 +324,25 @@ async def test_handle_file_upload(
         mock.assert_not_awaited()
 
 
+async def test_file_upload_deletion_event(joint_fixture: JointFixture, caplog):
+    """Test that the "deleted"-type outbox events for FileUploads produces a log but
+    no error.
+    """
+    file_id = str(EXAMPLE_AWAITING_ARCHIVAL.id)
+    await joint_fixture.kafka.publish_event(
+        payload={},
+        type_="deleted",
+        topic=joint_fixture.config.file_upload_topic,
+        key=file_id,
+    )
+
+    caplog.clear()
+    caplog.set_level("INFO")
+    await joint_fixture.event_subscriber.run(forever=False)
+    log = f"Received deletion outbox event for FileUpload {file_id}. Ignoring."
+    assert log in caplog.messages
+
+
 async def test_error_during_copy_to_download_bucket(
     joint_fixture: JointFixture,
     caplog,


### PR DESCRIPTION
IFRS currently raises an error if "deletion"-type FileUpload outbox events are received. It should actually log the event receipt and do nothing. Thus this PR.

The issue stems from an old conception that FileUploads are never deleted but rather marked failed or cancelled. There is an exception, however, when FileUploads are replaced, e.g. a new upload is initiated for the same alias within a FileUploadBox. In that case, the FileUpload is deleted and a new one is inserted (different ID, but same box ID + alias).