### PR TITLE
UCS: Delete orphaned objects from the inbox bucket (GSI-2435)

### DIFF
--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -489,9 +489,7 @@ class S3Client(S3ClientPort):
         bucket_id, object_storage = self._get_bucket_and_storage(storage_alias)
         extra: dict[str, Any] = {"storage_alias": storage_alias, "bucket_id": bucket_id}
         try:
-            object_ids: list[str] = await object_storage.list_all_object_ids(
-                bucket_id=bucket_id
-            )
+            object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
         except ObjectStorageProtocol.BucketNotFoundError as err:
             error = S3ClientPort.BucketNotFoundError(bucket_id=bucket_id)
             log.error(error, extra=extra)

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -474,3 +474,30 @@ class S3Client(S3ClientPort):
             op_name="get_all_multipart_uploads", bucket_id=bucket_id, extra=extra
         ):
             return await object_storage.get_all_multipart_uploads(bucket_id=bucket_id)
+
+    async def cleanup_orphaned_objects(
+        self, *, storage_alias: str, known_object_ids: set[str]
+    ):
+        """Cleans out all orphaned object IDs in the inbox bucket.
+
+        Raises:
+            `UnknownStorageAliasError` if the storage alias is not known.
+        """
+        bucket_id, object_storage = self._get_bucket_and_storage(storage_alias)
+        extra = {"storage_alias": storage_alias, "bucket_id": bucket_id}
+        with handle_bucket_and_general_s3_errors(
+            op_name="list_all_object_ids", bucket_id=bucket_id, extra=extra
+        ):
+            object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
+            orphaned_object_ids = set(object_ids) - known_object_ids
+            for object_id in orphaned_object_ids:
+                await object_storage.delete_object(
+                    bucket_id=bucket_id, object_id=object_id
+                )
+                log.info(
+                    "Deleted object %s from bucket %s in storage alias %s.",
+                    object_id,
+                    bucket_id,
+                    storage_alias,
+                    extra={"object_id": object_id, **extra},
+                )

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -528,8 +528,8 @@ class S3Client(S3ClientPort):
         problem_msg = ""
         if problem_ids or missing_ids:
             problem_msg = (
-                f" An additional {len(problem_ids)} could not be deleted and"
-                + f" {len(missing_ids)} were no longer present by the time"
+                f" An additional {len(problem_ids)} object(s) could not be deleted and"
+                + f" {len(missing_ids)} object(s) were no longer present by the time"
                 + " deletion was attempted."
             )
             extra["could_not_delete_count"] = len(problem_ids)

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -489,18 +489,24 @@ class S3Client(S3ClientPort):
         bucket_id, object_storage = self._get_bucket_and_storage(storage_alias)
         extra: dict[str, Any] = {"storage_alias": storage_alias, "bucket_id": bucket_id}
         try:
-            object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
+            object_ids: list[str] = await object_storage.list_all_object_ids(
+                bucket_id=bucket_id
+            )
         except ObjectStorageProtocol.BucketNotFoundError as err:
             error = S3ClientPort.BucketNotFoundError(bucket_id=bucket_id)
             log.error(error, extra=extra)
             raise error from err
 
         orphaned_object_ids = set(object_ids) - known_object_ids
+
+        # Return early if no orphaned objects
+        if not orphaned_object_ids:
+            log.info("Did not detect any orphaned objects in the bucket %s.", bucket_id)
+
         deleted_ids = []
         missing_ids = []
         problem_ids = []
         for object_id in orphaned_object_ids:
-            extra["object_id"] = object_id
             try:
                 await object_storage.delete_object(
                     bucket_id=bucket_id, object_id=object_id
@@ -515,15 +521,11 @@ class S3Client(S3ClientPort):
                     bucket_id,
                     storage_alias,
                     str(err),
-                    extra=extra,
+                    extra={**extra, "object_id": object_id},
                 )
                 problem_ids.append(object_id)
             else:
                 deleted_ids.append(object_id)
-
-        _ = extra.pop("object_id", None)
-        extra["deleted_count"] = len(deleted_ids)
-        extra["deleted_object_ids"] = deleted_ids
 
         problem_msg = ""
         if problem_ids or missing_ids:
