### PR TITLE
UCS: Pagination (GSI-2408)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.1.0"
+version = "16.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.1.0"
+version = "16.0.0"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:14.1.0
+docker pull ghga/upload-controller-service:15.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:14.1.0 .
+docker build -t ghga/upload-controller-service:15.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:14.1.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:15.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -53,6 +53,22 @@ components:
       - version
       title: Box Update Request
       type: object
+    BoxUploadsPage:
+      description: Paginated response for a box's file uploads.
+      properties:
+        elements:
+          items:
+            $ref: '#/components/schemas/FileUpload'
+          title: Elements
+          type: array
+        total_count:
+          title: Total Count
+          type: integer
+      required:
+      - elements
+      - total_count
+      title: BoxUploadsPage
+      type: object
     FileUpload:
       description: 'A FileUpload.
 
@@ -794,7 +810,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 14.1.0
+  version: 15.0.0
 openapi: 3.1.0
 paths:
   /boxes:
@@ -991,10 +1007,8 @@ paths:
       - UploadControllerService
   /boxes/{box_id}/uploads:
     get:
-      description: 'Retrieve list of FileUploads for a FileUploadBox.
+      description: 'Retrieve a paginated list of FileUploads for a FileUploadBox.
 
-
-        Returns the list of FileUploads for completed uploads in the specified box.
 
         Requires ViewFileBoxWorkOrder token from the RS.'
       operationId: getBoxUploads
@@ -1006,16 +1020,30 @@ paths:
           format: uuid4
           title: Box Id
           type: string
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 100
+          minimum: 0
+          title: Limit
+          type: integer
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/FileUpload'
-                title: Response Getboxuploads
-                type: array
-          description: List of file IDs for completed uploads in the box
+                $ref: '#/components/schemas/BoxUploadsPage'
+          description: Paginated list of file uploads for the box
         '404':
           content:
             application/json:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -627,6 +627,31 @@ components:
       properties: {}
       title: HttpS3UploadNotFoundErrorData
       type: object
+    HttpSkipOrLimitInvalidError:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: '#/components/schemas/HttpSkipOrLimitInvalidErrorData'
+        description:
+          description: A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          const: skipOrLimitInvalid
+          title: Exception Id
+          type: string
+      required:
+      - data
+      - description
+      - exception_id
+      title: HttpSkipOrLimitInvalidError
+      type: object
+    HttpSkipOrLimitInvalidErrorData:
+      additionalProperties: true
+      properties: {}
+      title: HttpSkipOrLimitInvalidErrorData
+      type: object
     HttpTooManyOpenUploadsError:
       additionalProperties: false
       properties:
@@ -1056,8 +1081,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+                $ref: '#/components/schemas/HttpSkipOrLimitInvalidError'
+          description: 'Exceptions by ID:
+
+            - skipOrLimitInvalid: The skip or limit pagination parameters are invalid.'
       security:
       - HTTPBearer: []
       summary: Retrieve list of file IDs for box

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -810,7 +810,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 14.1.0
+  version: 15.0.0
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -56,16 +56,16 @@ components:
     BoxUploadsPage:
       description: Paginated response for a box's file uploads.
       properties:
-        elements:
+        items:
           items:
             $ref: '#/components/schemas/FileUpload'
-          title: Elements
+          title: Items
           type: array
         total_count:
           title: Total Count
           type: integer
       required:
-      - elements
+      - items
       - total_count
       title: BoxUploadsPage
       type: object

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -627,31 +627,6 @@ components:
       properties: {}
       title: HttpS3UploadNotFoundErrorData
       type: object
-    HttpSkipOrLimitInvalidError:
-      additionalProperties: false
-      properties:
-        data:
-          $ref: '#/components/schemas/HttpSkipOrLimitInvalidErrorData'
-        description:
-          description: A human readable message to the client explaining the cause
-            of the exception.
-          title: Description
-          type: string
-        exception_id:
-          const: skipOrLimitInvalid
-          title: Exception Id
-          type: string
-      required:
-      - data
-      - description
-      - exception_id
-      title: HttpSkipOrLimitInvalidError
-      type: object
-    HttpSkipOrLimitInvalidErrorData:
-      additionalProperties: true
-      properties: {}
-      title: HttpSkipOrLimitInvalidErrorData
-      type: object
     HttpTooManyOpenUploadsError:
       additionalProperties: false
       properties:
