### PR TITLE
UCS: Unknown FileUpload Deletion Returns 404 (GSI-2407)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.3.0"
+version = "14.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "13.3.0"
+version = "14.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:12.2.1
+docker pull ghga/upload-controller-service:13.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:12.2.1 .
+docker build -t ghga/upload-controller-service:13.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:12.2.1 --help
+docker run -p 8080:8080 ghga/upload-controller-service:13.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -730,7 +730,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 12.2.1
+  version: 13.0.0
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -992,6 +992,8 @@ paths:
 
         Deletes the FileUpload and tells S3 to cancel the multipart upload if applicable.
 
+        Returns 404 if the FileUpload or box does not exist.
+
         Requires a DeleteFileWorkOrder token from the WPS.'
       operationId: removeFileUpload
       parameters:
@@ -1024,10 +1026,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpBoxNotFoundError'
+                $ref: '#/components/schemas/HttpFileUploadNotFoundError'
           description: 'Exceptions by ID:
 
-            - boxNotFound: The FileUploadBox with the given ID does not exist.'
+            - fileUploadNotFound: The FileUpload could not be found.'
         '409':
           content:
             application/json:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "12.2.1"
+version = "13.0.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -548,7 +548,8 @@ async def complete_file_upload(
     response_description="FileUpload removed successfully",
     responses={
         status.HTTP_400_BAD_REQUEST: ERROR_RESPONSES["noSuchStorage"],
-        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
+        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"]
+        | ERROR_RESPONSES["fileUploadNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES["uploadAbortError"],
     },
@@ -566,6 +567,7 @@ async def remove_file_upload(
     """Remove a FileUpload from the FileUploadBox.
 
     Deletes the FileUpload and tells S3 to cancel the multipart upload if applicable.
+    Returns 404 if the FileUpload or box does not exist.
     Requires a DeleteFileWorkOrder token from the WPS.
     """
     if work_order.box_id != box_id or work_order.file_id != file_id:
@@ -579,6 +581,8 @@ async def remove_file_upload(
         raise http_exceptions.HttpBoxStateError(
             box_id=box_id, box_state=error.box_state
         ) from error
+    except UploadControllerPort.FileUploadNotFound as error:
+        raise http_exceptions.HttpFileUploadNotFoundError(file_id=file_id) from error
     except UploadControllerPort.UnknownStorageAliasError as error:
         raise http_exceptions.HttpUnknownStorageAliasError() from error
     except UploadControllerPort.UploadAbortError as error:

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -744,9 +744,10 @@ class UploadController(UploadControllerPort):
         # Retrieve the FileUpload data
         try:
             file_upload = await self._file_upload_dao.get_by_id(file_id)
-        except ResourceNotFoundError:
-            log.info("File %s not found - presumed already deleted.", file_id)
-            return
+        except ResourceNotFoundError as err:
+            error = self.FileUploadNotFound(file_id=file_id)
+            log.error(error)
+            raise error from err
 
         # Remove the file from S3 only if it's still in the inbox state. After that
         #  point, the bucket ID and object ID will refer to another bucket for which UCS

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -338,6 +338,7 @@ class UploadControllerPort(ABC):
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.
+        - `FileUploadNotFound` if the FileUpload does not exist.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
         - `BucketMissingError` if the configured bucket does not exist in S3.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -775,6 +775,10 @@ async def test_complete_file_upload_endpoint_error_translation(
             http_exceptions.HttpUnknownStorageAliasError(),
         ),
         (
+            UploadControllerPort.FileUploadNotFound(file_id=TEST_FILE_ID),
+            http_exceptions.HttpFileUploadNotFoundError(file_id=TEST_FILE_ID),
+        ),
+        (
             UploadControllerPort.UploadAbortError(
                 file_id=TEST_FILE_ID,
                 s3_upload_id="test-upload",
@@ -788,6 +792,7 @@ async def test_complete_file_upload_endpoint_error_translation(
         "BoxNotFound",
         "LockedBox",
         "UnknownStorageAlias",
+        "FileUploadNotFound",
         "UploadAbortError",
         "InternalError",
     ],

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -660,8 +660,9 @@ async def test_remove_file_upload_when_upload_missing(rig: JointRig):
     # Create a FileUploadBox
     box_id = await rig.create_default_box()
 
-    # Try to delete a FileUpload that doesn't exist - this should NOT raise an error
-    await rig.controller.remove_file_upload(box_id=box_id, file_id=uuid4())
+    # Try to delete a FileUpload that doesn't exist - should raise FileUploadNotFound
+    with pytest.raises(UploadControllerPort.FileUploadNotFound):
+        await rig.controller.remove_file_upload(box_id=box_id, file_id=uuid4())
 
 
 async def test_delete_file_upload_with_s3_error(rig: JointRig):


### PR DESCRIPTION
Returns 404 from UCS when a client requests deletion for a FileUpload that doesn't exist.

Bumps the monorepo & UCS major versions to `14.0.0` and `13.0.0`, respectively.