### PR TITLE
Make upload rejection messages INFO and operator-oriented (GSI-2462)

### DIFF
--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -114,7 +114,7 @@ class HttpFileUploadAlreadyExistsError(HttpCustomExceptionBase):
         super().__init__(
             status_code=status_code,
             description=(
-                f"Failed to create a FileUpload for the alias {alias} because"
+                f"Rejected upload initiation for the alias {alias} because"
                 + " another one with the same alias already exists."
             ),
             data={"alias": alias},
@@ -351,8 +351,9 @@ class HttpTooManyOpenUploadsError(HttpCustomExceptionBase):
         super().__init__(
             status_code=status_code,
             description=(
-                f"Box {box_id} already has {max_concurrent} in-progress upload(s)."
-                + " Cancel or complete an existing upload before starting another."
+                f"Rejected upload initiation against box {box_id} because"
+                f" {max_concurrent} concurrent uploads are already in progress."
+                " Cancel or complete an existing upload before starting another."
             ),
             data={"box_id": str(box_id), "max_concurrent": max_concurrent},
         )

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -180,8 +180,7 @@ class HttpUploadCompletionError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description="An error occurred while completing the file upload. Delete the"
-            + " file from the file upload box and retry.",
+            description="",
             data={"box_id": str(box_id), "file_id": str(file_id)},
         )
 
@@ -195,7 +194,7 @@ class HttpUploadAbortError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description="An error occurred while canceling the file upload.",
+            description="",
             data={},
         )
 

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -29,7 +29,7 @@ class HttpUnknownStorageAliasError(HttpCustomExceptionBase):
         """Construct message and initialize exception"""
         super().__init__(
             status_code=status_code,
-            description=("There was a problem identifying the storage alias."),
+            description="",
             data={},
         )
 
@@ -48,7 +48,7 @@ class HttpBoxNotFoundError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(f"FileUploadBox with ID {box_id} not found."),
+            description="",
             data={"box_id": str(box_id)},
         )
 
@@ -70,10 +70,7 @@ class HttpBoxStateError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Can't perform this action because the box with ID {box_id} is"
-                + f" {box_state}."
-            ),
+            description="",
             data={"box_id": str(box_id), "box_state": box_state},
         )
 
@@ -92,9 +89,7 @@ class HttpBoxVersionError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Requested version of FileUploadBox with ID {box_id} is outdated."
-            ),
+            description="",
             data={"box_id": str(box_id)},
         )
 
@@ -113,10 +108,7 @@ class HttpFileUploadAlreadyExistsError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Rejected upload initiation for the alias {alias} because"
-                + " another one with the same alias already exists."
-            ),
+            description="",
             data={"alias": alias},
         )
 
@@ -135,11 +127,7 @@ class HttpOrphanedMultipartUploadError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"A multipart upload is already in progress for file {file_alias}, but"
-                + " cannot be aborted due to a system error. Please request file"
-                + " deletion and then attempt the upload again."
-            ),
+            description="",
             data={"file_alias": file_alias},
         )
 
@@ -153,7 +141,7 @@ class HttpS3UploadNotFoundError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description="S3 multipart upload not found.",
+            description="",
             data={},
         )
 
@@ -172,7 +160,7 @@ class HttpFileUploadNotFoundError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(f"FileUpload with ID {file_id} not found."),
+            description="",
             data={"file_id": str(file_id)},
         )
 
@@ -226,10 +214,7 @@ class HttpChecksumMismatchError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"The checksum supplied for file {file_id} doesn't match the value"
-                + " calculated by S3."
-            ),
+            description="",
             data={"file_id": str(file_id)},
         )
 
@@ -248,10 +233,7 @@ class HttpUploadSizeMismatchError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"The actual size of the uploaded object for file {file_id}"
-                + " doesn't match the declared encrypted_size."
-            ),
+            description="",
             data={"file_id": str(file_id)},
         )
 
@@ -279,10 +261,7 @@ class HttpMaxSizeTooLowError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Cannot set max_size to {max_size} for box {box_id} because"
-                f" {current_size} bytes are already committed."
-            ),
+            description="",
             data={
                 "box_id": str(box_id),
                 "max_size": max_size,
@@ -316,10 +295,7 @@ class HttpBoxMaxSizeExceededError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Cannot add the file {file_alias} because it would exceed the maximum"
-                + " total size limit allowed for the box."
-            ),
+            description="",
             data={
                 "box_id": str(box_id),
                 "max_size": max_size,
@@ -350,11 +326,7 @@ class HttpTooManyOpenUploadsError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Rejected upload initiation against box {box_id} because"
-                f" {max_concurrent} concurrent uploads are already in progress."
-                " Cancel or complete an existing upload before starting another."
-            ),
+            description="",
             data={"box_id": str(box_id), "max_concurrent": max_concurrent},
         )
 
@@ -374,11 +346,7 @@ class HttpPartSizeError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"The part size {part_size} for file '{file_alias}' is invalid."
-                + " It must be between 5 MiB and 5 GiB and no less than 1/10000th of"
-                + " the total file size."
-            ),
+            description="",
             data={"file_alias": file_alias, "part_size": part_size},
         )
 
