### PR TITLE
UCS: Handle edge case in File Upload init (GSI-2396)

### DIFF
--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -174,8 +174,8 @@ class UploadController(UploadControllerPort):
             #  the cleanup job takes care of it.
             extra = {"box_id": file_upload.box_id, "file_alias": file_upload.alias}
             log.error(
-                "Got an error while trying to insert FileUpload %s, for which it must"
-                + " be marked 'failed'. Error: %s",
+                "Encountered an error while inserting FileUpload %s; it will be marked"
+                + " as 'failed'. Error: %s",
                 file_upload.id,
                 err,
                 extra=extra,
@@ -193,16 +193,16 @@ class UploadController(UploadControllerPort):
                 if isinstance(mark_failed_err, DaoError):
                     # Database errors should be raised, not suppressed
                     log.error(
-                        "An error has occurred during FileUpload init which requires"
-                        + " that the FileUpload be marked 'failed'. While making that"
-                        + " DB write, we received this additional error: %s",
+                        "While marking FileUpload %s as 'failed', encountered another"
+                        + " database error: %s",
+                        file_upload.id,
                         mark_failed_err,
                         extra=extra,
                     )
                     raise mark_failed_err
                 else:
                     log.warning(
-                        "While marking FileUpload %s as 'failed', got another error."
+                        "While marking FileUpload %s as 'failed', encountered another error."
                         + " If it's from Kafka, this is fine - just fix Kafka and run"
                         + " the publish-all job. If it's not related to Kafka at all,"
                         + " then this warrants further investigation. Error: %s",

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -29,6 +29,7 @@ from ghga_event_schemas.pydantic_ import (
 )
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from hexkit.protocols.dao import (
+    DaoError,
     MultipleHitsFoundError,
     NoHitsFoundError,
     UniqueConstraintViolationError,
@@ -159,22 +160,55 @@ class UploadController(UploadControllerPort):
                 new_upload=file_upload,
                 logging_extras=logging_extras,
             )
+
+            # This means that the existing file is still "good" and needs explicit
+            #  cancellation/removal before a new upload can be started for this alias.
             if not replaced:
                 error = self.FileUploadAlreadyExists(alias=alias)
                 log.error(error, extra=logging_extras)
-                raise error from err
-        except Exception:
+                raise error from None  # don't need Unique* error in the trace
+        except Exception as err:
             # This branch handles all other errors that *don't* signify an existing file
             # If, e.g. kafka raises an error, delete the FileUpload so user can retry.
             # To avoid more potential failure points, let active S3 upload linger until
             #  the cleanup job takes care of it.
             extra = {"box_id": file_upload.box_id, "file_alias": file_upload.alias}
+            log.error(
+                "Got an error while trying to insert FileUpload %s, for which it must"
+                + " be marked 'failed'. Error: %s",
+                file_upload.id,
+                err,
+                extra=extra,
+            )
+
             file_upload.state = "failed"
             file_upload.state_updated = now_utc_ms_prec()
             file_upload.failure_reason = "Internal error during upload initiation"
-
             # If Kafka is the problem, this will also error but not until after the update
-            await self._file_upload_dao.update(file_upload)
+            try:
+                # In case first write didn't actually land, use upsert
+                await self._file_upload_dao.upsert(file_upload)
+            except Exception as mark_failed_err:
+                # TODO: Update this section once Hexkit has defined errors for Kafka
+                if isinstance(mark_failed_err, DaoError):
+                    # Database errors should be raised, not suppressed
+                    log.error(
+                        "An error has occurred during FileUpload init which requires"
+                        + " that the FileUpload be marked 'failed'. While making that"
+                        + " DB write, we received this additional error: %s",
+                        mark_failed_err,
+                        extra=extra,
+                    )
+                    raise mark_failed_err
+                else:
+                    log.warning(
+                        "While marking FileUpload %s as 'failed', got another error."
+                        + " If it's from Kafka, this is fine - just fix Kafka and run"
+                        + " the publish-all job. If it's not related to Kafka at all,"
+                        + " then this warrants further investigation. Error: %s",
+                        file_upload.id,
+                        mark_failed_err,
+                    )
 
             # This is INFO level because it's normal procedure for cleanup.
             log.info(

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -28,7 +28,11 @@ from ghga_event_schemas.pydantic_ import (
     InterrogationSuccess,
 )
 from ghga_service_commons.utils.utc_dates import UTCDatetime
-from hexkit.protocols.dao import NoHitsFoundError, UniqueConstraintViolationError
+from hexkit.protocols.dao import (
+    MultipleHitsFoundError,
+    NoHitsFoundError,
+    UniqueConstraintViolationError,
+)
 from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4
 
@@ -101,8 +105,14 @@ class UploadController(UploadControllerPort):
     ) -> None:
         """Insert a new FileUpload, replacing a failed/cancelled one if needed.
 
+        If a unique constraint violation occurs, the existing upload is retrieved and
+        replaced when it is in a failed or cancelled state. If any other error occurs,
+        the upload is marked 'failed' so a subsequent retry can replace it, and the
+        error is re-raised. The associated S3 multipart upload is left for the cleanup
+        job to handle.
+
         Raises `FileUploadAlreadyExists` if an active FileUpload already exists for
-        this alias and box_id.
+        this alias and box_id (and is not failed or cancelled).
         """
         box_id = box.id
         alias = file_upload.alias
@@ -111,32 +121,40 @@ class UploadController(UploadControllerPort):
             await self._file_upload_dao.insert(file_upload)
         except UniqueConstraintViolationError as err:
             # If there's already a FileUpload in the box with this alias, retrieve it
+            logging_extras = {  # only for logging
+                "box_id": box.id,
+                "file_alias": file_upload.alias,
+                "new_file_upload_id": file_upload.id,
+            }
             try:
                 existing_upload = await self._file_upload_dao.find_one(
                     mapping={"box_id": box_id, "alias": alias}
                 )
-            except NoHitsFoundError:
+            except (NoHitsFoundError, MultipleHitsFoundError) as find_err:
                 # If we don't get any hits, something weird is going on. This isn't a
                 #  typical error to handle, so raise a RuntimeError
+                qty = "no" if isinstance(find_err, NoHitsFoundError) else "multiple"
                 msg = (
                     "Encountered an error indicating this FileUploadBox already"
-                    + f" has a FileUpload for the alias {alias}, but got no results"
+                    + f" has a FileUpload for the alias {alias}, but got {qty} results"
                     + " when trying to retrieve the existing FileUpload."
                 )
-                error = RuntimeError(msg)
-                log.critical(error, extra={"box_id": box.id, "file_alias": alias})
-                raise error from err
+                log.error(msg)
+                raise RuntimeError(msg) from err
+            except Exception as other_err:
+                # If another error occurs during find_one, log it too
+                msg = (
+                    "Encountered an error indicating this FileUploadBox already"
+                    + f" has a FileUpload for the alias {alias}, but received the"
+                    + f" following error while trying to investigate: {other_err}"
+                )
+                log.error(msg, extra=logging_extras)
+                raise RuntimeError(msg) from other_err
 
             # If retrieval succeeds, evaluate and attempt to replace the file upload
-            logging_extras = {  # only for logging
-                "box_id": box.id,
-                "file_alias": file_upload.alias,
-                "old_file_upload_id": existing_upload.id,
-                "old_state": existing_upload.state,
-                "new_file_upload_id": file_upload.id,
-            }
+            logging_extras["old_file_upload_id"] = existing_upload.id
+            logging_extras["old_state"] = existing_upload.state
             replaced = await self._try_to_replace_upload(
-                box=box,
                 existing_upload=existing_upload,
                 new_upload=file_upload,
                 logging_extras=logging_extras,
@@ -145,10 +163,30 @@ class UploadController(UploadControllerPort):
                 error = self.FileUploadAlreadyExists(alias=alias)
                 log.error(error, extra=logging_extras)
                 raise error from err
+        except Exception:
+            # This branch handles all other errors that *don't* signify an existing file
+            # If, e.g. kafka raises an error, delete the FileUpload so user can retry.
+            # To avoid more potential failure points, let active S3 upload linger until
+            #  the cleanup job takes care of it.
+            extra = {"box_id": file_upload.box_id, "file_alias": file_upload.alias}
+            file_upload.state = "failed"
+            file_upload.state_updated = now_utc_ms_prec()
+            file_upload.failure_reason = "Internal error during upload initiation"
+
+            # If Kafka is the problem, this will also error but not until after the update
+            await self._file_upload_dao.update(file_upload)
+
+            # This is INFO level because it's normal procedure for cleanup.
+            log.info(
+                "Marked FileUpload %s as 'failed' due to error during initiation.",
+                file_upload.id,
+                extra=extra,
+            )
+            # Re-raise the exception
+            raise
 
     async def _try_to_replace_upload(
         self,
-        box: FileUploadBox,
         existing_upload: FileUpload,
         new_upload: FileUpload,
         logging_extras: dict[str, Any],
@@ -158,10 +196,16 @@ class UploadController(UploadControllerPort):
         If successful, this method will delete the old FileUpload and insert the new one.
         This does result in an outbox deletion event for the old FileUpload.
 
+        The old FileUpload is deleted, rather than re-used, to avoid complications with
+        downstream state management. Also, we can't have two FileUpload docs with the
+        same box ID and alias because it will violate the index.
+
         Returns a boolean indicating whether replacement was successful.
         """
         # Examine the existing FileUpload - it has to be either failed or cancelled to
         #  be replaced with the new submission. If not, we have to raise an error.
+        #  The user (or a DS) must first stop/remove the upload before it can be
+        #  replaced with a new one.
         if existing_upload.state not in ("failed", "cancelled"):
             return False
 
@@ -387,6 +431,8 @@ class UploadController(UploadControllerPort):
             s3_upload_id=s3_upload_id,
             initiated=initiated,
         )
+
+        # Extensive recovery/error handling occurs here:
         await self._insert_file_upload(box=box, file_upload=file_upload)
 
         # Create upload activity entry (overwrite if one unexpectedly exists)

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1690,3 +1690,50 @@ async def test_refresh_activity_warns_and_recreates_when_missing(rig: JointRig):
     # Verify the entry now exists again
     activity = await rig.upload_activity_dao.get_by_id(file_id)
     assert activity.file_id == file_id
+
+
+async def test_initiate_file_upload_marks_failed_on_insert_kafka_error(
+    rig: JointRig,
+):
+    """If a Kafka publishing error occurs during the FileUpload insert (or some other
+    kind of equivalent error), the FileUpload must be marked "failed" so that a
+    subsequent retry can replace it.
+
+    The test `test_initiate_upload_after_failed()` covers the process of starting a new
+    upload for the same essential file after a FileUpload is "failed".
+    """
+    box_id = await rig.create_default_box()
+
+    # Simulate the outbox publisher scenario: MongoDB write succeeds (we call the real
+    # insert), then Kafka raises an error (the reason doesn't matter)
+    original_insert = rig.file_upload_dao.insert
+    original_update = rig.file_upload_dao.update
+
+    async def insert_then_fail(dto):
+        await original_insert(dto)
+        raise RuntimeError("Simulated Kafka error on insert")
+
+    async def update_then_fail(dto):
+        await original_update(dto)
+        raise RuntimeError("Simulated Kafka error on update")
+
+    rig.file_upload_dao.insert = insert_then_fail
+    rig.file_upload_dao.update = update_then_fail
+
+    with pytest.raises(RuntimeError, match="Simulated Kafka error on update"):
+        await rig.controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test-file",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=PART_SIZE,
+        )
+
+    # The FileUpload was written to the DB but must now be marked 'failed'
+    assert len(rig.file_upload_dao.resources) == 1
+    stuck_upload = rig.file_upload_dao.latest
+    assert stuck_upload.state == "failed"
+    assert stuck_upload.failure_reason == "Internal error during upload initiation"
+
+    # Just double check that no UploadActivity was inserted
+    assert not [x async for x in rig.upload_activity_dao.find_all(mapping={})]

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -15,6 +15,7 @@
 
 """Tests for the UploadController class"""
 
+import logging
 from asyncio import sleep
 from contextlib import nullcontext
 from datetime import timedelta
@@ -1694,6 +1695,7 @@ async def test_refresh_activity_warns_and_recreates_when_missing(rig: JointRig):
 
 async def test_initiate_file_upload_marks_failed_on_insert_kafka_error(
     rig: JointRig,
+    caplog: pytest.LogCaptureFixture,
 ):
     """If a Kafka publishing error occurs during the FileUpload insert (or some other
     kind of equivalent error), the FileUpload must be marked "failed" so that a
@@ -1707,27 +1709,42 @@ async def test_initiate_file_upload_marks_failed_on_insert_kafka_error(
     # Simulate the outbox publisher scenario: MongoDB write succeeds (we call the real
     # insert), then Kafka raises an error (the reason doesn't matter)
     original_insert = rig.file_upload_dao.insert
-    original_update = rig.file_upload_dao.update
+    original_upsert = rig.file_upload_dao.upsert
 
     async def insert_then_fail(dto):
         await original_insert(dto)
-        raise RuntimeError("Simulated Kafka error on insert")
+        raise RuntimeError("First Error")
 
-    async def update_then_fail(dto):
-        await original_update(dto)
-        raise RuntimeError("Simulated Kafka error on update")
+    async def upsert_then_fail(dto):
+        await original_upsert(dto)
+        raise RuntimeError("Follow-up Error")
 
     rig.file_upload_dao.insert = insert_then_fail
-    rig.file_upload_dao.update = update_then_fail
+    rig.file_upload_dao.upsert = upsert_then_fail
 
-    with pytest.raises(RuntimeError, match="Simulated Kafka error on update"):
-        await rig.controller.initiate_file_upload(
-            box_id=box_id,
-            alias="test-file",
-            decrypted_size=DECRYPTED_SIZE,
-            encrypted_size=ENCRYPTED_SIZE,
-            part_size=PART_SIZE,
-        )
+    with caplog.at_level(logging.INFO, logger="ucs.core.controller"):
+        with pytest.raises(RuntimeError, match="First Error"):
+            await rig.controller.initiate_file_upload(
+                box_id=box_id,
+                alias="test-file",
+                decrypted_size=DECRYPTED_SIZE,
+                encrypted_size=ENCRYPTED_SIZE,
+                part_size=PART_SIZE,
+            )
+
+    controller_logs = [r for r in caplog.records if r.name == "ucs.core.controller"]
+    error_logs = [r for r in controller_logs if r.levelno == logging.ERROR]
+    warning_logs = [r for r in controller_logs if r.levelno == logging.WARNING]
+    info_logs = [r for r in controller_logs if r.levelno == logging.INFO]
+
+    assert len(error_logs) == 1
+    assert "Got an error while trying to insert" in error_logs[0].getMessage()
+
+    assert len(warning_logs) == 1
+    assert "While marking FileUpload" in warning_logs[0].getMessage()
+
+    assert len(info_logs) == 1
+    assert "as 'failed' due to error during initiation" in info_logs[0].getMessage()
 
     # The FileUpload was written to the DB but must now be marked 'failed'
     assert len(rig.file_upload_dao.resources) == 1

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1738,7 +1738,9 @@ async def test_initiate_file_upload_marks_failed_on_insert_kafka_error(
     info_logs = [r for r in controller_logs if r.levelno == logging.INFO]
 
     assert len(error_logs) == 1
-    assert "Got an error while trying to insert" in error_logs[0].getMessage()
+    assert (
+        "Encountered an error while inserting FileUpload" in error_logs[0].getMessage()
+    )
 
     assert len(warning_logs) == 1
     assert "While marking FileUpload" in warning_logs[0].getMessage()


### PR DESCRIPTION
We recently had something happen in Staging where Kafka was misconfigured and it produce an error during the Outbox DAO's publishing action. This was during FileUpload init. So the `"init"`-state FileUpload was sitting around in the database, and the S3 upload had been opened, but the Connector only saw the error and therefore tried again. But these retries failed because there was an `"init"`-state FileUpload for the specified box & alias already. At the moment, there's no deletion mechanism in the Connector (to be fixed soon), so this effectively killed the user's ability to upload that file. 

This update adds error handling for this scenario to mark the upload as `"failed"` so that the Connector may at least retry in the future. Other options considered and abandoned were: A) Check the db and suppress the error/allow processing to continue if we see that the updates were written successfully to the DB (this then opens up a lot of questions about consistent logic and should we do it for, e.g. completion as well). B) Instead of marking the upload as `"failed"`, delete it entirely. (Not a bad option, could also do, but don't see an advantage other than the next attempt has fewer DB I/O.)

The reduce further failure points during error handling, the S3 uploads are left open (we'll let the cleanup job take care of it).

Some other error handling in the vicinity was improved as well.

No version bump because the previous UCS PR is still not released.