### PR TITLE
Cache storages

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.0"
+version = "15.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.0"
+version = "15.0.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:14.0.0
+docker pull ghga/upload-controller-service:14.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:14.0.0 .
+docker build -t ghga/upload-controller-service:14.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:14.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:14.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -764,7 +764,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 14.0.0
+  version: 14.0.1
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "14.0.0"
+version = "14.0.1"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -56,14 +56,23 @@ class S3Client(S3ClientPort):
     def __init__(self, *, config: Config, object_storages: ObjectStorages):
         self._config = config
         self._object_storages = object_storages
+        self._storages_by_alias: dict[str, tuple[str, ObjectStorageProtocol]] = {}
 
     def _get_bucket_and_storage(
         self, storage_alias: str
     ) -> tuple[str, ObjectStorageProtocol]:
         """Return the bucket ID and ObjectStorageProtocol for a given storage alias.
 
+        The instances returned by `for_alias` are cached per alias: constructing an
+        `S3ObjectStorage` builds boto3 clients synchronously on the event loop and
+        discards the underlying connection pool, which is far too expensive to do
+        on every request.
+
         Raises `UnknownStorageAliasError` if the storage alias is not known.
         """
+        if storage_alias in self._storages_by_alias:
+            return self._storages_by_alias[storage_alias]
+
         try:
             bucket_id, object_storage = self._object_storages.for_alias(storage_alias)
         except KeyError as error:
@@ -75,6 +84,7 @@ class S3Client(S3ClientPort):
             bucket_id,
             storage_alias,
         )
+        self._storages_by_alias[storage_alias] = (bucket_id, object_storage)
         return bucket_id, object_storage
 
     def get_bucket_id_for_alias(self, *, storage_alias: str) -> str:

--- a/services/ucs/tests_ucs/unit/test_s3client.py
+++ b/services/ucs/tests_ucs/unit/test_s3client.py
@@ -465,3 +465,33 @@ async def test_generic_storage_error_raises_s3_operation_error(
     # Call the method and verify that it was translated as the generic S3OperationError
     with pytest.raises(S3ClientPort.S3OperationError):
         await getattr(s3_client, method_name)(**kwargs)
+
+
+async def test_object_storage_cached_per_alias(
+    config: ConfigFixture, object_storages: ObjectStorages
+):
+    """Test that S3Client only resolves each storage alias once.
+
+    `for_alias` constructs boto3 clients synchronously on the event loop, so it
+    must not be re-invoked on every request.
+    """
+    call_count = 0
+    original_for_alias = object_storages.for_alias
+
+    def counting_for_alias(endpoint_alias: str):
+        nonlocal call_count
+        call_count += 1
+        return original_for_alias(endpoint_alias)
+
+    object_storages.for_alias = counting_for_alias  # type: ignore[method-assign]
+    s3_client = S3Client(config=config.config, object_storages=object_storages)
+
+    file_upload = make_file_upload()
+    await s3_client.init_multipart_upload(file_upload_basics=_to_basics(file_upload))
+    s3_client.get_bucket_id_for_alias(storage_alias=file_upload.storage_alias)
+    await s3_client.list_all_multipart_uploads(storage_alias=file_upload.storage_alias)
+
+    assert call_count == 1
+
+    with pytest.raises(S3ClientPort.UnknownStorageAliasError):
+        s3_client.get_bucket_id_for_alias(storage_alias="does-not-exist")


### PR DESCRIPTION
S3 object storage client instances were being recreated on every call, causing a logjam. 

This bumps UCS to version `14.0.1` and the monorepo to `15.0.1`.

The fix will need to be pulled in separately to `main` later.