### PR TITLE
UCS: Fix Manual File Deletion

### DIFF
--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -748,10 +748,13 @@ class UploadController(UploadControllerPort):
             log.info("File %s not found - presumed already deleted.", file_id)
             return
 
-        # Remove the file from S3 using slightly different approach based on if finished
-        if file_upload.inbox_upload_completed:
+        # Remove the file from S3 only if it's still in the inbox state. After that
+        #  point, the bucket ID and object ID will refer to another bucket for which UCS
+        #  has no write access.
+        if file_upload.state == "inbox":
             await self._remove_completed_file_upload(file_upload=file_upload)
-        else:
+        # Abort the upload if it still hasn't completed
+        elif file_upload.state == "init":
             await self._remove_incomplete_file_upload(file_upload=file_upload)
 
         # Update the file_upload to 'cancelled'

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -550,7 +550,49 @@ async def test_delete_file_upload_when_box_locked(rig: JointRig):
     assert len(file_upload_dao.resources) == 1
 
 
-async def test_delete_file_upload_when_upload_missing(rig: JointRig):
+@pytest.mark.parametrize(
+    "state",
+    ["interrogated", "awaiting_archival", "archived", "cancelled", "failed"],
+    ids=["interrogated", "awaiting_archival", "archived", "cancelled", "failed"],
+)
+async def test_remove_file_upload_skips_s3_for_terminal_states(
+    rig: JointRig,
+    monkeypatch: pytest.MonkeyPatch,
+    state: FileUploadState,
+):
+    """Test that remove_file_upload makes no S3 calls for FileUploads in states that
+    are past the multipart upload phase (interrogated, awaiting_archival, archived) or
+    already in a terminal state (cancelled, failed).
+    """
+    box_id = await rig.create_default_box()
+    file_upload = make_file_upload(state=state)
+    file_upload.box_id = box_id
+    await rig.file_upload_dao.insert(file_upload)
+
+    s3_calls: list[str] = []
+
+    async def spy_delete_inbox_file(**kwargs):
+        s3_calls.append("delete_inbox_file")
+
+    async def spy_abort_multipart_upload(**kwargs):
+        s3_calls.append("abort_multipart_upload")
+
+    monkeypatch.setattr(rig.s3_client, "delete_inbox_file", spy_delete_inbox_file)
+    monkeypatch.setattr(
+        rig.s3_client, "abort_multipart_upload", spy_abort_multipart_upload
+    )
+
+    # Call remove_file_upload() and verify that the S3Client's delete method wasn't called
+    await rig.controller.remove_file_upload(box_id=box_id, file_id=file_upload.id)
+
+    assert not s3_calls, (
+        f"Expected no S3 calls for state '{state}', but got: {s3_calls}"
+    )
+    updated_upload = await rig.file_upload_dao.get_by_id(file_upload.id)
+    assert updated_upload.state == "cancelled"
+
+
+async def test_remove_file_upload_when_upload_missing(rig: JointRig):
     """Test error handling in the case where the user tries to delete a FileUpload
     that doesn't exist.
     """

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -202,6 +202,10 @@ async def test_delete_file_upload(rig: JointRig, complete_before_delete: bool):
     )
     object_id = str(rig.file_upload_dao.latest.object_id)
 
+    assert await object_storage.list_multipart_uploads_for_object(
+        bucket_id=bucket_id, object_id=object_id
+    )
+
     if complete_before_delete:
         await controller.complete_file_upload(
             box_id=box_id,
@@ -220,6 +224,10 @@ async def test_delete_file_upload(rig: JointRig, complete_before_delete: bool):
     # Now delete the file upload
     await controller.remove_file_upload(box_id=box_id, file_id=file_id)
     assert not await object_storage.does_object_exist(
+        bucket_id=bucket_id, object_id=object_id
+    )
+
+    assert not await object_storage.list_multipart_uploads_for_object(
         bucket_id=bucket_id, object_id=object_id
     )
 

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -560,8 +560,15 @@ async def test_delete_file_upload_when_box_locked(rig: JointRig):
 
 @pytest.mark.parametrize(
     "state",
-    ["interrogated", "awaiting_archival", "archived", "cancelled", "failed"],
-    ids=["interrogated", "awaiting_archival", "archived", "cancelled", "failed"],
+    [
+        "interrogated",
+        "awaiting_archival",
+        "archived",
+        "cancelled",
+        "failed",
+        "inbox",
+        "init",
+    ],
 )
 async def test_remove_file_upload_skips_s3_for_terminal_states(
     rig: JointRig,
@@ -571,6 +578,8 @@ async def test_remove_file_upload_skips_s3_for_terminal_states(
     """Test that remove_file_upload makes no S3 calls for FileUploads in states that
     are past the multipart upload phase (interrogated, awaiting_archival, archived) or
     already in a terminal state (cancelled, failed).
+
+    Also checks correct calls for inbox and init states for completeness.
     """
     box_id = await rig.create_default_box()
     file_upload = make_file_upload(state=state)
@@ -593,9 +602,14 @@ async def test_remove_file_upload_skips_s3_for_terminal_states(
     # Call remove_file_upload() and verify that the S3Client's delete method wasn't called
     await rig.controller.remove_file_upload(box_id=box_id, file_id=file_upload.id)
 
-    assert not s3_calls, (
-        f"Expected no S3 calls for state '{state}', but got: {s3_calls}"
-    )
+    if state in ["inbox", "init"]:
+        assert s3_calls == (
+            ["delete_inbox_file"] if state == "inbox" else ["abort_multipart_upload"]
+        )
+    else:
+        assert not s3_calls, (
+            f"Expected no S3 calls for state '{state}', but got: {s3_calls}"
+        )
     updated_upload = await rig.file_upload_dao.get_by_id(file_upload.id)
     assert updated_upload.state == "cancelled"
 


### PR DESCRIPTION
This PR fixes a bug with UCS's DELETE File Upload endpoint. Before, UCS would try to delete the S3 object if the state was anything other than `init`. The problem is that once the FileUpload moves to `interrogated`, the bucket ID and object ID on the FileUpload refer to a bucket and object that UCS has no power over. 
The fix makes it so that UCS only attempts the S3 object deletion if the state is `inbox`. Similarly, it only attempts the abortion of the unfinished upload if the state is `init`. 

Version has not been bumped because the current version, 12.2.1, still hasn't been released.