### PR TITLE
UCS: Set Correlation ID Before Starting Cleanup Job

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.2"
+version = "15.0.3"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "15.0.2"
+version = "15.0.3"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:14.0.2
+docker pull ghga/upload-controller-service:14.0.3
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:14.0.2 .
+docker build -t ghga/upload-controller-service:14.0.3 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:14.0.2 --help
+docker run -p 8080:8080 ghga/upload-controller-service:14.0.3 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -764,7 +764,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 14.0.2
+  version: 14.0.3
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "14.0.2"
+version = "14.0.3"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/cli.py
+++ b/services/ucs/src/ucs/cli.py
@@ -51,4 +51,4 @@ def sync_consume_events(run_forever: bool = True):
 @cli.command(name="cleanup")
 def sync_run_cleanup(run_forever: bool = True):
     """Run the periodic stale upload cleanup job."""
-    asyncio.run(perform_cleanup())
+    asyncio.run(perform_cleanup(run_forever=run_forever))

--- a/services/ucs/src/ucs/cli.py
+++ b/services/ucs/src/ucs/cli.py
@@ -49,6 +49,6 @@ def sync_consume_events(run_forever: bool = True):
 
 
 @cli.command(name="cleanup")
-def sync_run_cleanup():
+def sync_run_cleanup(run_forever: bool = True):
     """Run the periodic stale upload cleanup job."""
     asyncio.run(perform_cleanup())

--- a/services/ucs/src/ucs/main.py
+++ b/services/ucs/src/ucs/main.py
@@ -17,8 +17,10 @@
 
 import asyncio
 import logging
+from uuid import uuid4
 
 from ghga_service_commons.api import run_server
+from hexkit.correlation import set_correlation_id
 from hexkit.log import configure_logging
 from hexkit.opentelemetry import configure_opentelemetry
 
@@ -76,7 +78,7 @@ async def perform_cleanup(run_forever: bool = True) -> None:
     configure_logging(config=config)
     configure_opentelemetry(service_name=config.service_name, config=config)
 
-    async with prepare_core(config=config) as controller:
+    async with prepare_core(config=config) as controller, set_correlation_id(uuid4()):
         is_first_run = True
         while run_forever or is_first_run:
             is_first_run = False

--- a/services/ucs/tests_ucs/integration/test_controller.py
+++ b/services/ucs/tests_ucs/integration/test_controller.py
@@ -16,7 +16,7 @@
 """Integration tests for the UploadController"""
 
 import hashlib
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext
 from datetime import timedelta
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -33,6 +33,7 @@ from tests_ucs.fixtures import utils
 from tests_ucs.fixtures.joint import JointFixture
 from ucs.adapters.outbound.dao import FIELDS_NOT_PUBLISHED
 from ucs.constants import FILE_UPLOADS_COLLECTION, UPLOAD_ACTIVITY_COLLECTION
+from ucs.main import perform_cleanup
 from ucs.ports.inbound.controller import UploadControllerPort
 
 pytestmark = pytest.mark.asyncio()
@@ -736,7 +737,9 @@ async def test_file_deletion_requested_event(joint_fixture: JointFixture, caplog
     )
 
 
-async def test_cleanup_aborts_orphaned_s3_uploads(joint_fixture: JointFixture):
+async def test_cleanup_aborts_orphaned_s3_uploads(
+    joint_fixture: JointFixture, monkeypatch: pytest.MonkeyPatch
+):
     """Test that the cleanup job aborts S3 multipart uploads with no corresponding
     FileUpload record, while leaving recently-initiated uploads untouched.
     """
@@ -770,8 +773,13 @@ async def test_cleanup_aborts_orphaned_s3_uploads(joint_fixture: JointFixture):
     assert orphaned_s3_upload_id in active_uploads_before
     assert len(active_uploads_before) == 2
 
-    # Run the cleanup job
-    await controller.cleanup_stale_uploads()
+    # Run the cleanup job (patch prepare_core to return our test object)
+    @asynccontextmanager
+    async def _prepare_core(config):
+        yield joint_fixture.upload_controller
+
+    monkeypatch.setattr("ucs.main.prepare_core", _prepare_core)
+    await perform_cleanup(run_forever=False)
 
     # The orphaned upload should be aborted
     active_uploads_after = await s3_storage.get_all_multipart_uploads(
@@ -839,9 +847,13 @@ async def test_cleanup_cancels_despite_s3_abort_failure(
 
     monkeypatch.setattr(s3_client, "abort_multipart_upload", failing_abort)
 
-    # Run the cleanup job
-    async with set_correlation_id(uuid4()):
-        await controller.cleanup_stale_uploads()
+    # Run the cleanup job (patch prepare_core to return our test object)
+    @asynccontextmanager
+    async def _prepare_core(config):
+        yield joint_fixture.upload_controller
+
+    monkeypatch.setattr("ucs.main.prepare_core", _prepare_core)
+    await perform_cleanup(run_forever=False)
 
     # The FileUpload should be marked 'cancelled' despite the S3 failure
     file_upload_doc = db[FILE_UPLOADS_COLLECTION].find_one({"_id": file_id})


### PR DESCRIPTION
Also adds the missing `run_forever` parameter to the cleanup CLI method.

Bumps the UCS version to `14.0.3` and the monorepo version to `15.0.3`