### PR TITLE
UCS: Enhance box locking (GSI-2417)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "14.0.0"
+version = "15.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "14.0.0"
+version = "15.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:13.0.0
+docker pull ghga/upload-controller-service:14.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:13.0.0 .
+docker build -t ghga/upload-controller-service:14.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:13.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:14.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -452,43 +452,47 @@ components:
       - file_id
       title: HttpFileUploadStateErrorData
       type: object
-    HttpMaxSizeTooLowError:
+    HttpIncompleteUploadsError:
       additionalProperties: false
       properties:
         data:
-          $ref: '#/components/schemas/HttpMaxSizeTooLowErrorData'
+          $ref: '#/components/schemas/HttpIncompleteUploadsErrorData'
         description:
           description: A human readable message to the client explaining the cause
             of the exception.
           title: Description
           type: string
         exception_id:
-          const: boxMaxSizeTooLow
+          const: incompleteUploads
           title: Exception Id
           type: string
       required:
       - data
       - description
       - exception_id
-      title: HttpMaxSizeTooLowError
+      title: HttpIncompleteUploadsError
       type: object
-    HttpMaxSizeTooLowErrorData:
+    HttpIncompleteUploadsErrorData:
       properties:
         box_id:
           format: uuid4
           title: Box Id
           type: string
-        current_size:
-          title: Current Size
-          type: integer
-        max_size:
-          title: Max Size
-          type: integer
+        file_ids:
+          items:
+            maxItems: 2
+            minItems: 2
+            prefixItems:
+            - format: uuid4
+              type: string
+            - type: string
+            type: array
+          title: File Ids
+          type: array
       required:
       - box_id
-      - max_size
-      - current_size
-      title: HttpMaxSizeTooLowErrorData
+      - file_ids
+      title: HttpIncompleteUploadsErrorData
       type: object
     HttpOrphanedMultipartUploadError:
       additionalProperties: false
@@ -760,7 +764,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 13.0.0
+  version: 14.0.0
 openapi: 3.1.0
 paths:
   /boxes:
@@ -859,11 +863,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpMaxSizeTooLowError'
+                $ref: '#/components/schemas/HttpIncompleteUploadsError'
           description: 'Exceptions by ID:
 
-            - boxMaxSizeTooLow: The requested max_size is less than the box''s current
-            committed size.'
+            - incompleteUploads: The box has in-progress uploads that must be completed
+            or cancelled before it can be locked or archived.'
         '422':
           content:
             application/json:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -428,6 +428,36 @@ components:
       - file_id
       title: HttpFileUploadNotFoundErrorData
       type: object
+    HttpFileUploadStateError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpFileUploadStateErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: fileUploadStateError
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpFileUploadStateError
+      type: object
+    HttpFileUploadStateErrorData:
+      properties:
+        file_id:
+          format: uuid4
+          title: File Id
+          type: string
+      required:
+      - file_id
+      title: HttpFileUploadStateErrorData
+      type: object
     HttpMaxSizeTooLowError:
       additionalProperties: false
       properties:
@@ -1127,10 +1157,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpBoxStateError'
+                $ref: '#/components/schemas/HttpFileUploadStateError'
           description: 'Exceptions by ID:
 
-            - boxStateError: The FileUploadBox''s state precludes the requested action.'
+            - fileUploadStateError: The action is incompatible with the FileUpload''s
+            current state.'
         '422':
           content:
             application/json:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -21,6 +21,12 @@ components:
     BoxUpdateRequest:
       description: Request body for updating a FileUploadBox.
       properties:
+        force:
+          default: false
+          description: Only applies when locking the box. If True, any uploads still
+            in the 'init' state will be aborted before locking proceeds.
+          title: Force
+          type: boolean
         max_size:
           anyOf:
           - exclusiveMinimum: 0.0
