### PR TITLE
UCS: Add overwrite option for file uploads to replace active uploads (GSI-2460)

### DIFF
--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -252,6 +252,14 @@ components:
           minimum: 1.0
           title: Encrypted Size
           type: integer
+        overwrite:
+          default: false
+          description: If True and a FileUpload for this alias already exists in an
+            active state (init or inbox), cancel and replace it atomically. Has no
+            effect on already-failed or already-cancelled uploads. Uploads in interrogated,
+            awaiting_archival, or archived state cannot be overwritten.
+          title: Overwrite
+          type: boolean
         part_size:
           description: The number of bytes in each file part (last part may be smaller)
           exclusiveMinimum: 0.0

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -87,6 +87,16 @@ class FileUploadCreationRequest(BaseModel):
         ge=MIN_PART_SIZE,
         le=MAX_PART_SIZE,
     )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "If True and a FileUpload for this alias already exists in an active state"
+            " (init or inbox), cancel and replace it atomically. Has no effect on"
+            " already-failed or already-cancelled uploads."
+            " Uploads in interrogated, awaiting_archival, or archived state cannot be"
+            " overwritten."
+        ),
+    )
 
     @model_validator(mode="after")
     def encrypted_size_exceeds_decrypted_size(self) -> "FileUploadCreationRequest":

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -402,6 +402,7 @@ async def create_file_upload(  # noqa: C901
             decrypted_size=file_upload_creation.decrypted_size,
             encrypted_size=file_upload_creation.encrypted_size,
             part_size=file_upload_creation.part_size,
+            overwrite=file_upload_creation.overwrite,
         )
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -340,7 +340,7 @@ class UploadController(UploadControllerPort):
         except S3ClientPort.S3OperationError as err:
             raise self.S3OperationError(details=str(err)) from err
 