@@ -835,7 +810,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 15.0.0
+  version: 14.1.0
 openapi: 3.1.0
 paths:
   /boxes:
@@ -1081,13 +1056,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpSkipOrLimitInvalidError'
-          description: 'Exceptions by ID:
-
-            - skipOrLimitInvalid: The skip or limit pagination parameters are invalid.'
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
       security:
       - HTTPBearer: []
-      summary: Retrieve list of file IDs for box
+      summary: Retrieve a paginated list of file uploads for the given box
       tags:
       - UploadControllerService
     post:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "14.1.0"
+version = "15.0.0"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -450,6 +450,20 @@ class HttpNotAuthorizedError(HttpCustomExceptionBase):
         )
 
 
+class HttpSkipOrLimitInvalidError(HttpCustomExceptionBase):
+    """Thrown when the skip or limit pagination parameters are invalid."""
+
+    exception_id = "skipOrLimitInvalid"
+
+    def __init__(self, *, status_code: int = 422):
+        """Construct message and initialize exception."""
+        super().__init__(
+            status_code=status_code,
+            description="The skip or limit pagination parameters are invalid.",
+            data={},
+        )
+
+
 class HttpInternalError(HttpCustomExceptionBase):
     """Thrown for otherwise unhandled exceptions"""
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -450,16 +450,16 @@ class HttpNotAuthorizedError(HttpCustomExceptionBase):
         )
 
 
-class HttpSkipOrLimitInvalidError(HttpCustomExceptionBase):
+class HttpPaginationError(HttpCustomExceptionBase):
     """Thrown when the skip or limit pagination parameters are invalid."""
 
-    exception_id = "skipOrLimitInvalid"
+    exception_id = "paginationError"
 
     def __init__(self, *, status_code: int = 422):
         """Construct message and initialize exception."""
         super().__init__(
             status_code=status_code,
-            description="The skip or limit pagination parameters are invalid.",
+            description="",
             data={},
         )
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -21,6 +21,7 @@ from ghga_event_schemas.pydantic_ import UploadBoxState
 from pydantic import UUID4, BaseModel, ConfigDict, Field, PositiveInt, model_validator
 
 from ucs.constants import MAX_PART_SIZE, MIN_PART_SIZE
+from ucs.core.models import FileUpload
 
 
 class BoxCreationRequest(BaseModel):
@@ -213,3 +214,10 @@ class DeleteFileBoxWorkOrder(BaseWorkOrderToken[Literal["delete_box"]]):
     """
 
     box_id: UUID4
+
+
+class BoxUploadsPage(BaseModel):
+    """Paginated response for a box's file uploads."""
+
+    elements: list[FileUpload]
+    total_count: int

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -219,5 +219,5 @@ class DeleteFileBoxWorkOrder(BaseWorkOrderToken[Literal["delete_box"]]):
 class BoxUploadsPage(BaseModel):
     """Paginated response for a box's file uploads."""
 
-    elements: list[FileUpload]
+    items: list[FileUpload]
     total_count: int

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -170,6 +170,13 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpIncompleteUploadsError.get_body_model(),
     },
+    "skipOrLimitInvalid": {
+        "description": (
+            "Exceptions by ID:"
+            + "\n- skipOrLimitInvalid: The skip or limit pagination parameters are invalid."
+        ),
+        "model": http_exceptions.HttpSkipOrLimitInvalidError.get_body_model(),
+    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -319,6 +326,7 @@ async def update_box(  # noqa: C901, PLR0912
     response_description="Paginated list of file uploads for the box",
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
+        status.HTTP_422_UNPROCESSABLE_CONTENT: ERROR_RESPONSES["skipOrLimitInvalid"],
     },
 )
 @TRACER.start_as_current_span("routes.get_box_uploads")
@@ -345,6 +353,8 @@ async def get_box_uploads(
         )
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error
+    except UploadControllerPort.PaginationError as error:
+        raise http_exceptions.HttpSkipOrLimitInvalidError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -28,7 +28,6 @@ from ucs.adapters.inbound.fastapi_ import (
     rest_models,
 )
 from ucs.constants import TRACER