@@ -840,6 +846,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpUploadAbortError'
+          description: 'Exceptions by ID:
+
+            - uploadAbortError: There was an error aborting the s3 multipart upload.'
       security:
       - HTTPBearer: []
       summary: Update a FileUploadBox (lock/unlock/archive/resize)

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -125,12 +125,6 @@ components:
           format: uuid4
           title: Id
           type: string
-        inbox_upload_completed:
-          default: false
-          description: Indicates whether the file has been completely uploaded to
-            the inbox.
-          title: Inbox Upload Completed
-          type: boolean
         initiated:
           description: When the S3 multipart upload was initiated
           format: date-time

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "13.0.0"
+version = "14.0.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -382,6 +382,28 @@ class HttpPartSizeError(HttpCustomExceptionBase):
         )
 
 
+class HttpFileUploadStateError(HttpCustomExceptionBase):
+    """Thrown when an action is incompatible with the FileUpload's current state."""
+
+    exception_id = "fileUploadStateError"
+
+    class DataModel(BaseModel):
+        """Model for exception data"""
+
+        file_id: UUID4
+
+    def __init__(self, *, file_id: UUID4, status_code: int = 409):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=(
+                f"The requested action cannot be performed on FileUpload {file_id}"
+                " in its current state."
+            ),
+            data={"file_id": str(file_id)},
+        )
+
+
 class HttpNotAuthorizedError(HttpCustomExceptionBase):
     """Thrown when the user is not authorized to perform the requested action."""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -382,6 +382,38 @@ class HttpPartSizeError(HttpCustomExceptionBase):
         )
 
 
+class HttpIncompleteUploadsError(HttpCustomExceptionBase):
+    """Thrown when locking or archiving a box that still has in-progress uploads."""
+
+    exception_id = "incompleteUploads"
+
+    class DataModel(BaseModel):
+        """Model for exception data"""
+
+        box_id: UUID4
+        file_ids: list[tuple[UUID4, str]]
+
+    def __init__(
+        self,
+        *,
+        box_id: UUID4,
+        file_ids: list[tuple[UUID4, str]],
+        status_code: int = 409,
+    ):
+        """Construct message and init the exception."""
+        super().__init__(
+            status_code=status_code,
+            description=(
+                f"Cannot lock or archive box {box_id} because"
+                f" {len(file_ids)} incomplete upload(s) exist."
+            ),
+            data={
+                "box_id": str(box_id),
+                "file_ids": [[str(fid), alias] for fid, alias in file_ids],
+            },
+        )
+
+
 class HttpFileUploadStateError(HttpCustomExceptionBase):
     """Thrown when an action is incompatible with the FileUpload's current state."""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -48,6 +48,13 @@ class BoxUpdateRequest(BaseModel):
         ...,
         description="The expected current version of the box (for optimistic locking)",
     )
+    force: bool = Field(
+        default=False,
+        description=(
+            "Only applies when locking the box. If True, any uploads still in the"
+            " 'init' state will be aborted before locking proceeds."
+        ),
+    )
     model_config = ConfigDict(title="Box Update Request")
 
     @model_validator(mode="after")

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -163,6 +163,14 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpFileUploadStateError.get_body_model(),
     },
+    "incompleteUploads": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- incompleteUploads: The box has in-progress uploads that must"
+            + " be completed or cancelled before it can be locked or archived."
+        ),
+        "model": http_exceptions.HttpIncompleteUploadsError.get_body_model(),
+    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -229,7 +237,8 @@ async def create_box(
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxVersionOutdated"]
-        | ERROR_RESPONSES["boxMaxSizeTooLow"],
+        | ERROR_RESPONSES["boxMaxSizeTooLow"]
+        | ERROR_RESPONSES["incompleteUploads"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES["uploadAbortError"],
     },
 )
