### PR TITLE
FIS: Delete file uploads in response to outbox events (GSI-2397)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.2.1"
+version = "13.3.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.2.1"
+version = "13.3.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/fis/README.md
+++ b/services/fis/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:11.2.1
+docker pull ghga/file-ingest-service:11.3.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:11.2.1 .
+docker build -t ghga/file-ingest-service:11.3.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:11.2.1 --help
+docker run -p 8080:8080 ghga/file-ingest-service:11.3.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/fis/openapi.yaml
+++ b/services/fis/openapi.yaml
@@ -179,7 +179,7 @@ info:
   description: A service to liaise between Central File Services and Data Hubs for
     file inspection.
   title: File Ingest Service
-  version: 11.2.1
+  version: 11.3.0
 openapi: 3.1.0
 paths:
   /health:

--- a/services/fis/pyproject.toml
+++ b/services/fis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "11.2.1"
+version = "11.3.0"
 description = "File Ingest Service - A service to liaise between Central File Services and Data Hubs for file inspection."
 readme = "README.md"
 authors = [

--- a/services/fis/src/fis/adapters/inbound/event_sub.py
+++ b/services/fis/src/fis/adapters/inbound/event_sub.py
@@ -59,4 +59,4 @@ class OutboxSubTranslator(DaoSubscriberProtocol):
     async def deleted(self, resource_id: str) -> None:
         """Consume event indicating the cancellation or removal of a FileUpload."""
         file_id = UUID(resource_id)  # this ID is canonically a UUID4
-        await self._interrogation_handler.ack_file_cancellation(file_id=file_id)
+        await self._interrogation_handler.delete_file(file_id=file_id)

--- a/services/fis/src/fis/core/interrogation.py
+++ b/services/fis/src/fis/core/interrogation.py
@@ -356,14 +356,18 @@ class InterrogationHandler(InterrogationHandlerPort):
         return files
 
     async def delete_file(self, *, file_id: UUID4) -> None:
-        """Delete a file from the database.
+        """Delete a file and its interrogation report (if any) from the database.
 
-        This actually removes the entry from the database as a result of an upstream
+        This removes the entries from the database as a result of an upstream
         deletion in UCS. The usual cause for this is the replacement of a failed or
         cancelled FileUpload with a new instance for the same file alias.
 
         If no matching entry is found, it is assumed that the entry was already deleted.
         """
+        with suppress(ResourceNotFoundError):
+            await self._interrogation_report_dao.delete(file_id)
+            log.info("Interrogation report deleted for file ID %s.", file_id)
+
         try:
             await self._file_dao.delete(file_id)
             log.info("Local copy deleted for file ID %s.", file_id)

--- a/services/fis/src/fis/core/interrogation.py
+++ b/services/fis/src/fis/core/interrogation.py
@@ -21,7 +21,6 @@ import logging
 from contextlib import suppress
 
 from ghga_event_schemas import pydantic_ as event_schemas
-from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4
 
 from fis.config import Config
@@ -356,25 +355,17 @@ class InterrogationHandler(InterrogationHandlerPort):
         )
         return files
 
-    async def ack_file_cancellation(self, *, file_id: UUID4) -> None:
-        """Acknowledge the removal or cancellation of a FileUpload.
+    async def delete_file(self, *, file_id: UUID4) -> None:
+        """Delete a file from the database.
 
-        Raises:
-        - FileNotFoundError if there's no file with the ID specified in the report.
+        This actually removes the entry from the database as a result of an upstream
+        deletion in UCS. The usual cause for this is the replacement of a failed or
+        cancelled FileUpload with a new instance for the same file alias.
+
+        If no matching entry is found, it is assumed that the entry was already deleted.
         """
-        # First make sure we have this file
         try:
-            file = await self._file_dao.get_by_id(file_id)
-        except ResourceNotFoundError as err:
-            log.error(
-                "Can't acknowledge file cancellation because no file with ID %s exists.",
-                file_id,
-            )
-            raise self.FileNotFoundError(file_id=file_id) from err
-
-        file.state = "cancelled"
-        file.state_updated = now_utc_ms_prec()
-        file.can_remove = True
-
-        await self._file_dao.update(file)
-        log.info("Acknowledged file cancellation for %s", file_id)
+            await self._file_dao.delete(file_id)
+            log.info("Local copy deleted for file ID %s.", file_id)
+        except ResourceNotFoundError:
+            log.info("Did not find file with ID %s; presumed already deleted.", file_id)

--- a/services/fis/src/fis/ports/inbound/interrogation.py
+++ b/services/fis/src/fis/ports/inbound/interrogation.py
@@ -111,9 +111,9 @@ class InterrogationHandlerPort(ABC):
 
     @abstractmethod
     async def delete_file(self, *, file_id: UUID4) -> None:
-        """Delete a file from the database.
+        """Delete a file and its interrogation report (if any) from the database.
 
-        This actually removes the entry from the database as a result of an upstream
+        This removes the entries from the database as a result of an upstream
         deletion in UCS. The usual cause for this is the replacement of a failed or
         cancelled FileUpload with a new instance for the same file alias.
 

--- a/services/fis/src/fis/ports/inbound/interrogation.py
+++ b/services/fis/src/fis/ports/inbound/interrogation.py
@@ -110,9 +110,12 @@ class InterrogationHandlerPort(ABC):
         """Return a list of not-yet-interrogated files for a Data Hub"""
 
     @abstractmethod
-    async def ack_file_cancellation(self, *, file_id: UUID4) -> None:
-        """Acknowledge the removal or cancellation of a FileUpload.
+    async def delete_file(self, *, file_id: UUID4) -> None:
+        """Delete a file from the database.
 
-        Raises:
-        - FileNotFoundError if there's no file with the ID specified in the report.
+        This actually removes the entry from the database as a result of an upstream
+        deletion in UCS. The usual cause for this is the replacement of a failed or
+        cancelled FileUpload with a new instance for the same file alias.
+
+        If no matching entry is found, it is assumed that the entry was already deleted.
         """

--- a/services/fis/tests_fis/integration/test_outbox_sub.py
+++ b/services/fis/tests_fis/integration/test_outbox_sub.py
@@ -80,4 +80,4 @@ async def test_deleted(kafka: KafkaFixture):
         await outbox_consumer.run(forever=False)
 
     # Verify that the outbox subscriber called the right core method
-    core_mock.ack_file_cancellation.assert_awaited_once_with(file_id=file.id)
+    core_mock.delete_file.assert_awaited_once_with(file_id=file.id)

--- a/services/fis/tests_fis/unit/test_core.py
+++ b/services/fis/tests_fis/unit/test_core.py
@@ -343,26 +343,20 @@ async def test_get_files_not_yet_interrogated(rig: JointRig):
     assert set(f.id for f in results_h2) == hub2_ids
 
 
-async def test_ack_file_cancellation(rig: JointRig):
-    """Test the `.ack_file_cancellation()` method"""
-    # Test file not found error
+async def test_delete_file(rig: JointRig):
+    """Test the `.delete_file()` method"""
     file = create_file_under_interrogation(HUB1)
-    with pytest.raises(InterrogationHandlerPort.FileNotFoundError):
-        await rig.interrogation_handler.ack_file_cancellation(file_id=file.id)
 
-    # Insert a file
-    file.state = "inbox"
-    file.state_updated -= timedelta(hours=1)
+    # Deleting a file that doesn't exist should not raise an error
+    await rig.interrogation_handler.delete_file(file_id=file.id)
+
+    # Insert the file, then delete it
     await rig.file_dao.insert(file)
+    await rig.interrogation_handler.delete_file(file_id=file.id)
 
-    # Acknowledge the file cancellation
-    await rig.interrogation_handler.ack_file_cancellation(file_id=file.id)
-
-    # Verify file was updated
-    updated_file = await rig.file_dao.get_by_id(file.id)
-    assert updated_file.state == "cancelled"
-    assert updated_file.can_remove is True
-    assert updated_file.state_updated >= file.state_updated
+    # Verify the file is gone
+    with pytest.raises(ResourceNotFoundError):
+        await rig.file_dao.get_by_id(file.id)
 
 
 async def test_report_handling_duplicate(rig: JointRig):

--- a/services/fis/tests_fis/unit/test_core.py
+++ b/services/fis/tests_fis/unit/test_core.py
@@ -343,20 +343,35 @@ async def test_get_files_not_yet_interrogated(rig: JointRig):
     assert set(f.id for f in results_h2) == hub2_ids
 
 
-async def test_delete_file(rig: JointRig):
+@pytest.mark.parametrize("report_is_present", [True, False])
+async def test_delete_file(rig: JointRig, report_is_present: bool):
     """Test the `.delete_file()` method"""
     file = create_file_under_interrogation(HUB1)
 
     # Deleting a file that doesn't exist should not raise an error
     await rig.interrogation_handler.delete_file(file_id=file.id)
 
-    # Insert the file, then delete it
+    # Insert the file and an interrogation report, then delete
     await rig.file_dao.insert(file)
+
+    if report_is_present:
+        report = models.InterrogationReport(
+            file_id=file.id,
+            storage_alias=file.storage_alias,
+            interrogated_at=now_utc_ms_prec(),
+            passed=False,
+            reason="Checksum mismatch",
+        )
+        await rig.interrogation_report_dao.insert(report)
     await rig.interrogation_handler.delete_file(file_id=file.id)
 
-    # Verify the file is gone
+    # Verify both the file and its report (if present) are gone
     with pytest.raises(ResourceNotFoundError):
         await rig.file_dao.get_by_id(file.id)
+
+    if report_is_present:
+        with pytest.raises(ResourceNotFoundError):
+            await rig.interrogation_report_dao.get_by_id(file.id)
 
 
 async def test_report_handling_duplicate(rig: JointRig):


### PR DESCRIPTION
This PR is part of reconciliation with UCS. When a user creates a `FileUpload` for a given real file, then cancels it or it fails, then starts a _new_ `FileUpload` for that same real file (alias), UCS deletes the first one from the database in order to allow the second one to be created.

Before: FIS receives the `"deleted"`-type outbox event and marks its local copy of the `FileUpload` as `"cancelled"`. 

Now: FIS receives the `"deleted"`-type outbox event and _deletes_ its local copy of the `FileUpload`. It also deletes the associated `InterrogationReport`, if it exists.

Bumps FIS version to `11.3.0`.