### PR TITLE
UCS: Delete boxes (GSI-2409)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.0"
+version = "15.1.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.0"
+version = "15.1.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:14.0.0
+docker pull ghga/upload-controller-service:14.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:14.0.0 .
+docker build -t ghga/upload-controller-service:14.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:14.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:14.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -392,6 +392,36 @@ components:
       - box_state
       title: HttpBoxStateErrorData
       type: object
+    HttpBoxVersionError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpBoxVersionErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: boxVersionOutdated
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpBoxVersionError
+      type: object
+    HttpBoxVersionErrorData:
+      properties:
+        box_id:
+          format: uuid4
+          title: Box Id
+          type: string
+      required:
+      - box_id
+      title: HttpBoxVersionErrorData
+      type: object
     HttpFileUploadNotFoundError:
       additionalProperties: false
       properties:
@@ -815,6 +845,78 @@ paths:
       tags:
       - UploadControllerService
   /boxes/{box_id}:
+    delete:
+      description: 'Remove a FileUploadBox and all its associated FileUploads.
+
+
+        Cancels any in-progress S3 uploads, removes inbox objects from S3, then deletes
+
+        the box and all its FileUploads from the database. Deletion is blocked if
+        the box
+
+        is archived, or if a `version` query parameter is supplied and doesn''t match
+        the
+
+        current box version. Requires a DeleteFileBoxWorkOrder token from the RS.'
+      operationId: removeFileUploadBox
+      parameters:
+      - in: path
+        name: box_id
+        required: true
+        schema:
+          format: uuid4
+          title: Box Id
+          type: string
+      - description: The expected current version of the box (optional optimistic
+          locking). If provided and outdated, the deletion is rejected.
+        in: query
+        name: version
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          description: The expected current version of the box (optional optimistic
+            locking). If provided and outdated, the deletion is rejected.
+          title: Version
+      responses:
+        '204':
+          description: FileUploadBox and all associated uploads removed successfully
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpBoxNotFoundError'
+          description: 'Exceptions by ID:
+
+            - boxNotFound: The FileUploadBox with the given ID does not exist.'
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpBoxVersionError'
+          description: 'Exceptions by ID:
+
+            - boxVersionOutdated: The requested FileUploadBox version is outdated.'
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpUploadAbortError'
+          description: 'Exceptions by ID:
+
+            - uploadAbortError: There was an error aborting the s3 multipart upload.'
+      security:
+      - HTTPBearer: []
+      summary: Remove a FileUploadBox and all its associated uploads
+      tags:
+      - UploadControllerService
     patch:
       description: 'Update a FileUploadBox state or max_size.
 

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -794,7 +794,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 14.0.0
+  version: 14.1.0
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "14.0.0"
+version = "14.1.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_authorization.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_authorization.py
@@ -83,7 +83,7 @@ class JWTAuthContextProviderBundle:
         # File deletion is requested by the WPS (user-driven cancellation via the
         #  connector) and by the RS (manual deletion by a Data Steward or user),
         #  each signing with its own key, so both providers are needed.