@@ -290,6 +299,10 @@ async def update_box(  # noqa: C901, PLR0912
     except UploadControllerPort.BoxMaxSizeTooLowError as error:
         raise http_exceptions.HttpMaxSizeTooLowError(
             box_id=box_id, max_size=error.max_size, current_size=error.current_size
+        ) from error
+    except UploadControllerPort.IncompleteUploadsError as error:
+        raise http_exceptions.HttpIncompleteUploadsError(
+            box_id=error.box_id, file_ids=error.file_ids
         ) from error
     except UploadControllerPort.UploadAbortError as error:
         raise http_exceptions.HttpUploadAbortError() from error

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -155,6 +155,14 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpPartSizeError.get_body_model(),
     },
+    "fileUploadStateError": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- fileUploadStateError: The action is incompatible with the"
+            + " FileUpload's current state."
+        ),
+        "model": http_exceptions.HttpFileUploadStateError.get_body_model(),
+    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -489,7 +497,8 @@ async def get_part_upload_url(  # noqa: PLR0913
         | ERROR_RESPONSES["uploadSizeMismatch"],
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"]
         | ERROR_RESPONSES["fileUploadNotFound"],
-        status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"],
+        status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"]
+        | ERROR_RESPONSES["fileUploadStateError"],
         status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES[
             "s3UploadCompletionFailure"
         ],
@@ -532,6 +541,8 @@ async def complete_file_upload(
         ) from error
     except UploadControllerPort.FileUploadNotFound as error:
         raise http_exceptions.HttpFileUploadNotFoundError(file_id=file_id) from error
+    except UploadControllerPort.FileUploadStateError as error:
+        raise http_exceptions.HttpFileUploadStateError(file_id=file_id) from error
     except UploadControllerPort.UploadCompletionError as error:
         raise http_exceptions.HttpUploadCompletionError(
             box_id=box_id, file_id=file_id

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -222,6 +222,7 @@ async def create_box(
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
         status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxVersionOutdated"]
         | ERROR_RESPONSES["boxMaxSizeTooLow"],
+        status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES["uploadAbortError"],
     },
 )
 @TRACER.start_as_current_span("routes.update_box")
@@ -262,7 +263,9 @@ async def update_box(  # noqa: C901, PLR0912
             match box_update.state:
                 case "locked":
                     await upload_controller.lock_file_upload_box(
-                        box_id=box_id, version=box_update.version
+                        box_id=box_id,
+                        version=box_update.version,
+                        force=box_update.force,
                     )
                 case "open":
                     await upload_controller.unlock_file_upload_box(
@@ -280,6 +283,8 @@ async def update_box(  # noqa: C901, PLR0912
         raise http_exceptions.HttpMaxSizeTooLowError(
             box_id=box_id, max_size=error.max_size, current_size=error.current_size
         ) from error
+    except UploadControllerPort.UploadAbortError as error:
+        raise http_exceptions.HttpUploadAbortError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -857,29 +857,53 @@ class UploadController(UploadControllerPort):
         await self._file_upload_box_dao.update(box)
         log.info("Updated max_size for box %s to %s.", box_id, max_size)
 
-    async def lock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
+    async def lock_file_upload_box(
+        self, *, box_id: UUID4, version: int, force: bool = False
+    ) -> None:
         """Lock an existing FileUploadBox.
 
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         - `BoxVersionError` if the supplied version doesn't match the current version.
-        - `IncompleteUploadsError` if the FileUploadBox has incomplete FileUploads.
+        - `IncompleteUploadsError` if force is False and the box has incomplete FileUploads.
+        - `UploadAbortError` if force is True and aborting an in-progress upload fails.
         """
         box = await self._get_box_at_version(box_id=box_id, version=version)
 
         if box.state != "open":
             # This goes for archived boxes too
-            log.info("Box with ID %s already locked.", box_id)
+            log.info("Box with ID %s is already locked.", box_id)
             return
 
-        incomplete_files_cursor = self._file_upload_dao.find_all(
-            mapping={"box_id": box_id, "inbox_upload_completed": False}
-        )
-        file_ids = sorted([x.id async for x in incomplete_files_cursor])
-        if file_ids:
-            error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
-            log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
-            raise error
+        if force:
+            init_uploads = [
+                upload
+                async for upload in self._file_upload_dao.find_all(
+                    mapping={"box_id": box_id, "state": "init"}
+                )
+            ]
+            for upload in init_uploads:
+                await self._remove_incomplete_file_upload(file_upload=upload)
+                upload.state = "cancelled"
+                upload.state_updated = now_utc_ms_prec()
+                await self._file_upload_dao.update(upload)
+                with contextlib.suppress(ResourceNotFoundError):
+                    await self._upload_activity_dao.delete(upload.id)
+            if init_uploads:
+                log.info(
+                    "Aborted %d in-progress upload(s) in box %s for forced lock.",
+                    len(init_uploads),
+                    box_id,
+                )
+        else:
+            incomplete_files_cursor = self._file_upload_dao.find_all(
+                mapping={"box_id": box_id, "state": "init"}
+            )
+            file_ids = sorted([x.id async for x in incomplete_files_cursor])
+            if file_ids:
+                error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
+                log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
+                raise error
 
         box.version += 1
         box.state = "locked"

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -675,11 +675,6 @@ class UploadController(UploadControllerPort):
             log.error(error, extra=extra)
             raise error from err
 
-        # Exit early if the FileUpload is complete (already in the inbox or archived)
-        if file_upload.inbox_upload_completed:
-            log.info("FileUpload with ID %s already complete.", file_id)
-            return
-
         if file_upload.state in ("cancelled", "failed"):
             error = self.FileUploadStateError(
                 file_id=file_id,
@@ -687,6 +682,11 @@ class UploadController(UploadControllerPort):
             )
             log.error(error, extra=extra)
             raise error
+
+        # Exit early if the FileUpload is complete (already in the inbox or archived)
+        if file_upload.state != "init":
+            log.info("FileUpload with ID %s already complete.", file_id)
+            return
 
         try:
             await self._s3_client.complete_multipart_upload(file_upload=file_upload)

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -719,7 +719,6 @@ class UploadController(UploadControllerPort):
         file_upload.decrypted_sha256 = unencrypted_checksum
         file_upload.encrypted_parts_md5 = encrypted_parts_md5
         file_upload.encrypted_parts_sha256 = encrypted_parts_sha256
-        file_upload.inbox_upload_completed = True
         file_upload.state_updated = now_utc_ms_prec()
         file_upload.completed = now_utc_ms_prec()
         await self._file_upload_dao.update(file_upload)

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -882,32 +882,30 @@ class UploadController(UploadControllerPort):
             log.info("Box with ID %s is already locked.", box_id)
             return
 
+        incomplete_files = [
+            upload
+            async for upload in self._file_upload_dao.find_all(
+                mapping={"box_id": box_id, "state": "init"}
+            )
+        ]
+
         if force:
-            init_uploads = [
-                upload
-                async for upload in self._file_upload_dao.find_all(
-                    mapping={"box_id": box_id, "state": "init"}
-                )
-            ]
-            for upload in init_uploads:
+            for upload in incomplete_files:
                 await self._remove_incomplete_file_upload(file_upload=upload)
                 upload.state = "cancelled"
                 upload.state_updated = now_utc_ms_prec()
                 await self._file_upload_dao.update(upload)
                 with contextlib.suppress(ResourceNotFoundError):
                     await self._upload_activity_dao.delete(upload.id)
-            if init_uploads:
+            if incomplete_files:
                 log.info(
                     "Aborted %d in-progress upload(s) in box %s for forced lock.",
-                    len(init_uploads),
+                    len(incomplete_files),
                     box_id,
                 )
         else:
-            incomplete_files_cursor = self._file_upload_dao.find_all(
-                mapping={"box_id": box_id, "state": "init"}
-            )
             file_ids = sorted(
-                [(x.id, x.alias) async for x in incomplete_files_cursor],
+                [(x.id, x.alias) for x in incomplete_files],
                 key=lambda entry: entry[1],
             )
             if file_ids:

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -906,7 +906,10 @@ class UploadController(UploadControllerPort):
             incomplete_files_cursor = self._file_upload_dao.find_all(
                 mapping={"box_id": box_id, "state": "init"}
             )
-            file_ids = sorted([x.id async for x in incomplete_files_cursor])
+            file_ids = sorted(
+                [(x.id, x.alias) async for x in incomplete_files_cursor],
+                key=lambda entry: entry[1],
+            )
             if file_ids:
                 error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
                 log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
@@ -962,7 +965,10 @@ class UploadController(UploadControllerPort):
         files_not_interrogated_cursor = self._file_upload_dao.find_all(
             mapping={"box_id": box_id, "state": {"$in": ["init", "inbox"]}}
         )
-        file_ids = sorted([x.id async for x in files_not_interrogated_cursor])
+        file_ids = sorted(
+            [(x.id, x.alias) async for x in files_not_interrogated_cursor],
+            key=lambda entry: entry[1],
+        )
         if file_ids:
             error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
             log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -680,6 +680,14 @@ class UploadController(UploadControllerPort):
             log.info("FileUpload with ID %s already complete.", file_id)
             return
 
+        if file_upload.state in ("cancelled", "failed"):
+            error = self.FileUploadStateError(
+                file_id=file_id,
+                details=f"Cannot complete a FileUpload in the '{file_upload.state}' state.",
+            )
+            log.error(error, extra=extra)
+            raise error
+
         try:
             await self._s3_client.complete_multipart_upload(file_upload=file_upload)
         except S3ClientPort.UnknownStorageAliasError as err:

--- a/services/ucs/src/ucs/core/models.py
+++ b/services/ucs/src/ucs/core/models.py
@@ -71,10 +71,6 @@ class FileUpload(event_schemas.FileUpload):
     """
 
     # Note: The following are UCS-only fields
-    inbox_upload_completed: bool = Field(
-        default=False,
-        description="Indicates whether the file has been completely uploaded to the inbox.",
-    )
     s3_upload_id: str = Field(
         default=..., description="The ID of the S3 multipart upload"
     )

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -377,13 +377,16 @@ class UploadControllerPort(ABC):
         ...
 
     @abstractmethod
-    async def lock_file_upload_box(self, *, box_id: UUID4, version: int) -> None:
+    async def lock_file_upload_box(
+        self, *, box_id: UUID4, version: int, force: bool = False
+    ) -> None:
         """Lock an existing FileUploadBox.
 
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         - `BoxVersionError` if the supplied version doesn't match the current version.
-        - `IncompleteUploadsError` if the FileUploadBox has incomplete FileUploads.
+        - `IncompleteUploadsError` if force is False and the box has incomplete FileUploads.
+        - `UploadAbortError` if force is True and aborting an in-progress upload fails.
         """
         ...
 

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -39,7 +39,9 @@ class UploadControllerPort(ABC):
         at least one incomplete FileUpload exists.
         """
 
-        def __init__(self, *, box_id: UUID4, file_ids: list[UUID4]):
+        def __init__(self, *, box_id: UUID4, file_ids: list[tuple[UUID4, str]]):
+            self.box_id = box_id
+            self.file_ids = file_ids
             msg = (
                 f"Cannot lock or archive box {box_id} because these"
                 + f" files are incomplete: {file_ids}"

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -318,6 +318,7 @@ class UploadControllerPort(ABC):
 
         Raises:
         - `FileUploadNotFound` if the FileUpload isn't found.
+        - `FileUploadStateError` if the FileUpload is in a cancelled or failed state.
         - `BoxNotFoundError` if the FileUploadBox isn't found.
         - `BoxStateError` if the box exists but is locked.
         - `BoxVersionError` if the box version changed before stats could be updated.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -420,9 +420,17 @@ async def test_create_box_endpoint_error_handling(
             UploadControllerPort.BoxVersionError(box_id=TEST_BOX_ID),
             http_exceptions.HttpBoxVersionError(box_id=TEST_BOX_ID),
         ),
+        (
+            UploadControllerPort.IncompleteUploadsError(
+                box_id=TEST_BOX_ID, file_ids=[(TEST_FILE_ID, "test_file")]
+            ),
+            http_exceptions.HttpIncompleteUploadsError(
+                box_id=TEST_BOX_ID, file_ids=[(TEST_FILE_ID, "test_file")]
+            ),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
-    ids=["BoxNotFound", "BoxVersionOutdated", "InternalError"],
+    ids=["BoxNotFound", "BoxVersionOutdated", "IncompleteUploads", "InternalError"],
 )
 async def test_update_box_endpoint_error_handling(
     config: ConfigFixture,

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -720,6 +720,12 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
             UploadControllerPort.UploadSizeMismatchError(file_id=TEST_FILE_ID),
             http_exceptions.HttpUploadSizeMismatchError(file_id=TEST_FILE_ID),
         ),
+        (
+            UploadControllerPort.FileUploadStateError(
+                file_id=TEST_FILE_ID, details="cancelled"
+            ),
+            http_exceptions.HttpFileUploadStateError(file_id=TEST_FILE_ID),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
     ids=[
@@ -728,6 +734,7 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
         "FileUploadNotFound",
         "UploadCompletionError",
         "UploadSizeMismatchError",
+        "FileUploadStateError",
         "InternalError",
     ],
 )

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -752,17 +752,15 @@ async def test_lock_box_with_incomplete_upload(rig: JointRig):
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
     )
-    file_ids = sorted([file_id1, file_id2])
-
     # Attempt to lock the box while the upload is still incomplete
     with pytest.raises(UploadControllerPort.IncompleteUploadsError) as exc_info:
         await controller.lock_file_upload_box(box_id=box_id, version=0)
 
-    # Verify the exception is correct
-    assert (
-        str(exc_info.value)
-        == f"Cannot lock or archive box {box_id} because these files are incomplete: {file_ids}"
-    )
+    # Verify the exception carries the right IDs and aliases (sorted by alias)
+    assert exc_info.value.file_ids == [
+        (file_id1, "test_file"),
+        (file_id2, "test_file2"),
+    ]
 
     # Verify that the box is still open
     assert file_upload_box_dao.latest.state == "open"

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -148,7 +148,6 @@ async def test_complete_file_upload(rig: JointRig):
     assert file_upload_dao.latest.id == file_id
     assert file_upload_dao.latest.completed is not None
     assert completed - file_upload_dao.latest.completed < timedelta(seconds=5)
-    assert file_upload_dao.latest.inbox_upload_completed
     file_upload_box_dao = rig.file_upload_box_dao
     assert file_upload_box_dao.latest.size == DECRYPTED_SIZE
     assert file_upload_box_dao.latest.file_count == 1
@@ -826,7 +825,6 @@ async def test_complete_file_upload_when_box_missing(rig: JointRig):
 
     # Verify the exception contains the correct box_id
     assert str(box_id) in str(exc_info.value)
-    assert not file_upload_dao.latest.inbox_upload_completed
 
 
 @pytest.mark.parametrize("terminal_state", ["cancelled", "failed"])
@@ -919,7 +917,6 @@ async def test_complete_file_upload_with_unknown_storage_alias(rig: JointRig):
 
     # Verify the exception message contains the unknown storage alias
     assert "does_not_exist" in str(exc_info.value)
-    assert not file_upload_dao.latest.inbox_upload_completed
     assert rig.file_upload_box_dao.latest.size == 0
     assert rig.file_upload_box_dao.latest.file_count == 0
 
@@ -964,7 +961,6 @@ async def test_complete_file_upload_with_s3_error(rig: JointRig):
     # Verify the exception contains the S3 upload ID
     s3_upload_id = file_upload_dao.latest.s3_upload_id
     assert s3_upload_id in str(exc_info.value)
-    assert not rig.file_upload_dao.latest.inbox_upload_completed
     assert not file_upload_dao.latest.completed
     assert file_upload_box_dao.latest.size == 0
     assert file_upload_box_dao.latest.file_count == 0
@@ -1014,7 +1010,6 @@ async def test_complete_file_upload_size_mismatch(rig: JointRig):
     file_upload = rig.file_upload_dao.latest
     assert file_upload.state == "failed"
     assert file_upload.state_updated > state_updated
-    assert not file_upload.inbox_upload_completed
     assert not file_upload.completed
     assert rig.file_upload_box_dao.latest.size == 0
     assert rig.file_upload_box_dao.latest.file_count == 0
@@ -1057,7 +1052,6 @@ async def test_complete_file_upload_checksum_mismatch(rig: JointRig):
     file_upload = rig.file_upload_dao.latest
     assert file_upload.state == "failed"
     assert file_upload.state_updated > state_updated
-    assert not file_upload.inbox_upload_completed
     assert not file_upload.completed
     assert file_upload_box_dao.latest.size == 0
     assert file_upload_box_dao.latest.file_count == 0

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -769,6 +769,25 @@ async def test_lock_box_with_incomplete_upload(rig: JointRig):
     assert file_upload_box_dao.latest.state == "open"
 
 
+@pytest.mark.parametrize("terminal_state", ["failed", "cancelled"])
+async def test_lock_box_ignores_terminal_uploads(
+    rig: JointRig, terminal_state: FileUploadState
+):
+    """Locking with force=False must succeed when the only incomplete uploads
+    (inbox_upload_completed=False) are in a terminal state (failed/cancelled).
+    Those uploads are no longer active. The only state that should block locking
+    is 'init'.
+    """
+    box_id = await rig.create_default_box()
+
+    file_upload = make_file_upload(state=terminal_state)
+    file_upload.box_id = box_id
+    await rig.file_upload_dao.insert(file_upload)
+
+    await rig.controller.lock_file_upload_box(box_id=box_id, version=0)
+    assert rig.file_upload_box_dao.latest.state == "locked"
+
+
 async def test_complete_file_upload_when_box_missing(rig: JointRig):
     """Test error handling in the case where the user tries to complete a FileUpload
     for a box ID that doesn't exist.
@@ -808,6 +827,32 @@ async def test_complete_file_upload_when_box_missing(rig: JointRig):
     # Verify the exception contains the correct box_id
     assert str(box_id) in str(exc_info.value)
     assert not file_upload_dao.latest.inbox_upload_completed
+
+
+@pytest.mark.parametrize("terminal_state", ["cancelled", "failed"])
+async def test_complete_file_upload_in_terminal_state(
+    rig: JointRig, terminal_state: FileUploadState
+):
+    """Completing a cancelled or failed FileUpload must raise FileUploadStateError
+    rather than attempting the S3 operation on an already-aborted or invalid upload.
+    """
+    box_id = await rig.create_default_box()
+    file_upload = make_file_upload(state=terminal_state)
+    file_upload.box_id = box_id
+    await rig.file_upload_dao.insert(file_upload)
+
+    with pytest.raises(UploadControllerPort.FileUploadStateError) as exc_info:
+        await rig.controller.complete_file_upload(
+            box_id=box_id,
+            file_id=file_upload.id,
+            unencrypted_checksum="sha256:checksum",
+            encrypted_checksum="md5:checksum",
+            encrypted_parts_md5=["abc123"],
+            encrypted_parts_sha256=["def456"],
+        )
+
+    assert str(file_upload.id) in str(exc_info.value)
+    assert terminal_state in str(exc_info.value)
 
 
 async def test_complete_missing_file_upload(rig: JointRig):


### PR DESCRIPTION
Returns a dedicated 409 error with detail when locking the box if there are unfinished uploads.  
This can be overridden by specifying `force: True` in the request, which will **abort** any unfinished uploads and lock the box.

Fixes a couple bugs related to cancelled/failed files too.

Bumps the versions of UCS and the monorepo to `14.0.0` and `15.0.0`, respectively.