@@ -537,6 +539,8 @@ class S3Client(S3ClientPort):
             extra["no_longer_present_count"] = len(missing_ids)
             extra["no_longer_present_object_ids"] = missing_ids
 
+        extra["deleted_count"] = len(deleted_ids)
+        extra["deleted_object_ids"] = deleted_ids
         log.info(
             "Cleaned up %i orphaned object(s) from bucket %s in storage alias %s.%s",
             len(deleted_ids),

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -478,26 +478,70 @@ class S3Client(S3ClientPort):
     async def cleanup_orphaned_objects(
         self, *, storage_alias: str, known_object_ids: set[str]
     ):
-        """Cleans out all orphaned object IDs in the inbox bucket.
+        """Clean out all orphaned object IDs in the inbox bucket.
+
+        When finished, log basic stats for deleted objects.
 
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
+            `BucketNotFoundError` if the configured bucket does not exist in S3.
         """
         bucket_id, object_storage = self._get_bucket_and_storage(storage_alias)
-        extra = {"storage_alias": storage_alias, "bucket_id": bucket_id}
-        with handle_bucket_and_general_s3_errors(
-            op_name="list_all_object_ids", bucket_id=bucket_id, extra=extra
-        ):
+        extra: dict[str, Any] = {"storage_alias": storage_alias, "bucket_id": bucket_id}
+        try:
             object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
-            orphaned_object_ids = set(object_ids) - known_object_ids
-            for object_id in orphaned_object_ids:
+        except ObjectStorageProtocol.BucketNotFoundError as err:
+            error = S3ClientPort.BucketNotFoundError(bucket_id=bucket_id)
+            log.error(error, extra=extra)
+            raise error from err
+
+        orphaned_object_ids = set(object_ids) - known_object_ids
+        deleted_ids = []
+        missing_ids = []
+        problem_ids = []
+        for object_id in orphaned_object_ids:
+            extra["object_id"] = object_id
+            try:
                 await object_storage.delete_object(
                     bucket_id=bucket_id, object_id=object_id
                 )
-                log.info(
-                    "Deleted object %s from bucket %s in storage alias %s.",
+            except ObjectStorageProtocol.ObjectNotFoundError:
+                missing_ids.append(object_id)
+            except ObjectStorageProtocol.ObjectStorageProtocolError as err:
+                log.error(
+                    "Unable to clean up object %s from bucket %s in storage alias %s"
+                    + " because of the following error: %s",
                     object_id,
                     bucket_id,
                     storage_alias,
-                    extra={"object_id": object_id, **extra},
+                    str(err),
+                    extra=extra,
                 )
+                problem_ids.append(object_id)
+            else:
+                deleted_ids.append(object_id)
+
+        _ = extra.pop("object_id", None)
+        extra["deleted_count"] = len(deleted_ids)
+        extra["deleted_object_ids"] = deleted_ids
+
+        problem_msg = ""
+        if problem_ids or missing_ids:
+            problem_msg = (
+                f" An additional {len(problem_ids)} could not be deleted and"
+                + f" {len(missing_ids)} were no longer present by the time"
+                + " deletion was attempted."
+            )
+            extra["could_not_delete_count"] = len(problem_ids)
+            extra["could_not_delete_object_ids"] = problem_ids
+            extra["no_longer_present_count"] = len(missing_ids)
+            extra["no_longer_present_object_ids"] = missing_ids
+
+        log.info(
+            "Cleaned up %i orphaned object(s) from bucket %s in storage alias %s.%s",
+            len(deleted_ids),
+            bucket_id,
+            storage_alias,
+            problem_msg,
+            extra=extra,
+        )

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1427,15 +1427,25 @@ class UploadController(UploadControllerPort):
         storage_alias: str,
         cutoff: UTCDatetime,
     ) -> None:
-        """Run stale upload cleanup for a single storage alias."""
-        # Fetch all in-progress uploads for this storage alias
-        ongoing_uploads = [
+        """Run stale upload cleanup for a single storage alias.
+
+        This aborts ongoing uploads that are too old or not tied to any FileUpload.
+        Orphaned objects are also deleted.
+        """
+        # Fetch all FileUploads for this storage alias that are still 'init' or 'inbox'
+        init_and_inbox_uploads = [
             upload
             async for upload in self._file_upload_dao.find_all(
-                mapping={"storage_alias": storage_alias, "state": "init"}
+                mapping={
+                    "storage_alias": storage_alias,
+                    "state": {"$in": ["init", "inbox"]},
+                }
             )
         ]
-        known_object_ids = {str(upload.object_id) for upload in ongoing_uploads}
+
+        # Get just the 'init', i.e. ongoing, uploads from that list
+        ongoing_uploads = [x for x in init_and_inbox_uploads if x.state == "init"]
+        known_init_object_ids = {str(upload.object_id) for upload in ongoing_uploads}
 
         # Determine which of the ongoing uploads have been dormant since the cutoff time
         stale_uploads = await self._find_stale_uploads(
@@ -1464,7 +1474,7 @@ class UploadController(UploadControllerPort):
         orphaned_s3_uploads = {
             s3_upload_id: object_id
             for s3_upload_id, object_id in active_s3_uploads.items()
-            if object_id not in known_object_ids
+            if object_id not in known_init_object_ids
         }
 
         # Cancel each of the stale uploads that have FileUpload entries in the DB
@@ -1475,4 +1485,11 @@ class UploadController(UploadControllerPort):
 
         await self._abort_orphaned_s3_uploads(
             storage_alias=storage_alias, orphaned_s3_uploads=orphaned_s3_uploads
+        )
+
+        # Get a set of all object_ids from init_and_inbox_uploads. Cast to str because
+        #  S3Client does a set diff on the string object IDs returned by S3
+        known_object_ids = {str(x.object_id) for x in init_and_inbox_uploads}
+        await self._s3_client.cleanup_orphaned_objects(
+            storage_alias=storage_alias, known_object_ids=known_object_ids
         )

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1433,6 +1433,7 @@ class UploadController(UploadControllerPort):
         Orphaned objects are also deleted.
         """
         # Fetch all FileUploads for this storage alias that are still 'init' or 'inbox'
+        #  to avoid doing a second query later when performing object cleanup
         init_and_inbox_uploads = [
             upload
             async for upload in self._file_upload_dao.find_all(

--- a/services/ucs/src/ucs/ports/outbound/storage.py
+++ b/services/ucs/src/ucs/ports/outbound/storage.py
@@ -228,3 +228,13 @@ class S3ClientPort(ABC):
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
         """
+
+    @abstractmethod
+    async def cleanup_orphaned_objects(
+        self, *, storage_alias: str, known_object_ids: set[str]
+    ):
+        """Cleans out all orphaned object IDs in the inbox bucket.
+
+        Raises:
+            `UnknownStorageAliasError` if the storage alias is not known.
+        """

--- a/services/ucs/src/ucs/ports/outbound/storage.py
+++ b/services/ucs/src/ucs/ports/outbound/storage.py
@@ -233,8 +233,11 @@ class S3ClientPort(ABC):
     async def cleanup_orphaned_objects(
         self, *, storage_alias: str, known_object_ids: set[str]
     ):
-        """Cleans out all orphaned object IDs in the inbox bucket.
+        """Clean out all orphaned object IDs in the inbox bucket.
+
+        When finished, log basic stats for deleted objects.
 
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
+            `BucketNotFoundError` if the configured bucket does not exist in S3.
         """

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -864,6 +864,113 @@ async def test_cleanup_cancels_despite_s3_abort_failure(
     assert s3_upload_id not in uploads
 
 
+async def test_cleanup_of_orphaned_files(joint_fixture: JointFixture):
+    """Test that orphaned files are deleted from the inbox by the cleanup job."""
+    controller = joint_fixture.upload_controller
+    s3_storage = joint_fixture.s3.storage
+    bucket_id = joint_fixture.bucket_id
+
+    # Create a box and initiate a file upload
+    async with set_correlation_id(uuid4()):
+        box_id = await controller.create_file_upload_box(
+            storage_alias="test", max_size=utils.TEST_MAX_BOX_SIZE
+        )
+        file_init_id, _ = await controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test-file1",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=utils.PART_SIZE,
+        )
+        file_inbox_id, _ = await controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test-file2",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=utils.PART_SIZE,
+        )
+        file_cancelled_id, _ = await controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test-file3",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=utils.PART_SIZE,
+        )
+    for file_id in [file_init_id, file_inbox_id, file_cancelled_id]:
+        url = await controller.get_part_upload_url(file_id=file_id, part_no=1)
+        httpx.put(url, content=b"some-data")
+
+    # Complete the uploads
+    collection = joint_fixture.mongodb.client[joint_fixture.config.db_name][
+        FILE_UPLOADS_COLLECTION
+    ]
+    file_init_doc = collection.find_one({"_id": file_init_id})
+    file_inbox_doc = collection.find_one({"_id": file_inbox_id})
+    file_cancelled_doc = collection.find_one({"_id": file_cancelled_id})
+    assert file_init_doc is not None
+    assert file_inbox_doc is not None
+    assert file_cancelled_doc is not None
+    file_init_object_id = str(file_init_doc["object_id"])
+    file_inbox_object_id = str(file_inbox_doc["object_id"])
+    file_cancelled_object_id = str(file_cancelled_doc["object_id"])
+    await s3_storage.complete_multipart_upload(
+        upload_id=file_init_doc["s3_upload_id"],
+        bucket_id=bucket_id,
+        object_id=file_init_object_id,
+    )
+    await s3_storage.complete_multipart_upload(
+        upload_id=file_inbox_doc["s3_upload_id"],
+        bucket_id=bucket_id,
+        object_id=file_inbox_object_id,
+    )
+    await s3_storage.complete_multipart_upload(
+        upload_id=file_cancelled_doc["s3_upload_id"],
+        bucket_id=bucket_id,
+        object_id=file_cancelled_object_id,
+    )
+
+    # Set the inbox and cancelled docs to the desired states but leave init as is to
+    #  simulate race condition
+    file_inbox_doc["inbox"] = "inbox"
+    file_cancelled_doc["state"] = "cancelled"
+    collection.replace_one(filter={"_id": file_inbox_id}, replacement=file_inbox_doc)
+    collection.replace_one(
+        filter={"_id": file_cancelled_id}, replacement=file_cancelled_doc
+    )
+
+    # Upload two different orphaned objects
+    orphaned_object_id1 = str(uuid4())
+    orphaned_object_id2 = "not-a-uuid"
+    for object_id in [orphaned_object_id1, orphaned_object_id2]:
+        upload_id = await s3_storage.init_multipart_upload(
+            bucket_id=bucket_id, object_id=object_id
+        )
+        url = await s3_storage.get_part_upload_url(
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id, part_number=1
+        )
+        httpx.put(url, content=b"some-data")
+        await s3_storage.complete_multipart_upload(
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+        )
+
+    # Check the list of current IDs before running the job
+    all_object_ids = await s3_storage.list_all_object_ids(bucket_id=bucket_id)
+    assert set(all_object_ids) == {
+        file_init_object_id,
+        file_inbox_object_id,
+        file_cancelled_object_id,
+        orphaned_object_id1,
+        orphaned_object_id2,
+    }
+
+    # Run the cleanup job
+    await controller.cleanup_stale_uploads()
+
+    # Verify that the orphaned and cancelled files are gone, but init and inbox remain
+    all_object_ids = await s3_storage.list_all_object_ids(bucket_id=bucket_id)
+    assert set(all_object_ids) == {file_init_object_id, file_inbox_object_id}
+
+
 async def test_upload_activity_deleted_after_completion_failure(
     joint_fixture: JointFixture,
 ):

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -27,6 +27,7 @@ import httpx
 import pytest
 from ghga_event_schemas.pydantic_ import FileDeletionRequested, InterrogationSuccess
 from hexkit.correlation import set_correlation_id
+from hexkit.protocols.objstorage import ObjectStorageProtocolError
 from hexkit.utils import now_utc_ms_prec
 
 from tests_ucs.fixtures import utils
@@ -864,7 +865,10 @@ async def test_cleanup_cancels_despite_s3_abort_failure(
     assert s3_upload_id not in uploads
 
 
-async def test_cleanup_of_orphaned_files(joint_fixture: JointFixture):
+@pytest.mark.parametrize("simulate_errors", [True, False])
+async def test_cleanup_of_orphaned_files(
+    joint_fixture: JointFixture, simulate_errors: bool, caplog
+):
     """Test that orphaned files are deleted from the inbox by the cleanup job."""
     controller = joint_fixture.upload_controller
     s3_storage = joint_fixture.s3.storage
@@ -963,12 +967,57 @@ async def test_cleanup_of_orphaned_files(joint_fixture: JointFixture):
         orphaned_object_id2,
     }
 
+    # Simulate errors in the S3 delete method if simulate_errors is True
+    _real_deletion_method = s3_storage.delete_object
+
+    class _S3PermissionError(ObjectStorageProtocolError):
+        def __init__(self, *, bucket_id: str, object_id: str):
+            super().__init__("You don't have permission to do that.")
+
+    async def _delete_with_error(bucket_id: str, object_id: str) -> None:
+        """Raises an ObjectNotFoundError, then _S3PermissionError, then reverts."""
+        if object_id == orphaned_object_id1:
+            await _real_deletion_method(bucket_id=bucket_id, object_id=object_id)
+            raise s3_storage.ObjectNotFoundError(
+                bucket_id=bucket_id, object_id=object_id
+            )
+        elif object_id == file_cancelled_object_id:
+            raise _S3PermissionError(bucket_id=bucket_id, object_id=object_id)
+        else:
+            return await _real_deletion_method(bucket_id=bucket_id, object_id=object_id)
+
+    if simulate_errors:
+        s3_storage.delete_object = _delete_with_error
+        controller._s3_client._get_bucket_and_storage = lambda x: (
+            bucket_id,
+            s3_storage,
+        )
+
     # Run the cleanup job
-    await controller.cleanup_stale_uploads()
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        await controller.cleanup_stale_uploads()
+
+    deleted_count = 1 if simulate_errors else 3
+    log_msg = (
+        f"Cleaned up {deleted_count} orphaned object(s) from bucket {bucket_id}"
+        + " in storage alias test."
+    )
+
+    if simulate_errors:
+        log_msg += (
+            " An additional 1 object(s) could not be deleted and 1 object(s) were no"
+            + " longer present by the time deletion was attempted."
+        )
+    assert log_msg in caplog.messages
 
     # Verify that the orphaned and cancelled files are gone, but init and inbox remain
     all_object_ids = await s3_storage.list_all_object_ids(bucket_id=bucket_id)
-    assert set(all_object_ids) == {file_init_object_id, file_inbox_object_id}
+
+    expected_objects = {file_init_object_id, file_inbox_object_id}
+    if simulate_errors:
+        expected_objects.add(file_cancelled_object_id)  # didn't get deleted due to exc
+    assert set(all_object_ids) == expected_objects
 
 
 async def test_upload_activity_deleted_after_completion_failure(

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -27,7 +27,7 @@ import httpx
 import pytest
 from ghga_event_schemas.pydantic_ import FileDeletionRequested, InterrogationSuccess
 from hexkit.correlation import set_correlation_id
-from hexkit.protocols.objstorage import ObjectStorageProtocolError
+from hexkit.protocols.objstorage import ObjectStorageProtocol
 from hexkit.utils import now_utc_ms_prec
 
 from tests_ucs.fixtures import utils
@@ -970,7 +970,7 @@ async def test_cleanup_of_orphaned_files(
     # Simulate errors in the S3 delete method if simulate_errors is True
     _real_deletion_method = s3_storage.delete_object
 
-    class _S3PermissionError(ObjectStorageProtocolError):
+    class _S3PermissionError(ObjectStorageProtocol.ObjectStorageProtocolError):
         def __init__(self, *, bucket_id: str, object_id: str):
             super().__init__("You don't have permission to do that.")
 


### PR DESCRIPTION
Adds on to the UCS's cleanup job to delete objects whose object ID doesn't correspond to any `init` or `inbox` state `FileUpload`. 


Does not bump the UCS version because there are unreleased changes in main that already contain the requisite version bump.