-from ucs.core.models import FileUpload
 from ucs.ports.inbound.controller import UploadControllerPort
 
 router = APIRouter(tags=["UploadControllerService"])
@@ -316,8 +315,8 @@ async def update_box(  # noqa: C901, PLR0912
     summary="Retrieve list of file IDs for box",
     operation_id="getBoxUploads",
     status_code=status.HTTP_200_OK,
-    response_model=list[FileUpload],
-    response_description="List of file IDs for completed uploads in the box",
+    response_model=rest_models.BoxUploadsPage,
+    response_description="Paginated list of file uploads for the box",
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
     },
@@ -330,24 +329,27 @@ async def get_box_uploads(
         http_authorization.require_view_file_box_work_order,
     ],
     upload_controller: dummies.UploadControllerDummy,
-) -> list[FileUpload]:
-    """Retrieve list of FileUploads for a FileUploadBox.
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=0, le=100)] = 50,
+) -> rest_models.BoxUploadsPage:
+    """Retrieve a paginated list of FileUploads for a FileUploadBox.
 
-    Returns the list of FileUploads for completed uploads in the specified box.
     Requires ViewFileBoxWorkOrder token from the RS.
     """
     if work_order.box_id != box_id:
         raise http_exceptions.HttpNotAuthorizedError()
 
     try:
-        file_uploads = await upload_controller.get_box_file_info(box_id=box_id)
+        file_uploads, total_count = await upload_controller.get_box_file_info(
+            box_id=box_id, skip=skip, limit=limit
+        )
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error
 
-    return file_uploads
+    return rest_models.BoxUploadsPage(elements=file_uploads, total_count=total_count)
 
 
 @router.post(

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -170,13 +170,6 @@ ERROR_RESPONSES = {
         ),
         "model": http_exceptions.HttpIncompleteUploadsError.get_body_model(),
     },
-    "skipOrLimitInvalid": {
-        "description": (
-            "Exceptions by ID:"
-            + "\n- skipOrLimitInvalid: The skip or limit pagination parameters are invalid."
-        ),
-        "model": http_exceptions.HttpSkipOrLimitInvalidError.get_body_model(),
-    },
 }
 
 # For the update_box endpoint, map the work type required to change to a given box state
@@ -319,14 +312,13 @@ async def update_box(  # noqa: C901, PLR0912
 
 @router.get(
     "/boxes/{box_id}/uploads",
-    summary="Retrieve list of file IDs for box",
+    summary="Retrieve a paginated list of file uploads for the given box",
     operation_id="getBoxUploads",
     status_code=status.HTTP_200_OK,
     response_model=rest_models.BoxUploadsPage,
     response_description="Paginated list of file uploads for the box",
     responses={
         status.HTTP_404_NOT_FOUND: ERROR_RESPONSES["boxNotFound"],
-        status.HTTP_422_UNPROCESSABLE_CONTENT: ERROR_RESPONSES["skipOrLimitInvalid"],
     },
 )
 @TRACER.start_as_current_span("routes.get_box_uploads")
@@ -354,7 +346,7 @@ async def get_box_uploads(
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error
     except UploadControllerPort.PaginationError as error:
-        raise http_exceptions.HttpSkipOrLimitInvalidError() from error
+        raise http_exceptions.HttpPaginationError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -349,7 +349,7 @@ async def get_box_uploads(
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error
 
-    return rest_models.BoxUploadsPage(elements=file_uploads, total_count=total_count)
+    return rest_models.BoxUploadsPage(items=file_uploads, total_count=total_count)
 
 
 @router.post(

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1135,6 +1135,7 @@ class UploadController(UploadControllerPort):
         """Return a page of FileUploads for a FileUploadBox, sorted by alias.
 
         Raises:
+        - `PaginationError` if skip and/or limit are invalid.
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         """
         try:
@@ -1144,12 +1145,16 @@ class UploadController(UploadControllerPort):
             log.error(error)
             raise error from err
 
-        find_result = self._file_upload_dao.find_all(
-            mapping={"box_id": box_id},
-            skip=skip,
-            limit=limit,
-            sort=["alias"],
-        )
+        try:
+            find_result = self._file_upload_dao.find_all(
+                mapping={"box_id": box_id},
+                skip=skip,
+                limit=limit,
+                sort=["alias"],
+            )
+        except ValueError as err:
+            raise self.PaginationError() from err
+
         file_uploads = [x async for x in find_result]
         total_count = await find_result.total_count()
         return file_uploads, total_count

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1129,26 +1129,30 @@ class UploadController(UploadControllerPort):
         await self._file_upload_box_dao.update(box)
         log.info("Archived box with ID %s", box_id)
 
-    async def get_box_file_info(self, *, box_id: UUID4) -> list[FileUpload]:
-        """Return the list of FileUploads for a FileUploadBox, sorted by alias.
+    async def get_box_file_info(
+        self, *, box_id: UUID4, skip: int = 0, limit: int | None = None
+    ) -> tuple[list[FileUpload], int]:
+        """Return a page of FileUploads for a FileUploadBox, sorted by alias.
 
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         """
         try:
-            # assert the box exists
             _ = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
             error = self.BoxNotFoundError(box_id=box_id)
             log.error(error)
             raise error from err
 
-        # Box exists, now get all file uploads
-        file_uploads = [
-            x async for x in self._file_upload_dao.find_all(mapping={"box_id": box_id})
-        ]
-        file_uploads.sort(key=lambda x: x.alias)
-        return file_uploads
+        find_result = self._file_upload_dao.find_all(
+            mapping={"box_id": box_id},
+            skip=skip,
+            limit=limit,
+            sort=["alias"],
+        )
+        file_uploads = [x async for x in find_result]
+        total_count = await find_result.total_count()
+        return file_uploads, total_count
 
     async def process_interrogation_success(
         self, *, report: InterrogationSuccess

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -250,6 +250,9 @@ class UploadControllerPort(ABC):
             )
             super().__init__(msg)
 