-    async def initiate_file_upload(
+    async def initiate_file_upload(  # noqa: C901, PLR0913, PLR0915
         self,
         *,
         box_id: UUID4,
@@ -348,21 +348,30 @@ class UploadController(UploadControllerPort):
         decrypted_size: int,
         encrypted_size: int,
         part_size: int,
+        overwrite: bool = False,
     ) -> tuple[UUID4, str]:
         """Initialize a new multipart upload.
 
         Returns the file ID and storage alias as a 2-tuple.
+
+        If `overwrite` is True and an active FileUpload (in 'init' or 'inbox' state)
+        already exists for this alias, it will be cancelled/aborted before the new
+        upload is created. Uploads in 'interrogated', 'awaiting_archival', or 'archived'
+        state cannot be overwritten and will still raise `FileUploadAlreadyExists`.
 
         Raises:
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxMaxSizeExceededError` if adding the file would exceed the box's size limit.
         - `TooManyOpenUploadsError` if the box is already at the concurrent upload limit.
-        - `FileUploadAlreadyExists` if there's already a FileUpload for this alias.
+        - `FileUploadAlreadyExists` if there's already a FileUpload for this alias that
+            cannot be overwritten.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAlreadyInProgressError` if an upload is already in progress.
         - `PartSizeError` if the specified part size would results in more
             parts than S3 allows, or is smaller or larger than what S3 allows.
+        - `BucketMissingError` if the configured bucket does not exist in S3.
+        - `S3OperationError` if S3 returns any other unexpected error.
         """
         extra: dict[str, Any] = {"box_id": box_id, "alias": alias}
         # Get the box and resolve S3 storage details
@@ -376,6 +385,22 @@ class UploadController(UploadControllerPort):
             raise self.UnknownStorageAliasError(storage_alias=storage_alias) from err
         extra["storage_alias"] = storage_alias
         extra["bucket_id"] = bucket_id
+
+        # If overwrite is requested, cancel any active upload for this alias before
+        # re-deriving size/count. 'failed'/'cancelled' states are handled later by
+        # _insert_file_upload; only 'init'/'inbox' need explicit cancellation here.
+        if overwrite:
+            try:
+                existing_upload = await self._file_upload_dao.find_one(
+                    mapping={"box_id": box_id, "alias": alias}
+                )
+            except NoHitsFoundError:
+                existing_upload = None
+
+            if existing_upload and existing_upload.state in ("init", "inbox"):
+                await self.remove_file_upload(box_id=box_id, file_id=existing_upload.id)
+                # Re-fetch box to get the updated size/file count
+                box = await self._get_unlocked_box(box_id=box_id)
 
         # Get both box size + in progress size and the number of in progress files
         current_size = box.size

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -255,7 +255,7 @@ class UploadControllerPort(ABC):
         """Raised when pagination parameters, such as skip and limit, are invalid"""
 
     @abstractmethod
-    async def initiate_file_upload(
+    async def initiate_file_upload(  # noqa: PLR0913
         self,
         *,
         box_id: UUID4,
@@ -263,17 +263,24 @@ class UploadControllerPort(ABC):
         decrypted_size: int,
         encrypted_size: int,
         part_size: int,
+        overwrite: bool = False,
     ) -> tuple[UUID4, str]:
         """Initialize a new multipart upload.
 
         Returns the file ID and storage alias as a 2-tuple.
+
+        If `overwrite` is True and an active FileUpload (in 'init' or 'inbox' state)
+        already exists for this alias, it will be cancelled/aborted before the new
+        upload is created. Uploads in 'interrogated', 'awaiting_archival', or 'archived'
+        state cannot be overwritten and will still raise `FileUploadAlreadyExists`.
 
         Raises:
         - `BoxNotFoundError` if the box does not exist.
         - `BoxStateError` if the box exists but is locked.
         - `BoxMaxSizeExceededError` if adding the file would exceed the box's size limit.
         - `TooManyOpenUploadsError` if the box is already at the concurrent upload limit.
-        - `FileUploadAlreadyExists` if there's already a FileUpload for this alias.
+        - `FileUploadAlreadyExists` if there's already a FileUpload for this alias that
+            cannot be overwritten.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAlreadyInProgressError` if an upload is already in progress.
         - `PartSizeError` if the specified part size would results in more

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -322,6 +322,40 @@ async def test_create_file_upload_endpoint_auth(
     }
 
 
+@pytest.mark.parametrize("overwrite", [True, False])
+async def test_create_file_upload_passes_overwrite_to_core(
+    config: ConfigFixture, app_fixture: AppFixture, overwrite: bool
+):
+    """Test that the overwrite field from the request body is forwarded to the core."""
+    wps_jwk = config.wps_jwk
+    core_mock = app_fixture.core_mock
+    core_mock.initiate_file_upload.return_value = (TEST_FILE_ID, "HD01")
+
+    body = {
+        "alias": "test_file",
+        "decrypted_size": utils.DECRYPTED_SIZE,
+        "encrypted_size": utils.ENCRYPTED_SIZE,
+        "part_size": utils.PART_SIZE,
+        "overwrite": overwrite,
+    }
+    good_token_header = utils.create_file_token_header(
+        box_id=TEST_BOX_ID, alias="test_file", jwk=wps_jwk
+    )
+    response = await app_fixture.rest_client.post(
+        f"/boxes/{TEST_BOX_ID}/uploads", json=body, headers=good_token_header
+    )
+    assert response.status_code == 201
+
+    core_mock.initiate_file_upload.assert_called_once_with(
+        box_id=TEST_BOX_ID,
+        alias="test_file",
+        decrypted_size=utils.DECRYPTED_SIZE,
+        encrypted_size=utils.ENCRYPTED_SIZE,
+        part_size=utils.PART_SIZE,
+        overwrite=overwrite,
+    )
+
+
 async def test_get_file_part_upload_url_endpoint_auth(
     config: ConfigFixture, app_fixture: AppFixture
 ):

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1371,7 +1371,7 @@ async def test_overwrite_cancels_active_upload(
     "state",
     ["interrogated", "awaiting_archival", "archived"],
 )
-async def test_overwrite_blocked_for_terminal_states(
+async def test_overwrite_blocked_for_immutable_states(
     rig: JointRig,
     state: FileUploadState,
 ):
@@ -1415,8 +1415,11 @@ async def test_overwrite_blocked_for_terminal_states(
     assert (await file_upload_dao.get_by_id(file_upload.id)).state == state
 
 
-async def test_overwrite_false_still_blocks_active_upload(rig: JointRig):
-    """With overwrite=False (default), an active 'init' upload still raises
+@pytest.mark.parametrize("state", ["init", "inbox"])
+async def test_overwrite_false_still_blocks_active_upload(
+    rig: JointRig, state: FileUploadState
+):
+    """With overwrite=False (default), an active 'init' or 'inbox' upload still raises
     FileUploadAlreadyExists, confirming overwrite is opt-in.
 
     The InMemDao doesn't enforce compound unique indexes, so we simulate the
@@ -1433,6 +1436,12 @@ async def test_overwrite_false_still_blocks_active_upload(rig: JointRig):
         encrypted_size=ENCRYPTED_SIZE,
         part_size=PART_SIZE,
     )
+
+    if state == "inbox":
+        file_upload = file_upload_dao.latest
+        file_upload.state = "inbox"
+        await file_upload_dao.update(file_upload)
+        assert file_upload_dao.latest.state == "inbox"
 
     # Simulate the compound unique index violation MongoDB would raise on insert
     async def patched_insert(dto):
@@ -1454,7 +1463,7 @@ async def test_overwrite_false_still_blocks_active_upload(rig: JointRig):
 
     # First upload must be untouched and still in 'init'
     upload = await file_upload_dao.get_by_id(file_id_1)
-    assert upload.state == "init"
+    assert upload.state == state
 
 
 @pytest.mark.parametrize(

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -1303,6 +1303,160 @@ async def test_initiate_upload_blocked_for_inbox_state(rig: JointRig):
     assert (await file_upload_dao.get_by_id(file_id_1)).state == "inbox"
 
 
+@pytest.mark.parametrize("state", ["init", "inbox"])
+async def test_overwrite_cancels_active_upload(
+    rig: JointRig,
+    state: FileUploadState,
+):
+    """Test that when overwrite=True, an active FileUpload in 'init' or 'inbox' state is
+    cancelled and replaced by a new one for the same alias without raising an error.
+    """
+    controller = rig.controller
+    file_upload_dao = rig.file_upload_dao
+    bucket_id, object_storage = rig.object_storages.for_alias("test")
+
+    box_id = await rig.create_default_box()
+    file_id_1, _ = await controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+    object_id_1 = str(rig.file_upload_dao.latest.object_id)
+
+    if state == "inbox":
+        await controller.complete_file_upload(
+            box_id=box_id,
+            file_id=file_id_1,
+            unencrypted_checksum="unencrypted_checksum",
+            encrypted_checksum=f"etag_for_{object_id_1}",
+            encrypted_parts_md5=["abc123"],
+            encrypted_parts_sha256=["def456"],
+        )
+        assert (await file_upload_dao.get_by_id(file_id_1)).state == "inbox"
+
+    file_id_2, _ = await controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+        overwrite=True,
+    )
+
+    assert file_id_2 != file_id_1
+
+    # Old upload should be cancelled now
+    old_upload = await file_upload_dao.get_by_id(file_id_1)
+    assert old_upload.state == "cancelled"
+
+    # New upload should be in 'init' state
+    new_upload = await file_upload_dao.get_by_id(file_id_2)
+    assert new_upload.state == "init"
+    assert new_upload.alias == "test_file"
+
+    # S3 resources for the old upload should have been cleaned up
+    if state == "init":
+        assert not await object_storage.list_multipart_uploads_for_object(
+            bucket_id=bucket_id, object_id=object_id_1
+        )
+    else:
+        assert not await object_storage.does_object_exist(
+            bucket_id=bucket_id, object_id=object_id_1
+        )
+
+
+@pytest.mark.parametrize(
+    "state",
+    ["interrogated", "awaiting_archival", "archived"],
+)
+async def test_overwrite_blocked_for_terminal_states(
+    rig: JointRig,
+    state: FileUploadState,
+):
+    """Test that when overwrite=True, uploads in 'interrogated', 'awaiting_archival', or
+    'archived' state cannot be replaced and FileUploadAlreadyExists is raised.
+
+    The InMemDao doesn't enforce compound unique indexes, so we simulate the
+    MongoDB UniqueConstraintViolationError the same way existing idempotence tests do.
+    """
+    controller = rig.controller
+    file_upload_dao = rig.file_upload_dao
+
+    box_id = await rig.create_default_box()
+
+    # Insert a FileUpload directly in the non-overwritable state
+    file_upload = make_file_upload(state=state)
+    file_upload.box_id = box_id
+    file_upload.alias = "test_file"
+    await file_upload_dao.insert(file_upload)
+
+    # Simulate the compound unique index violation MongoDB would raise on insert
+    async def patched_insert(dto):
+        raise UniqueConstraintViolationError(
+            unique_fields={"box_id": str(box_id), "alias": "test_file"}
+        )
+
+    file_upload_dao.insert = patched_insert
+
+    with pytest.raises(UploadControllerPort.FileUploadAlreadyExists):
+        await controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test_file",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=PART_SIZE,
+            overwrite=True,
+        )
+
+    # Original FileUpload must be untouched
+    assert len(file_upload_dao.resources) == 1
+    assert (await file_upload_dao.get_by_id(file_upload.id)).state == state
+
+
+async def test_overwrite_false_still_blocks_active_upload(rig: JointRig):
+    """With overwrite=False (default), an active 'init' upload still raises
+    FileUploadAlreadyExists, confirming overwrite is opt-in.
+
+    The InMemDao doesn't enforce compound unique indexes, so we simulate the
+    MongoDB UniqueConstraintViolationError the same way existing idempotence tests do.
+    """
+    controller = rig.controller
+    file_upload_dao = rig.file_upload_dao
+
+    box_id = await rig.create_default_box()
+    file_id_1, _ = await controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+
+    # Simulate the compound unique index violation MongoDB would raise on insert
+    async def patched_insert(dto):
+        raise UniqueConstraintViolationError(
+            unique_fields={"box_id": str(box_id), "alias": "test_file"}
+        )
+
+    file_upload_dao.insert = patched_insert
+
+    with pytest.raises(UploadControllerPort.FileUploadAlreadyExists):
+        await controller.initiate_file_upload(
+            box_id=box_id,
+            alias="test_file",
+            decrypted_size=DECRYPTED_SIZE,
+            encrypted_size=ENCRYPTED_SIZE,
+            part_size=PART_SIZE,
+            overwrite=False,
+        )
+
+    # First upload must be untouched and still in 'init'
+    upload = await file_upload_dao.get_by_id(file_id_1)
+    assert upload.state == "init"
+
+
 @pytest.mark.parametrize(
     "max_size, pre_existing_sizes, expect_error",
     [


### PR DESCRIPTION
Adds an `overwrite` parameter to UCS's `POST /boxes/{box_id}/uploads` endpoint. When used, UCS will attempt to cancel any existing upload in the box for the same alias specified in the request.

No version bump included because the unreleased changes in `main` already include a major version bump.