@@ -404,10 +372,7 @@ class HttpIncompleteUploadsError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"Cannot lock or archive box {box_id} because"
-                f" {len(file_ids)} incomplete upload(s) exist."
-            ),
+            description="",
             data={
                 "box_id": str(box_id),
                 "file_ids": [[str(fid), alias] for fid, alias in file_ids],
@@ -429,10 +394,7 @@ class HttpFileUploadStateError(HttpCustomExceptionBase):
         """Construct message and init the exception."""
         super().__init__(
             status_code=status_code,
-            description=(
-                f"The requested action cannot be performed on FileUpload {file_id}"
-                " in its current state."
-            ),
+            description="",
             data={"file_id": str(file_id)},
         )
 

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -165,7 +165,7 @@ class UploadController(UploadControllerPort):
             #  cancellation/removal before a new upload can be started for this alias.
             if not replaced:
                 error = self.FileUploadAlreadyExists(alias=alias)
-                log.error(error, extra=logging_extras)
+                log.info(error, extra=logging_extras)  # intentionally set to INFO
                 raise error from None  # don't need Unique* error in the trace
         except Exception as err:
             # This branch handles all other errors that *don't* signify an existing file
@@ -392,7 +392,7 @@ class UploadController(UploadControllerPort):
             error = self.TooManyOpenUploadsError(
                 box_id=box.id, max_concurrent=max_concurrent
             )
-            log.error(error, extra=extra)
+            log.info(error, extra=extra)  # intentionally set to INFO
             raise error
 
         # Ensure file size doesn't exceed box limit

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1175,7 +1175,7 @@ class UploadController(UploadControllerPort):
             old_file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.warning(error, extra={"file_id": file_id})
+            log.error(error, extra={"file_id": file_id})
             raise error from err
 
         match old_file_upload.state:
@@ -1227,7 +1227,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.warning(error, extra={"file_id": file_id})
+            log.error(error, extra={"file_id": file_id})
             raise error from err
 
         match file_upload.state:
@@ -1267,7 +1267,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.warning(error, extra={"file_id": file_id})
+            log.error(error, extra={"file_id": file_id})
             raise error from err
 
         if file_upload.state == "archived":

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -88,12 +88,12 @@ class UploadController(UploadControllerPort):
             box = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
             error = self.BoxNotFoundError(box_id=box_id)
-            log.error(error)
+            log.info(error)
             raise error from err
 
         if box.version != version:
             error = self.BoxVersionError(box_id=box_id)
-            log.error(error, extra={"box_id": box_id, "version": version})
+            log.info(error, extra={"box_id": box_id, "version": version})
             raise error
 
         return box
@@ -267,13 +267,13 @@ class UploadController(UploadControllerPort):
             box = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
             error = self.BoxNotFoundError(box_id=box_id)
-            log.error(error)
+            log.info(error)
             raise error from err
 
         # Verify that the box is not locked or archived
         if box.state != "open":
             error = self.BoxStateError(box_id=box_id, box_state=box.state)
-            log.error(error)
+            log.info(error)
             raise error
 
         return box
@@ -400,7 +400,7 @@ class UploadController(UploadControllerPort):
             error = self.BoxMaxSizeExceededError(
                 box_id=box.id, max_size=box.max_size, current_size=current_size
             )
-            log.error(error, extra=extra)
+            log.info(error, extra=extra)
             raise error
 
         # Ensure part size is okay - verify size & implied part count. Min and Max part
@@ -497,7 +497,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(
+            log.info(
                 error,
                 extra={"file_id": file_id, "part_no": part_no},
             )
@@ -592,7 +592,7 @@ class UploadController(UploadControllerPort):
                 "expected_checksum": expected_checksum,
                 "actual_checksum": actual_checksum,
             }
-            log.error(error, extra=extra)
+            log.info(error, extra=extra)
             raise error
 
     async def _verify_object_size(self, *, file_upload: FileUpload) -> None:
@@ -626,7 +626,7 @@ class UploadController(UploadControllerPort):
             file_upload.failure_reason = "Actual object size didn't match expected size"
             await self._file_upload_dao.update(file_upload)
             error = self.UploadSizeMismatchError(file_id=file_id)
-            log.error(
+            log.info(
                 error,
                 extra={
                     "bucket_id": file_upload.bucket_id,
@@ -672,7 +672,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(error, extra=extra)
+            log.info(error, extra=extra)
             raise error from err
 
         if file_upload.state in ("cancelled", "failed"):
@@ -680,7 +680,7 @@ class UploadController(UploadControllerPort):
                 file_id=file_id,
                 details=f"Cannot complete a FileUpload in the '{file_upload.state}' state.",
             )
-            log.error(error, extra=extra)
+            log.info(error, extra=extra)
             raise error
 
         # Exit early if the FileUpload is complete (already in the inbox or archived)
@@ -753,7 +753,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(error)
+            log.info(error)
             raise error from err
 
         # Remove the file from S3 only if it's still in the inbox state. After that
@@ -808,19 +808,19 @@ class UploadController(UploadControllerPort):
             box = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
             error = self.BoxNotFoundError(box_id=box_id)
-            log.error(error)
+            log.info(error)
             raise error from err
 
         # Verify the version
         if version is not None and box.version != version:
             error = self.BoxVersionError(box_id=box_id)
-            log.error(error, extra={"box_id": box_id, "version": version})
+            log.info(error, extra={"box_id": box_id, "version": version})
             raise error
 
         # Raise an error if the box is archived
         if box.state == "archived":
             error = self.BoxStateError(box_id=box_id, box_state=box.state)
-            log.error(error)
+            log.info(error)
             raise error
 
         # Lock the box so no new uploads can be initiated while sweeping
@@ -981,7 +981,7 @@ class UploadController(UploadControllerPort):
             error = self.BoxMaxSizeTooLowError(
                 box_id=box_id, max_size=max_size, current_size=box.size
             )
-            log.error(error, extra={"box_id": box_id, "max_size": max_size})
+            log.info(error, extra={"box_id": box_id, "max_size": max_size})
             raise error
 
         box.version += 1
@@ -1035,7 +1035,7 @@ class UploadController(UploadControllerPort):
             )
             if file_ids:
                 error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
-                log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
+                log.info(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
                 raise error
 
         box.version += 1
@@ -1059,7 +1059,7 @@ class UploadController(UploadControllerPort):
             await self._file_upload_box_dao.update(box)
             log.info("Unlocked box with ID %s", box_id)
         elif box.state == "archived":
-            log.error("Can't unlock box %s because it's already archived.", box_id)
+            log.info("Can't unlock box %s because it's already archived.", box_id)
             raise self.BoxStateError(box_id=box_id, box_state=box.state)
         else:
             log.info("Box with ID %s is already unlocked", box_id)
@@ -1081,7 +1081,7 @@ class UploadController(UploadControllerPort):
             log.info("Box with ID %s is already archived", box_id)
             return
         elif box.state == "open":
-            log.error("Can't unlock box %s because it's still open.", box_id)
+            log.info("Can't unlock box %s because it's still open.", box_id)
             raise self.BoxStateError(box_id=box_id, box_state=box.state)
 
         # Scan for incomplete files
@@ -1094,7 +1094,7 @@ class UploadController(UploadControllerPort):
         )
         if file_ids:
             error = self.IncompleteUploadsError(box_id=box_id, file_ids=file_ids)
-            log.error(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
+            log.info(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
             raise error
 
         # Verify that all files are in state 'interrogated' or 'awaiting_archival'.
@@ -1142,7 +1142,7 @@ class UploadController(UploadControllerPort):
             _ = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
             error = self.BoxNotFoundError(box_id=box_id)
-            log.error(error)
+            log.info(error)
             raise error from err
 
         try:
@@ -1175,7 +1175,7 @@ class UploadController(UploadControllerPort):
             old_file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(error, extra={"file_id": file_id})
+            log.warning(error, extra={"file_id": file_id})
             raise error from err
 
         match old_file_upload.state:
@@ -1227,7 +1227,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(error, extra={"file_id": file_id})
+            log.warning(error, extra={"file_id": file_id})
             raise error from err
 
         match file_upload.state:
@@ -1267,7 +1267,7 @@ class UploadController(UploadControllerPort):
             file_upload = await self._file_upload_dao.get_by_id(file_id)
         except ResourceNotFoundError as err:
             error = self.FileUploadNotFound(file_id=file_id)
-            log.error(error, extra={"file_id": file_id})
+            log.warning(error, extra={"file_id": file_id})
             raise error from err
 
         if file_upload.state == "archived":

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -179,7 +179,8 @@ class UploadControllerPort(ABC):
         def __init__(self, *, box_id: UUID4, max_concurrent: int):
             self.max_concurrent = max_concurrent
             msg = (
-                f"Box {box_id} already has {max_concurrent} in-progress upload(s)."
+                f"Rejected upload initiation against box {box_id} because"
+                f" {max_concurrent} concurrent uploads are already in progress."
                 " Cancel or complete an existing upload before starting another."
             )
             super().__init__(msg)
@@ -201,7 +202,7 @@ class UploadControllerPort(ABC):
 
         def __init__(self, *, alias: str):
             msg = (
-                f"Failed to create a FileUpload for file alias {alias} because"
+                f"Rejected upload initiation for file alias {alias} because"
                 + " one already exists."
             )
             super().__init__(msg)


### PR DESCRIPTION
This addresses feedback regarding log messages for upload rejections. When a box already has the max allowed simultaneous uploads, or when an upload for a given alias already exists, the logs were recorded at ERROR and started with `"Failed to create an upload for..."`. This PR changes the log level to INFO and rephrases the messages to sound more active and direct: `"Rejected upload initiation for..."`

The version is not bumped for either UCS or the monorepo because a currently open PR already makes those changes.