+    class PaginationError(RuntimeError):
+        """Raised when pagination parameters, such as skip and limit, are invalid"""
+
     @abstractmethod
     async def initiate_file_upload(
         self,
@@ -453,6 +456,7 @@ class UploadControllerPort(ABC):
         """Return a page of FileUploads for a FileUploadBox, sorted by alias.
 
         Raises:
+        - `PaginationError` if skip and/or limit are invalid.
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         """
         ...

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -447,8 +447,10 @@ class UploadControllerPort(ABC):
         ...
 
     @abstractmethod
-    async def get_box_file_info(self, *, box_id: UUID4) -> list[FileUpload]:
-        """Return the list of FileUploads for a FileUploadBox, sorted by alias.
+    async def get_box_file_info(
+        self, *, box_id: UUID4, skip: int = 0, limit: int | None = None
+    ) -> tuple[list[FileUpload], int]:
+        """Return a page of FileUploads for a FileUploadBox, sorted by alias.
 
         Raises:
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -597,7 +597,7 @@ async def test_update_box_max_size_below_current_error_handling(
         ),
         (
             UploadControllerPort.PaginationError(),
-            http_exceptions.HttpSkipOrLimitInvalidError(),
+            http_exceptions.HttpPaginationError(),
         ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -595,9 +595,13 @@ async def test_update_box_max_size_below_current_error_handling(
             UploadControllerPort.BoxNotFoundError(box_id=TEST_BOX_ID),
             http_exceptions.HttpBoxNotFoundError(box_id=TEST_BOX_ID),
         ),
+        (
+            UploadControllerPort.PaginationError(),
+            http_exceptions.HttpSkipOrLimitInvalidError(),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
-    ids=["BoxNotFound", "InternalError"],
+    ids=["BoxNotFound", "PaginationError", "InternalError"],
 )
 async def test_view_box_endpoint_error_handling(
     config: ConfigFixture,

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -181,7 +181,7 @@ async def test_view_box_endpoint_auth(config: ConfigFixture, app_fixture: AppFix
     response = await rest_client.get(url, headers=good_token_header)
     assert response.status_code == 200
     body = response.json()
-    assert body["elements"] == []
+    assert body["items"] == []
     assert body["total_count"] == 0
 
 
@@ -211,9 +211,9 @@ async def test_get_box_uploads_response_format(
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 5
-    assert len(body["elements"]) == 2
-    assert body["elements"][0]["alias"] == "test0.bam"
-    assert body["elements"][1]["alias"] == "test1.vcf"
+    assert len(body["items"]) == 2
+    assert body["items"][0]["alias"] == "test0.bam"
+    assert body["items"][1]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
         box_id=TEST_BOX_ID, skip=0, limit=50
     )
@@ -226,8 +226,8 @@ async def test_get_box_uploads_response_format(
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 5
-    assert len(body["elements"]) == 1
-    assert body["elements"][0]["alias"] == "test1.vcf"
+    assert len(body["items"]) == 1
+    assert body["items"][0]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(box_id=TEST_BOX_ID, skip=3, limit=1)
 
     # skip beyond all results  controller returns empty page but preserves total_count
@@ -236,7 +236,7 @@ async def test_get_box_uploads_response_format(
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 5
-    assert body["elements"] == []
+    assert body["items"] == []
 
 
 async def test_get_box_uploads_invalid_params(

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -197,7 +197,7 @@ async def test_get_box_uploads_response_format(
     token_header = utils.view_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
     url = f"/boxes/{TEST_BOX_ID}/uploads"
 
-    # Create two file uploads with different aliases
+    # Build two mock file uploads with different aliases
     file_upload_a = utils.make_file_upload(file_id=TEST_FILE_ID)
     file_upload_a.alias = "test0.bam"
     file_upload_a.box_id = TEST_BOX_ID

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -158,6 +158,8 @@ async def test_view_box_endpoint_auth(config: ConfigFixture, app_fixture: AppFix
     """
     rs_jwk = config.rs_jwk
     rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.get_box_file_info.return_value = ([], 0)
 
     url = f"/boxes/{TEST_BOX_ID}/uploads"
     response = await rest_client.get(url)
@@ -178,6 +180,87 @@ async def test_view_box_endpoint_auth(config: ConfigFixture, app_fixture: AppFix
     good_token_header = utils.view_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
     response = await rest_client.get(url, headers=good_token_header)
     assert response.status_code == 200
+    body = response.json()
+    assert body["elements"] == []
+    assert body["total_count"] == 0
+
+
+async def test_get_box_uploads_response_format(
+    config: ConfigFixture, app_fixture: AppFixture
+):
+    """Test that the endpoint returns the correct paginated response shape and
+    forwards skip/limit query parameters to the controller correctly.
+    """
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    token_header = utils.view_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
+    url = f"/boxes/{TEST_BOX_ID}/uploads"
+
+    # Create two file uploads with different aliases
+    file_upload_a = utils.make_file_upload(file_id=TEST_FILE_ID)
+    file_upload_a.alias = "test0.bam"
+    file_upload_a.box_id = TEST_BOX_ID
+    file_upload_b = utils.make_file_upload()
+    file_upload_b.alias = "test1.vcf"
+    file_upload_b.box_id = TEST_BOX_ID
+
+    # Test with default parameters (no skip/limit in query string)
+    core_mock.get_box_file_info.return_value = ([file_upload_a, file_upload_b], 5)
+    response = await rest_client.get(url, headers=token_header)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 5
+    assert len(body["elements"]) == 2
+    assert body["elements"][0]["alias"] == "test0.bam"
+    assert body["elements"][1]["alias"] == "test1.vcf"
+    core_mock.get_box_file_info.assert_awaited_with(
+        box_id=TEST_BOX_ID, skip=0, limit=50
+    )
+
+    # Test with skip and limit parameters explicitly set
+    core_mock.get_box_file_info.return_value = ([file_upload_b], 5)
+    response = await rest_client.get(
+        url, params={"skip": 3, "limit": 1}, headers=token_header
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 5
+    assert len(body["elements"]) == 1
+    assert body["elements"][0]["alias"] == "test1.vcf"
+    core_mock.get_box_file_info.assert_awaited_with(box_id=TEST_BOX_ID, skip=3, limit=1)
+
+    # skip beyond all results  controller returns empty page but preserves total_count
+    core_mock.get_box_file_info.return_value = ([], 5)
+    response = await rest_client.get(url, params={"skip": 100}, headers=token_header)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 5
+    assert body["elements"] == []
+
+
+async def test_get_box_uploads_invalid_params(
+    config: ConfigFixture, app_fixture: AppFixture
+):
+    """Test that invalid skip/limit query parameters are rejected with 422."""
+    rs_jwk = config.rs_jwk
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.get_box_file_info.return_value = ([], 0)
+    token_header = utils.view_file_box_token_header(jwk=rs_jwk, box_id=TEST_BOX_ID)
+    url = f"/boxes/{TEST_BOX_ID}/uploads"
+
+    # skip must be >= 0
+    response = await rest_client.get(url, params={"skip": -1}, headers=token_header)
+    assert response.status_code == 422
+
+    # limit must be <= 100
+    response = await rest_client.get(url, params={"limit": 101}, headers=token_header)
+    assert response.status_code == 422
+
+    # limit must also be >=0
+    response = await rest_client.get(url, params={"limit": -1}, headers=token_header)
+    assert response.status_code == 422
 
 
 async def test_create_file_upload_endpoint_auth(

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -408,19 +408,22 @@ async def test_get_box_uploads(rig: JointRig):
     empty_box_id = await rig.create_default_box()
 
     # Get the file uploads for the first box - should be sorted by alias
-    results = await controller.get_box_file_info(box_id=box_id)
-    assert len(results) == 3
-    assert [r.alias for r in results] == ["file0", "file1", "file2"]
-    assert all(r.id in file_ids for r in results)
+    file_uploads, total_count = await controller.get_box_file_info(box_id=box_id)
+    assert len(file_uploads) == 3
+    assert total_count == 3
+    assert [r.alias for r in file_uploads] == ["file0", "file1", "file2"]
+    assert all(r.id in file_ids for r in file_uploads)
 
     # Verify the other box returns only its own files
-    other_results = await controller.get_box_file_info(box_id=other_box_id)
-    assert len(other_results) == 2
-    assert all(r.id in other_file_ids for r in other_results)
+    other_uploads, other_total = await controller.get_box_file_info(box_id=other_box_id)
+    assert len(other_uploads) == 2
+    assert other_total == 2
+    assert all(r.id in other_file_ids for r in other_uploads)
 
     # Verify that we get an empty list for the third box
-    no_ids = await controller.get_box_file_info(box_id=empty_box_id)
-    assert no_ids == []
+    empty_uploads, empty_total = await controller.get_box_file_info(box_id=empty_box_id)
+    assert empty_uploads == []
+    assert empty_total == 0
 
 
 async def test_get_box_uploads_retrieves_all_states(rig: JointRig):
@@ -458,8 +461,9 @@ async def test_get_box_uploads_retrieves_all_states(rig: JointRig):
         )
         await rig.file_upload_dao.insert(file_upload)
 
-    files = await rig.controller.get_box_file_info(box_id=box_id)
+    files, total = await rig.controller.get_box_file_info(box_id=box_id)
     assert [f.alias for f in files] == states
+    assert total == len(states)
 
 
 async def test_create_box_with_unknown_storage_alias(rig: JointRig):

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1126,6 +1126,15 @@ async def test_get_file_ids_for_non_existent_box(rig: JointRig):
         await rig.controller.get_box_file_info(box_id=uuid4())
 
 
+async def test_get_box_file_info_pagination_error(
+    rig: JointRig, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that a ValueError raised by the DAO's find_all is translated to PaginationError."""
+    box_id = await rig.create_default_box()
+    with pytest.raises(UploadControllerPort.PaginationError):
+        await rig.controller.get_box_file_info(box_id=box_id, skip=-1)
+
+
 async def test_process_interrogation_success_no_file_upload(rig: JointRig):
     """Test the alt case where the file upload doesn't exist."""
     non_existent_file_id = uuid4()


### PR DESCRIPTION
Since boxes can potentially contain thousands of files, there needs to be a way to limit how many files UCS returns at once. To that end, this PR adds pagination to the GET endpoint which lists file uploads in a given box.

Bumps UCS version to `15.0.0` and the monorepo version to `16.0.0`.