### PR TITLE
UCS: Idempotence fix report handling (GSI-2348)

### DIFF
--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1179,6 +1179,7 @@ class UploadController(UploadControllerPort):
                 return
             case "inbox":
                 # Update the FileUpload's parameters using the InterrogationReport
+                await self._remove_completed_file_upload(file_upload=old_file_upload)
                 updated_file_upload = old_file_upload.model_copy(deep=True)
                 updated_file_upload.state = "interrogated"
                 updated_file_upload.state_updated = now_utc_ms_prec()
@@ -1201,8 +1202,6 @@ class UploadController(UploadControllerPort):
                     file_id,
                     old_file_upload.state,
                 )
-
-        await self._remove_completed_file_upload(file_upload=old_file_upload)
 
     async def process_interrogation_failure(
         self, *, report: InterrogationFailure
@@ -1236,6 +1235,7 @@ class UploadController(UploadControllerPort):
                 file_upload.failure_reason = report.reason
                 log.debug("Marking FileUpload %s as '%s'", file_id, file_upload.state)
                 await self._file_upload_dao.update(file_upload)
+                await self._remove_completed_file_upload(file_upload=file_upload)
             case _:
                 log.info(
                     "FileUpload %s was already marked as '%s', so it's likely"
@@ -1243,8 +1243,6 @@ class UploadController(UploadControllerPort):
                     file_id,
                     file_upload.state,
                 )
-
-        await self._remove_completed_file_upload(file_upload=file_upload)
 
     async def process_internal_file_registration(
         self, *, registration_metadata: FileInternallyRegistered

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1230,12 +1230,12 @@ class UploadController(UploadControllerPort):
                 )
                 return
             case "inbox":
+                await self._remove_completed_file_upload(file_upload=file_upload)
                 file_upload.state = "failed"
                 file_upload.state_updated = now_utc_ms_prec()
                 file_upload.failure_reason = report.reason
                 log.debug("Marking FileUpload %s as '%s'", file_id, file_upload.state)
                 await self._file_upload_dao.update(file_upload)
-                await self._remove_completed_file_upload(file_upload=file_upload)
             case _:
                 log.info(
                     "FileUpload %s was already marked as '%s', so it's likely"

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -639,7 +639,7 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
         s3_storage,
     )
 
-    # REGRESSION TEST: Publish/consume the InterrogationSuccess event to trigger S3 error
+    # Publish/consume the InterrogationSuccess event to trigger S3 error
     await joint_fixture.kafka.publish_event(
         payload=interrogation_success.model_dump(mode="json"),
         type_=config.interrogation_success_type,
@@ -648,15 +648,14 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
     with pytest.raises(UploadControllerPort.S3OperationError):
         await joint_fixture.event_subscriber.run(forever=False)
 
-    # REGRESSION TEST: Verify that the the FileUpload is unchanged and the object is
-    #  still in the inbox
+    # Verify that the the FileUpload is unchanged and the object is still in the inbox
     await s3_storage.does_object_exist(bucket_id=inbox_bucket_id, object_id=object_id)
     file_upload_check = file_upload_collection.find_one({"_id": file_id})
     assert file_upload_check is not None
     assert file_upload_check["state"] == "inbox"
     assert file_upload_check["object_id"] == UUID(object_id)
 
-    # REGRESSION TEST: Undo the S3 patches. Regression test finished
+    # Undo the S3 patches. This is the end of the regression test
     s3_storage.delete_object = _real_delete_fn
     controller._s3_client._get_bucket_and_storage = _real_get_storage_fn
 

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -601,7 +601,7 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
         encrypted_size=ENCRYPTED_SIZE,
     )
 
-    # Put an object into the interrogation bucket to simulated DHFS's work
+    # Put an object into the interrogation bucket to simulate DHFS's work
     await s3_storage.create_bucket(interrogation_bucket_id)
     upload_id = await s3_storage.init_multipart_upload(
         bucket_id=interrogation_bucket_id,
@@ -626,7 +626,41 @@ async def test_file_interrogation_report_happy(joint_fixture: JointFixture):
     )
     assert interrogation_file_exists, "Dummy object not present in interrogation bucket"
 
-    # Dummy object is in place, now we can publish the InterrogationSuccess event
+    # REGRESSION TEST: Verify that an S3 error doesn't result in an orphaned inbox object
+    _real_get_storage_fn = controller._s3_client._get_bucket_and_storage
+    _real_delete_fn = s3_storage.delete_object
+
+    async def _erroring_delete_fn(*, bucket_id: str, object_id: str) -> None:
+        raise s3_storage.ObjectStorageProtocolError("problem")
+
+    s3_storage.delete_object = _erroring_delete_fn
+    controller._s3_client._get_bucket_and_storage = lambda x: (
+        inbox_bucket_id,
+        s3_storage,
+    )
+
+    # REGRESSION TEST: Publish/consume the InterrogationSuccess event to trigger S3 error
+    await joint_fixture.kafka.publish_event(
+        payload=interrogation_success.model_dump(mode="json"),
+        type_=config.interrogation_success_type,
+        topic=config.file_interrogations_topic,
+    )
+    with pytest.raises(UploadControllerPort.S3OperationError):
+        await joint_fixture.event_subscriber.run(forever=False)
+
+    # REGRESSION TEST: Verify that the the FileUpload is unchanged and the object is
+    #  still in the inbox
+    await s3_storage.does_object_exist(bucket_id=inbox_bucket_id, object_id=object_id)
+    file_upload_check = file_upload_collection.find_one({"_id": file_id})
+    assert file_upload_check is not None
+    assert file_upload_check["state"] == "inbox"
+    assert file_upload_check["object_id"] == UUID(object_id)
+
+    # REGRESSION TEST: Undo the S3 patches. Regression test finished
+    s3_storage.delete_object = _real_delete_fn
+    controller._s3_client._get_bucket_and_storage = _real_get_storage_fn
+
+    # Now we can publish the InterrogationSuccess event for real
     await joint_fixture.kafka.publish_event(
         payload=interrogation_success.model_dump(mode="json"),
         type_=config.interrogation_success_type,


### PR DESCRIPTION
Fixes a latent bug. When UCS gets an InterrogationSuccess event, it has to update it's local copy of the `FileUpload` info in the DB and it has to delete the associated object from the database. When it does the DB update, it updates FileUpload's bucket_id and object_id to reflect the details of the data in the interrogation bucket. In the pre-patched version, UCS did this DB update _before_ deleting the S3 object from the inbox. We encountered a config issue that precipitated an error in the S3 deletion operation, and when we requeued the event we received a permission error because the information UCS used for the deletion operation now pointed to the interrogation bucket instead of the inbox. This patch reverses the order of operations so S3 deletion precedes the DB update.

Does not bump the UCS version because there are unreleased changes in main that already contain the requisite version bump.