-        self.delete_file_provider = JWTAuthContextProvider(
+        self.delete_file_wps_provider = JWTAuthContextProvider(
             config=self.wps_auth_config,
             context_class=models.DeleteFileWorkOrder,
         )
@@ -190,7 +190,7 @@ async def _require_delete_file_work_order(
     try:
         return await require_auth_context_using_credentials(
             credentials=credentials,
-            auth_provider=auth_provider_bundle.delete_file_provider,
+            auth_provider=auth_provider_bundle.delete_file_wps_provider,
         )
     except HTTPException as wps_error:
         if wps_error.status_code != 401 or not (

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_authorization.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_authorization.py
@@ -17,7 +17,7 @@
 
 from typing import Annotated
 
-from fastapi import Depends, Security
+from fastapi import Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from ghga_service_commons.auth.jwt_auth import JWTAuthContextProvider
 from ghga_service_commons.auth.policies import require_auth_context_using_credentials
@@ -31,6 +31,7 @@ __all__ = [
     "require_change_file_box_work_order",
     "require_create_file_box_work_order",
     "require_create_file_work_order",
+    "require_delete_file_box_work_order",
     "require_upload_file_work_order",
     "require_view_file_box_work_order",
 ]
@@ -40,6 +41,7 @@ ChangeFileBoxProvider = JWTAuthContextProvider[models.ChangeFileBoxWorkOrder]
 ViewFileBoxProvider = JWTAuthContextProvider[models.ViewFileBoxWorkOrder]
 CreateFileProvider = JWTAuthContextProvider[models.CreateFileWorkOrder]
 UploadFileProvider = JWTAuthContextProvider[models.UploadFileWorkOrder]
+DeleteFileBoxProvider = JWTAuthContextProvider[models.DeleteFileBoxWorkOrder]
 
 
 class JWTAuthContextProviderBundle:
@@ -78,9 +80,20 @@ class JWTAuthContextProviderBundle:
             config=self.wps_auth_config,
             context_class=models.CloseFileWorkOrder,
         )
+        # File deletion is requested by the WPS (user-driven cancellation via the
+        #  connector) and by the RS (manual deletion by a Data Steward or user),
+        #  each signing with its own key, so both providers are needed.
         self.delete_file_provider = JWTAuthContextProvider(
             config=self.wps_auth_config,
             context_class=models.DeleteFileWorkOrder,
+        )
+        self.delete_file_rs_provider = JWTAuthContextProvider(
+            config=self.rs_auth_config,
+            context_class=models.DeleteFileWorkOrder,
+        )
+        self.delete_file_box_provider = JWTAuthContextProvider(
+            config=self.rs_auth_config,
+            context_class=models.DeleteFileBoxWorkOrder,
         )
 
 
@@ -170,8 +183,34 @@ async def _require_delete_file_work_order(
     ],
     credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
 ) -> models.DeleteFileWorkOrder:
-    """Require a "delete file" work order context using FastAPI."""
-    provider = auth_provider_bundle.delete_file_provider
+    """Require a "delete file" work order context using FastAPI.
+
+    Tokens signed by either the WPS or the RS are accepted (see provider bundle).
+    """
+    try:
+        return await require_auth_context_using_credentials(
+            credentials=credentials,
+            auth_provider=auth_provider_bundle.delete_file_provider,
+        )
+    except HTTPException as wps_error:
+        if wps_error.status_code != 401 or not (
+            credentials and credentials.credentials
+        ):
+            raise
+        return await require_auth_context_using_credentials(
+            credentials=credentials,
+            auth_provider=auth_provider_bundle.delete_file_rs_provider,
+        )
+
+
+async def _require_delete_file_box_work_order(
+    auth_provider_bundle: Annotated[
+        JWTAuthContextProviderBundle, Depends(dummies.auth_provider_bundle)
+    ],
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+) -> models.DeleteFileBoxWorkOrder:
+    """Require a "delete file box" work order context using FastAPI."""
+    provider = auth_provider_bundle.delete_file_box_provider
     return await require_auth_context_using_credentials(
         credentials=credentials, auth_provider=provider
     )
@@ -184,3 +223,4 @@ require_create_file_work_order = Security(_require_create_file_work_order)
 require_upload_file_work_order = Security(_require_upload_file_work_order)
 require_close_file_work_order = Security(_require_close_file_work_order)
 require_delete_file_work_order = Security(_require_delete_file_work_order)
+require_delete_file_box_work_order = Security(_require_delete_file_box_work_order)

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -136,7 +136,16 @@ class FileUploadCompletionRequest(BaseModel):
 
 
 WorkType = Literal[
-    "create", "lock", "unlock", "archive", "resize", "view", "upload", "close", "delete"
+    "create",
+    "lock",
+    "unlock",
+    "archive",
+    "resize",
+    "view",
+    "upload",
+    "close",
+    "delete",
+    "delete_box",
 ]
 
 T = TypeVar("T", bound=WorkType)
@@ -193,3 +202,14 @@ class CloseFileWorkOrder(BaseWorkOrderToken[Literal["close"]], _FileUploadToken)
 
 class DeleteFileWorkOrder(BaseWorkOrderToken[Literal["delete"]], _FileUploadToken):
     """WOT schema authorizing a user to delete a file upload"""
+
+
+class DeleteFileBoxWorkOrder(BaseWorkOrderToken[Literal["delete_box"]]):
+    """WOT schema authorizing the RS to delete a FileUploadBox and all its files.
+
+    The work type is 'delete_box' rather than 'delete' so that a DeleteFileWorkOrder
+    (which shares the 'delete' work type and may be signed with the same RS key)
+    can never validate as a box-level deletion token.
+    """
+
+    box_id: UUID4

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -18,7 +18,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, status
+from fastapi import APIRouter, BackgroundTasks, Query, status
 from pydantic import UUID4
 
 from ucs.adapters.inbound.fastapi_ import (
@@ -614,6 +614,65 @@ async def remove_file_upload(
         raise http_exceptions.HttpFileUploadNotFoundError(file_id=file_id) from error
     except UploadControllerPort.UnknownStorageAliasError as error:
         raise http_exceptions.HttpUnknownStorageAliasError() from error
+    except UploadControllerPort.UploadAbortError as error:
+        raise http_exceptions.HttpUploadAbortError() from error
+    except Exception as error:
+        log.error(error, exc_info=True)
+        raise http_exceptions.HttpInternalError() from error
+
+
+@router.delete(
+    "/boxes/{box_id}",
+    summary="Remove a FileUploadBox and all its associated uploads",
+    operation_id="removeFileUploadBox",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_description="FileUploadBox and all associated uploads removed successfully",
+    responses={
+        status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
+        status.HTTP_409_CONFLICT: ERROR_RESPONSES["boxStateError"]
+        | ERROR_RESPONSES["boxVersionOutdated"],
+        status.HTTP_500_INTERNAL_SERVER_ERROR: ERROR_RESPONSES["uploadAbortError"],
+    },
+)
+@TRACER.start_as_current_span("routes.remove_file_upload_box")
+async def remove_file_upload_box(
+    box_id: UUID4,
+    work_order: Annotated[
+        rest_models.DeleteFileBoxWorkOrder,
+        http_authorization.require_delete_file_box_work_order,
+    ],
+    upload_controller: dummies.UploadControllerDummy,
+    version: Annotated[
+        int | None,
+        Query(
+            description="The expected current version of the box (optional optimistic"
+            + " locking). If provided and outdated, the deletion is rejected."
+        ),
+    ] = None,
+) -> None:
+    """Remove a FileUploadBox and all its associated FileUploads.
+
+    Cancels any in-progress S3 uploads, removes inbox objects from S3, then deletes
+    the box and all its FileUploads from the database. Deletion is blocked if the box
+    is archived, or if a `version` query parameter is supplied and doesn't match the
+    current box version. Requires a DeleteFileBoxWorkOrder token from the RS.
+    """
+    if work_order.box_id != box_id:
+        raise http_exceptions.HttpNotAuthorizedError()
+
+    try:
+        await upload_controller.remove_file_upload_box(box_id=box_id, version=version)
+    except UploadControllerPort.BoxNotFoundError as error:
+        raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error
+    except UploadControllerPort.BoxVersionError as error:
+        raise http_exceptions.HttpBoxVersionError(box_id=box_id) from error
+    except UploadControllerPort.BoxStateError as error:
+        raise http_exceptions.HttpBoxStateError(
+            box_id=box_id, box_state=error.box_state
+        ) from error
+    except UploadControllerPort.FileUploadStateError as error:
+        log.error(error, exc_info=True)
+        raise http_exceptions.HttpInternalError() from error
     except UploadControllerPort.UploadAbortError as error:
         raise http_exceptions.HttpUploadAbortError() from error
     except Exception as error:

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -823,25 +823,6 @@ class UploadController(UploadControllerPort):
             log.error(error)
             raise error
 
-        # Before deleting anything, make sure there aren't any FileUploads in an
-        #  unexpected state
-        async for file_upload in self._file_upload_dao.find_all(
-            mapping={
-                "box_id": box_id,
-                "state": {"$in": ["awaiting_archival", "archived"]},
-            }
-        ):
-            error = self.FileUploadStateError(
-                file_id=file_upload.id,
-                details=(
-                    f"FileUpload {file_upload.id} is in '{file_upload.state}' state,"
-                    + " which should only be reachable when the box is archived."
-                    + " This indicates a data inconsistency."
-                ),
-            )
-            log.error(error)
-            raise error
-
         # Lock the box so no new uploads can be initiated while sweeping
         if box.state == "open":
             box.version += 1
@@ -849,13 +830,44 @@ class UploadController(UploadControllerPort):
             await self._file_upload_box_dao.update(box)
             log.info("Locked FileUploadBox %s before deleting files.", box_id)
 
+        # Before deleting anything, make sure there aren't any FileUploads in an
+        #  unexpected state. Raising an error here leaves the box in the locked state,
+        #  which should be fine because it doesn't prevent a subsequent deletion attempt
+        files_with_wrong_state = [
+            x
+            async for x in self._file_upload_dao.find_all(
+                mapping={
+                    "box_id": box_id,
+                    "state": {"$in": ["awaiting_archival", "archived"]},
+                }
+            )
+        ]
+
+        if files_with_wrong_state:
+            first_bad_file = files_with_wrong_state[0]
+            error = self.FileUploadStateError(
+                file_id=first_bad_file.id,
+                details=(
+                    f"FileUpload {first_bad_file.id} is in the '{first_bad_file.state}',"
+                    + " state which should only be reachable when the box is archived."
+                    + " This indicates a data inconsistency."
+                ),
+            )
+            log.error(
+                error,
+                extra={
+                    "box_id": box_id,
+                    "files_with_wrong_state": [f.id for f in files_with_wrong_state],
+                },
+            )
+            raise error
+
         # Delete the FileUploads
-        log.debug("Deleting all FileUploads for FileUploadBox %s.", box_id)
         await self._delete_box_file_uploads(box_id=box_id)
 
         # Finally, delete the box itself
         await self._file_upload_box_dao.delete(box_id)
-        log.info("Box %s and all its FileUploads were deleted.", box_id)
+        log.info("Deleted FileUploadBox %s.", box_id)
 
     async def _delete_box_file_uploads(self, *, box_id: UUID4) -> None:
         """Hard-delete all FileUploads belonging to a box after S3 cleanup.
@@ -879,6 +891,7 @@ class UploadController(UploadControllerPort):
                 log.info("Deleted all FileUploads for FileUploadBox %s.", box_id)
                 break
 
+            log.debug("Deleting all FileUploads for FileUploadBox %s.", box_id)
             for file_upload in file_uploads:
                 if file_upload.state == "inbox":
                     await self._remove_completed_file_upload(file_upload=file_upload)

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -777,6 +777,118 @@ class UploadController(UploadControllerPort):
         await self._update_box_stats(box_id=box_id, version=box.version)
         log.info("File %s deleted from box %s", file_id, box_id)
 
+    async def remove_file_upload_box(
+        self, *, box_id: UUID4, version: int | None = None
+    ) -> None:
+        """Remove a FileUploadBox and delete all associated FileUploads.
+
+        If `version` is provided, it must match the box's current version.
+        The box is locked before its FileUploads are swept so no new uploads
+        can be initiated mid-deletion.
+
+        Files in 'init' state have their S3 multipart upload aborted.
+        Files in 'inbox' state have their S3 object deleted.
+        Files in other states require no S3 interaction.
+        Files in 'awaiting_archival' or 'archived' state cause a FileUploadStateError
+        (invariant violation: these states require the box to be archived).
+
+        All FileUpload documents belonging to the box are hard-deleted, emitting
+        'deleted' outbox events.
+
+        Raises:
+        - `BoxNotFoundError` if the box does not exist.
+        - `BoxVersionError` if a version is supplied and doesn't match the current one.
+        - `BoxStateError` if the box is archived.
+        - `FileUploadStateError` if any FileUpload is in 'awaiting_archival' or 'archived' state.
+        - `UnknownStorageAliasError` if the storage alias is not known.
+        - `UploadAbortError` if there's an error aborting an in-progress multipart upload.
+        """
+        # Get the box
+        try:
+            box = await self._file_upload_box_dao.get_by_id(box_id)
+        except ResourceNotFoundError as err:
+            error = self.BoxNotFoundError(box_id=box_id)
+            log.error(error)
+            raise error from err
+
+        # Verify the version
+        if version is not None and box.version != version:
+            error = self.BoxVersionError(box_id=box_id)
+            log.error(error, extra={"box_id": box_id, "version": version})
+            raise error
+
+        # Raise an error if the box is archived
+        if box.state == "archived":
+            error = self.BoxStateError(box_id=box_id, box_state=box.state)
+            log.error(error)
+            raise error
+
+        # Before deleting anything, make sure there aren't any FileUploads in an
+        #  unexpected state
+        async for file_upload in self._file_upload_dao.find_all(
+            mapping={
+                "box_id": box_id,
+                "state": {"$in": ["awaiting_archival", "archived"]},
+            }
+        ):
+            error = self.FileUploadStateError(
+                file_id=file_upload.id,
+                details=(
+                    f"FileUpload {file_upload.id} is in '{file_upload.state}' state,"
+                    + " which should only be reachable when the box is archived."
+                    + " This indicates a data inconsistency."
+                ),
+            )
+            log.error(error)
+            raise error
+
+        # Lock the box so no new uploads can be initiated while sweeping
+        if box.state == "open":
+            box.version += 1
+            box.state = "locked"
+            await self._file_upload_box_dao.update(box)
+            log.info("Locked FileUploadBox %s before deleting files.", box_id)
+
+        # Delete the FileUploads
+        log.debug("Deleting all FileUploads for FileUploadBox %s.", box_id)
+        await self._delete_box_file_uploads(box_id=box_id)
+
+        # Finally, delete the box itself
+        await self._file_upload_box_dao.delete(box_id)
+        log.info("Box %s and all its FileUploads were deleted.", box_id)
+
+    async def _delete_box_file_uploads(self, *, box_id: UUID4) -> None:
+        """Hard-delete all FileUploads belonging to a box after S3 cleanup.
+
+        Sweeps until clean: initiation requests in flight before the box was locked
+        may still insert FileUploads after a pass completes; the lock guarantees the
+        loop terminates because no new initiations can begin.
+
+        Raises:
+        - `UnknownStorageAliasError` if a storage alias is not known.
+        - `UploadAbortError` if there's an error aborting an in-progress multipart upload.
+        """
+        while True:
+            file_uploads = [
+                upload
+                async for upload in self._file_upload_dao.find_all(
+                    mapping={"box_id": box_id}
+                )
+            ]
+            if not file_uploads:
+                log.info("Deleted all FileUploads for FileUploadBox %s.", box_id)
+                break
+
+            for file_upload in file_uploads:
+                if file_upload.state == "inbox":
+                    await self._remove_completed_file_upload(file_upload=file_upload)
+                elif file_upload.state == "init":
+                    await self._remove_incomplete_file_upload(file_upload=file_upload)
+
+                with contextlib.suppress(ResourceNotFoundError):
+                    await self._upload_activity_dao.delete(file_upload.id)
+                await self._file_upload_dao.delete(file_upload.id)
+
     async def _update_box_stats(self, *, box_id: UUID4, version: int) -> None:
         """Update FileUploadBox stats (file count & size) in an idempotent manner,
         counting only files that are finished uploading.

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -350,6 +350,35 @@ class UploadControllerPort(ABC):
         ...
 
     @abstractmethod
+    async def remove_file_upload_box(
+        self, *, box_id: UUID4, version: int | None = None
+    ) -> None:
+        """Remove a FileUploadBox and delete all associated FileUploads.
+
+        If `version` is provided, it must match the box's current version.
+        The box is locked before its FileUploads are swept so no new uploads
+        can be initiated mid-deletion.
+
+        Files in 'init' state have their S3 multipart upload aborted.
+        Files in 'inbox' state have their S3 object deleted.
+        Files in other states require no S3 interaction.
+        Files in 'awaiting_archival' or 'archived' state cause a FileUploadStateError
+        (invariant violation: these states require the box to be archived).
+
+        All FileUpload documents belonging to the box are hard-deleted, emitting
+        'deleted' outbox events.
+
+        Raises:
+        - `BoxNotFoundError` if the box does not exist.
+        - `BoxVersionError` if a version is supplied and doesn't match the current one.
+        - `BoxStateError` if the box is archived.
+        - `FileUploadStateError` if any FileUpload is in 'awaiting_archival' or 'archived' state.
+        - `UnknownStorageAliasError` if the storage alias is not known.
+        - `UploadAbortError` if there's an error aborting an in-progress multipart upload.
+        """
+        ...
+
+    @abstractmethod
     async def create_file_upload_box(
         self, *, storage_alias: str, max_size: int
     ) -> UUID4:

--- a/services/ucs/tests_ucs/fixtures/utils.py
+++ b/services/ucs/tests_ucs/fixtures/utils.py
@@ -144,6 +144,16 @@ def delete_file_token_header(
     return _make_auth_header(work_order, jwk)
 
 
+def delete_file_box_token_header(
+    *,
+    box_id: UUID = uuid4(),
+    jwk: JWK,
+) -> dict[str, str]:
+    """Generate DeleteFileBoxWorkOrder token for testing."""
+    work_order = models.DeleteFileBoxWorkOrder(work_type="delete_box", box_id=box_id)
+    return _make_auth_header(work_order, jwk)
+
+
 def make_file_upload(
     *,
     storage_alias: str = TEST_STORAGE_ALIAS,

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -858,3 +858,124 @@ async def test_delete_file_endpoint_error_handling(
         headers=token_header,
     )
     assert response.json()["description"] == str(http_error)
+
+
+async def test_delete_box_endpoint_auth(config: ConfigFixture, app_fixture: AppFixture):
+    """Test that the delete box endpoint returns 401 with no/invalid auth, 403 with a
+    mismatched box_id in the token, and 204 on success with a valid token.
+    """
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.remove_file_upload_box.return_value = None
+
+    # No auth token = 401
+    response = await rest_client.delete(f"/boxes/{TEST_BOX_ID}")
+    assert response.status_code == 401
+
+    # Invalid auth token = 401
+    response = await rest_client.delete(f"/boxes/{TEST_BOX_ID}", headers=INVALID_HEADER)
+    assert response.status_code == 401
+
+    # Wrong work type (use a ChangeFileBoxWorkOrder token) = 401 too
+    bad_token_header = utils.change_file_box_token_header(
+        jwk=rs_jwk, box_id=TEST_BOX_ID, work_type="lock"
+    )
+    response = await rest_client.delete(
+        f"/boxes/{TEST_BOX_ID}", headers=bad_token_header
+    )
+    assert response.status_code == 401
+
+    # Correct work type but wrong box_id in token
+    wrong_box_token_header = utils.delete_file_box_token_header(jwk=rs_jwk)
+    response = await rest_client.delete(
+        f"/boxes/{TEST_BOX_ID}", headers=wrong_box_token_header
+    )
+    assert response.status_code == 403
+
+    # Correct token
+    good_token_header = utils.delete_file_box_token_header(
+        jwk=rs_jwk, box_id=TEST_BOX_ID
+    )
+    response = await rest_client.delete(
+        f"/boxes/{TEST_BOX_ID}", headers=good_token_header
+    )
+    assert response.status_code == 204
+
+
+async def test_delete_box_endpoint_version_param(
+    config: ConfigFixture, app_fixture: AppFixture
+):
+    """Test that the optional 'version' query parameter is forwarded to the core,
+    and that omitting it forwards None.
+    """
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.remove_file_upload_box.return_value = None
+    token_header = utils.delete_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
+
+    # Delete the box
+    response = await rest_client.delete(
+        f"/boxes/{TEST_BOX_ID}", params={"version": 4}, headers=token_header
+    )
+    assert response.status_code == 204
+    core_mock.remove_file_upload_box.assert_awaited_with(box_id=TEST_BOX_ID, version=4)
+
+    # Delete the box but omit the version query param
+    response = await rest_client.delete(f"/boxes/{TEST_BOX_ID}", headers=token_header)
+    assert response.status_code == 204
+    core_mock.remove_file_upload_box.assert_awaited_with(
+        box_id=TEST_BOX_ID, version=None
+    )
+
+
+@pytest.mark.parametrize(
+    "core_error, http_error",
+    [
+        (
+            UploadControllerPort.BoxNotFoundError(box_id=TEST_BOX_ID),
+            http_exceptions.HttpBoxNotFoundError(box_id=TEST_BOX_ID),
+        ),
+        (
+            UploadControllerPort.BoxVersionError(box_id=TEST_BOX_ID),
+            http_exceptions.HttpBoxVersionError(box_id=TEST_BOX_ID),
+        ),
+        (
+            UploadControllerPort.BoxStateError(
+                box_id=TEST_BOX_ID, box_state="archived"
+            ),
+            http_exceptions.HttpBoxStateError(box_id=TEST_BOX_ID, box_state="archived"),
+        ),
+        (
+            UploadControllerPort.UploadAbortError(
+                file_id=TEST_FILE_ID,
+                s3_upload_id="test-upload",
+                bucket_id="test-bucket",
+            ),
+            http_exceptions.HttpUploadAbortError(),
+        ),
+        (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
+    ],
+    ids=[
+        "BoxNotFound",
+        "BoxVersionOutdated",
+        "BoxStateError",
+        "UploadAbortError",
+        "InternalError",
+    ],
+)
+async def test_delete_box_endpoint_error_handling(
+    config: ConfigFixture,
+    core_error: Exception,
+    http_error: Exception,
+    app_fixture: AppFixture,
+):
+    """Test that the endpoint correctly translates errors from the core."""
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.remove_file_upload_box.side_effect = core_error
+    token_header = utils.delete_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
+    response = await rest_client.delete(f"/boxes/{TEST_BOX_ID}", headers=token_header)
+    assert response.json()["description"] == str(http_error)

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -381,6 +381,33 @@ async def test_delete_file_endpoint_auth(
     assert response.status_code == 204
 
 
+async def test_delete_file_endpoint_accepts_rs_signed_token(
+    config: ConfigFixture, app_fixture: AppFixture
+):
+    """Test that the delete file endpoint also accepts a DeleteFileWorkOrder signed
+    with the RS key (used for manual deletion by the RS), in addition to the
+    WPS-signed tokens covered by test_delete_file_endpoint_auth. Mismatched claims
+    must still be rejected.
+    """
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    url = f"/boxes/{TEST_BOX_ID}/uploads/{TEST_FILE_ID}"
+
+    # Specifying the wrong box should get a 403 even if token signature is valid
+    wrong_box_token_header = utils.delete_file_token_header(
+        file_id=TEST_FILE_ID, jwk=rs_jwk
+    )
+    response = await rest_client.delete(url, headers=wrong_box_token_header)
+    assert response.status_code == 403
+
+    # Should be able to successfully call the endpoint
+    good_token_header = utils.delete_file_token_header(
+        box_id=TEST_BOX_ID, file_id=TEST_FILE_ID, jwk=rs_jwk
+    )
+    response = await rest_client.delete(url, headers=good_token_header)
+    assert response.status_code == 204
+
+
 @pytest.mark.parametrize(
     "core_error, http_error",
     [

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1897,3 +1897,165 @@ async def test_initiate_file_upload_marks_failed_on_insert_kafka_error(
 
     # Just double check that no UploadActivity was inserted
     assert not [x async for x in rig.upload_activity_dao.find_all(mapping={})]
+
+
+@pytest.mark.parametrize("box_state", ["open", "locked"])
+async def test_remove_file_upload_box_open_and_locked(rig: JointRig, box_state: str):
+    """Test that a box in 'open' or 'locked' state can be successfully deleted."""
+    box_id = await rig.create_default_box()
+    if box_state == "locked":
+        await rig.controller.lock_file_upload_box(box_id=box_id, version=0)
+
+    await rig.controller.remove_file_upload_box(box_id=box_id)
+
+    assert not rig.file_upload_box_dao.resources
+
+
+async def test_remove_file_upload_box_version_check(rig: JointRig):
+    """Test that supplying an outdated version raises BoxVersionError and leaves the
+    box intact, while supplying the current version allows deletion.
+    """
+    box_id = await rig.create_default_box()
+
+    with pytest.raises(UploadControllerPort.BoxVersionError) as exc_info:
+        await rig.controller.remove_file_upload_box(box_id=box_id, version=99)
+
+    assert str(box_id) in str(exc_info.value)
+    assert rig.file_upload_box_dao.resources
+
+    await rig.controller.remove_file_upload_box(box_id=box_id, version=0)
+    assert not rig.file_upload_box_dao.resources
+
+
+async def test_remove_file_upload_box_when_archived(rig: JointRig):
+    """Test that BoxStateError is raised when attempting to delete an archived box."""
+    box_id = await rig.create_default_box()
+    box = await rig.file_upload_box_dao.get_by_id(box_id)
+    box.state = "archived"
+    await rig.file_upload_box_dao.update(box)
+
+    with pytest.raises(UploadControllerPort.BoxStateError) as exc_info:
+        await rig.controller.remove_file_upload_box(box_id=box_id)
+
+    assert str(box_id) in str(exc_info.value)
+    assert rig.file_upload_box_dao.resources
+
+
+async def test_remove_file_upload_box_not_found(rig: JointRig):
+    """Test that BoxNotFoundError is raised for a non-existent box ID."""
+    non_existent_box_id = uuid4()
+
+    with pytest.raises(UploadControllerPort.BoxNotFoundError) as exc_info:
+        await rig.controller.remove_file_upload_box(box_id=non_existent_box_id)
+
+    assert str(non_existent_box_id) in str(exc_info.value)
+
+
+@pytest.mark.parametrize("bad_state", ["awaiting_archival", "archived"])
+async def test_remove_file_upload_box_with_invalid_file_state(
+    rig: JointRig, bad_state: FileUploadState
+):
+    """Test that FileUploadStateError is raised when a FileUpload is in 'awaiting_archival'
+    or 'archived' state, which indicates a data inconsistency.
+    """
+    box_id = await rig.create_default_box()
+    file_upload = make_file_upload(state=bad_state)
+    file_upload.box_id = box_id
+    await rig.file_upload_dao.insert(file_upload)
+
+    with pytest.raises(UploadControllerPort.FileUploadStateError) as exc_info:
+        await rig.controller.remove_file_upload_box(box_id=box_id)
+
+    assert str(file_upload.id) in str(exc_info.value)
+    assert rig.file_upload_box_dao.resources
+
+
+async def test_remove_file_upload_box_success(
+    rig: JointRig, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that removing a box correctly handles each FileUpload state:
+    - 'init': S3 multipart upload is aborted
+    - 'inbox': S3 object is deleted
+    - 'interrogated', 'failed', 'cancelled': no S3 action
+
+    The box and all its FileUploads are hard-deleted from the DB and the activity
+    entry for the init file is removed as well.
+    """
+    box_id = await rig.create_default_box()
+    storage_alias = next(iter(rig.config.object_storages))
+
+    s3_calls: list[str] = []
+
+    async def spy_delete_inbox_file(**kwargs):
+        s3_calls.append("delete_inbox_file")
+
+    async def spy_abort_multipart_upload(**kwargs):
+        s3_calls.append("abort_multipart_upload")
+
+    monkeypatch.setattr(rig.s3_client, "delete_inbox_file", spy_delete_inbox_file)
+    monkeypatch.setattr(
+        rig.s3_client, "abort_multipart_upload", spy_abort_multipart_upload
+    )
+
+    file_uploads_by_state: dict[str, FileUpload] = {}
+    for state in ["init", "inbox", "interrogated", "failed", "cancelled"]:
+        file_upload = make_file_upload(state=state, storage_alias=storage_alias)
+        file_upload.box_id = box_id
+        await rig.file_upload_dao.insert(file_upload)
+        file_uploads_by_state[state] = file_upload
+
+    init_file = file_uploads_by_state["init"]
+    await rig.upload_activity_dao.upsert(
+        UploadActivity(file_id=init_file.id, last_activity=now_utc_ms_prec())
+    )
+
+    # Call the box deletion method
+    await rig.controller.remove_file_upload_box(box_id=box_id)
+
+    # Verify the box is gone
+    assert not rig.file_upload_box_dao.resources
+
+    # Should have one file deletion due to 'inbox' and one upload abort due to 'init'
+    assert s3_calls.count("abort_multipart_upload") == 1
+    assert s3_calls.count("delete_inbox_file") == 1
+
+    # Verify that all FileUploads were hard-deleted regardless of state
+    assert not rig.file_upload_dao.resources
+
+    # Make sure the upload activity associated with the 'init' file is deleted
+    with pytest.raises(ResourceNotFoundError):
+        await rig.upload_activity_dao.get_by_id(init_file.id)
+
+
+async def test_remove_file_upload_box_s3_abort_error(rig: JointRig):
+    """Make sure an UploadAbortError is raised and the box is NOT deleted when S3 fails
+    to abort a multipart upload for an 'init'-state file. The box is left locked
+    because deletion locks open boxes before sweeping their uploads.
+    """
+    box_id = await rig.create_default_box()
+
+    # Make an upload, we don't care about the file ID or upload ID
+    _, _ = await rig.controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+
+    # Hardwire the object storage to raise an error when we try to abort the upload
+    storage = rig.object_storages.for_alias("test")[1]
+
+    async def do_error(*args, **kwargs):
+        raise ObjectStorageProtocol.MultiPartUploadAbortError("", "", "")
+
+    storage.abort_multipart_upload = do_error
+
+    # Call the box deletion method
+    with pytest.raises(UploadControllerPort.UploadAbortError):
+        await rig.controller.remove_file_upload_box(box_id=box_id)
+
+    # Verify that the box is still there and still locked
+    assert rig.file_upload_box_dao.resources
+    surviving_box = await rig.file_upload_box_dao.get_by_id(box_id)
+    assert surviving_box.state == "locked"


### PR DESCRIPTION
Adds an endpoint to delete FileUploadBoxes.

Also adds missing WOT support for file deletion requests originating from RS.

Bumps UCS version to `14.1.0` and monorepo version to `15.1.0`.