### PR TITLE
UCS: Speedy box stats (GSI-2489)

### DIFF
--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -305,6 +305,9 @@ async def update_box(  # noqa: C901, PLR0912
         ) from error
     except UploadControllerPort.UploadAbortError as error:
         raise http_exceptions.HttpUploadAbortError() from error
+    except UploadControllerPort.BoxStatsCalcError as error:
+        # The controller already logs the underlying cause, so don't re-log here
+        raise http_exceptions.HttpInternalError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error
@@ -523,7 +526,7 @@ async def get_part_upload_url(  # noqa: PLR0913
     },
 )
 @TRACER.start_as_current_span("routes.complete_file_upload")
-async def complete_file_upload(
+async def complete_file_upload(  # noqa: C901
     box_id: UUID4,
     file_id: UUID4,
     file_upload_completion: rest_models.FileUploadCompletionRequest,
@@ -569,6 +572,9 @@ async def complete_file_upload(
         raise http_exceptions.HttpChecksumMismatchError(file_id=file_id) from error
     except UploadControllerPort.UploadSizeMismatchError as error:
         raise http_exceptions.HttpUploadSizeMismatchError(file_id=file_id) from error
+    except UploadControllerPort.BoxStatsCalcError as error:
+        # The controller already logs the underlying cause, so don't re-log here
+        raise http_exceptions.HttpInternalError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error
@@ -621,6 +627,9 @@ async def remove_file_upload(
         raise http_exceptions.HttpUnknownStorageAliasError() from error
     except UploadControllerPort.UploadAbortError as error:
         raise http_exceptions.HttpUploadAbortError() from error
+    except UploadControllerPort.BoxStatsCalcError as error:
+        # The controller already logs the underlying cause, so don't re-log here
+        raise http_exceptions.HttpInternalError() from error
     except Exception as error:
         log.error(error, exc_info=True)
         raise http_exceptions.HttpInternalError() from error

--- a/services/ucs/src/ucs/adapters/outbound/box_stats.py
+++ b/services/ucs/src/ucs/adapters/outbound/box_stats.py
@@ -1,0 +1,59 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MongoDB adapter for aggregating FileUploadBox statistics."""
+
+from pydantic import UUID4
+from pymongo import AsyncMongoClient
+
+from ucs.constants import COUNTED_UPLOAD_STATES
+from ucs.ports.outbound.dao import BoxStatsAggregatorPort
+
+
+class MongoDbBoxStatsAggregator(BoxStatsAggregatorPort):
+    """Computes box stats with a server-side MongoDB aggregation.
+
+    This bypasses the hexkit DAO deliberately: the DAO would deserialize each matching
+    FileUpload document (including its large per-part checksum lists) into a Pydantic
+    model just to read `decrypted_size`. The aggregation instead sums the values inside
+    MongoDB and returns only the two resulting numbers.
+    """
+
+    def __init__(self, *, client: AsyncMongoClient, db_name: str, collection_name: str):
+        self._collection = client[db_name][collection_name]
+
+    async def compute_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
+        """Return `(file_count, total_decrypted_size)` for the counted FileUploads in
+        the box. Returns `(0, 0)` when the box has no counted files.
+        """
+        pipeline: list[dict] = [
+            {
+                "$match": {
+                    "box_id": box_id,
+                    "state": {"$in": list(COUNTED_UPLOAD_STATES)},
+                }
+            },
+            {
+                "$group": {
+                    "_id": None,
+                    "file_count": {"$sum": 1},
+                    "size": {"$sum": "$decrypted_size"},
+                }
+            },
+        ]
+        cursor = await self._collection.aggregate(pipeline)
+        async for group in cursor:
+            return group["file_count"], group["size"]
+        return 0, 0

--- a/services/ucs/src/ucs/adapters/outbound/dao.py
+++ b/services/ucs/src/ucs/adapters/outbound/dao.py
@@ -85,6 +85,10 @@ class UploadDaoPublisherFactory(UploadDaoPublisherFactoryPort):
                 # Supports the stale upload cleanup job, which queries by
                 #  storage_alias and state
                 MongoDbIndex(fields={"storage_alias": 1, "state": 1}),
+                # Covering index for the box stats aggregation: matching on
+                #  box_id + state and summing decrypted_size can be served entirely
+                #  from this index without fetching documents
+                MongoDbIndex(fields={"box_id": 1, "state": 1, "decrypted_size": 1}),
             ],
         )
 

--- a/services/ucs/src/ucs/adapters/outbound/dao.py
+++ b/services/ucs/src/ucs/adapters/outbound/dao.py
@@ -81,7 +81,10 @@ class UploadDaoPublisherFactory(UploadDaoPublisherFactoryPort):
                 MongoDbIndex(
                     fields={"box_id": 1, "alias": 1},
                     properties={"unique": True, "sparse": True},
-                )
+                ),
+                # Supports the stale upload cleanup job, which queries by
+                #  storage_alias and state
+                MongoDbIndex(fields={"storage_alias": 1, "state": 1}),
             ],
         )
 

--- a/services/ucs/src/ucs/constants.py
+++ b/services/ucs/src/ucs/constants.py
@@ -20,6 +20,9 @@ SERVICE_NAME = "ucs"
 TRACER = trace.get_tracer_provider().get_tracer(SERVICE_NAME)
 FILE_UPLOAD_BOXES_COLLECTION = "fileUploadBoxes"
 FILE_UPLOADS_COLLECTION = "fileUploads"
+# FileUpload states that count toward a box's file_count and size (i.e. files that
+#  have finished uploading and have not been cancelled or failed)
+COUNTED_UPLOAD_STATES = ("inbox", "interrogated", "awaiting_archival", "archived")
 MIN_PART_SIZE = 5 * 1024**2
 MAX_PART_SIZE = 5 * 1024**3
 MAX_PART_COUNT = 10000

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -756,8 +756,15 @@ class UploadController(UploadControllerPort):
                 "Activity entry not found when completing upload for file %s.", file_id
             )
 
-        # Update the FileUploadBox with new size and file count
-        await self._update_box_stats(box_id=box_id, version=box_version)
+        # Update the FileUploadBox with new size and file count. The early-return
+        #  guard on the file state above ensures this runs at most once per file, so
+        #  a delta is applied instead of a full stats recompute.
+        await self._apply_box_stat_delta(
+            box_id=box_id,
+            version=box_version,
+            file_count_delta=1,
+            size_delta=file_upload.decrypted_size,
+        )
         log.info("DB data updated for upload completion of file %s", file_id)
 
     async def remove_file_upload(self, *, box_id: UUID4, file_id: UUID4) -> None:
@@ -927,6 +934,26 @@ class UploadController(UploadControllerPort):
                     await self._upload_activity_dao.delete(file_upload.id)
                 await self._file_upload_dao.delete(file_upload.id)
 
+    async def _compute_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
+        """Compute the file count and total decrypted size for a FileUploadBox,
+        counting only files that are finished uploading.
+
+        Returns a tuple of (file_count, total_size).
+        """
+        file_count = 0
+        total_size = 0
+        async for file_upload in self._file_upload_dao.find_all(
+            mapping={
+                "box_id": box_id,
+                "state": {
+                    "$in": ["inbox", "interrogated", "awaiting_archival", "archived"]
+                },
+            }
+        ):
+            file_count += 1
+            total_size += file_upload.decrypted_size
+        return file_count, total_size
+
     async def _update_box_stats(self, *, box_id: UUID4, version: int) -> None:
         """Update FileUploadBox stats (file count & size) in an idempotent manner,
         counting only files that are finished uploading.
@@ -942,18 +969,7 @@ class UploadController(UploadControllerPort):
         """
         box = await self._get_box_at_version(box_id=box_id, version=version)
 
-        file_count = 0
-        total_size = 0
-        async for file_upload in self._file_upload_dao.find_all(
-            mapping={
-                "box_id": box_id,
-                "state": {
-                    "$in": ["inbox", "interrogated", "awaiting_archival", "archived"]
-                },
-            }
-        ):
-            file_count += 1
-            total_size += file_upload.decrypted_size
+        file_count, total_size = await self._compute_box_stats(box_id=box_id)
 
         # Since every update triggers an event, only update if data differs
         if file_count != box.file_count or total_size != box.size:
@@ -961,6 +977,28 @@ class UploadController(UploadControllerPort):
             box.file_count = file_count
             box.size = total_size
             await self._file_upload_box_dao.update(box)
+
+    async def _apply_box_stat_delta(
+        self, *, box_id: UUID4, version: int, file_count_delta: int, size_delta: int
+    ) -> None:
+        """Apply a delta to the FileUploadBox stats (file count & size).
+
+        Unlike `_update_box_stats`, this does not rescan the box's FileUploads, so it
+        stays O(1) regardless of box size. It must only be called from paths where the
+        triggering state transition is guaranteed to occur at most once per file (e.g.
+        the guarded 'init' -> 'inbox' transition on upload completion). Any drift left
+        behind by a crash or a concurrent box update is corrected by the full recompute
+        performed on file removal and box locking.
+
+        Raises:
+        - `BoxNotFoundError` if the box no longer exists.
+        - `BoxVersionError` if the box version has changed since it was fetched.
+        """
+        box = await self._get_box_at_version(box_id=box_id, version=version)
+        box.version += 1
+        box.file_count += file_count_delta
+        box.size += size_delta
+        await self._file_upload_box_dao.update(box)
 
     async def create_file_upload_box(
         self, *, storage_alias: str, max_size: int
@@ -1063,8 +1101,16 @@ class UploadController(UploadControllerPort):
                 log.info(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
                 raise error
 
+        # Recompute stats from scratch while locking: the completion path only applies
+        #  deltas, so this is the backstop that corrects any drift (e.g. from crashes,
+        #  concurrent box updates, or interrogation failures) before the box contents
+        #  are finalized.
+        file_count, total_size = await self._compute_box_stats(box_id=box_id)
+
         box.version += 1
         box.state = "locked"
+        box.file_count = file_count
+        box.size = total_size
         await self._file_upload_box_dao.update(box)
         log.info("Locked box with ID %s.", box_id)
 

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -47,6 +47,7 @@ from ucs.core.models import (
 )
 from ucs.ports.inbound.controller import UploadControllerPort
 from ucs.ports.outbound.dao import (
+    BoxStatsAggregatorPort,
     FileUploadBoxDao,
     FileUploadDao,
     ResourceNotFoundError,
@@ -60,19 +61,21 @@ log = logging.getLogger(__name__)
 class UploadController(UploadControllerPort):
     """A class for managing file uploads"""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         config: Config,
         file_upload_box_dao: FileUploadBoxDao,
         file_upload_dao: FileUploadDao,
         upload_activity_dao: UploadActivityDao,
+        box_stats_aggregator: BoxStatsAggregatorPort,
         s3_client: S3ClientPort,
     ):
         self._config = config
         self._file_upload_box_dao = file_upload_box_dao
         self._file_upload_dao = file_upload_dao
         self._upload_activity_dao = upload_activity_dao
+        self._box_stats_aggregator = box_stats_aggregator
         self._s3_client = s3_client
 
     async def _get_box_at_version(
@@ -686,6 +689,7 @@ class UploadController(UploadControllerPort):
         - `UploadCompletionError` if there's an error while telling S3 to complete the upload.
         - `UploadSizeMismatchError` if the object size doesn't match the declared encrypted_size.
         - `ChecksumMismatchError` if the checksums don't match.
+        - `BoxStatsCalcError` if there's a problem calculating box size and file count.
         """
         # Get the FileUploadBox instance and verify that it is unlocked
         box = await self._get_unlocked_box(box_id=box_id)
@@ -756,15 +760,8 @@ class UploadController(UploadControllerPort):
                 "Activity entry not found when completing upload for file %s.", file_id
             )
 
-        # Update the FileUploadBox with new size and file count. The early-return
-        #  guard on the file state above ensures this runs at most once per file, so
-        #  a delta is applied instead of a full stats recompute.
-        await self._apply_box_stat_delta(
-            box_id=box_id,
-            version=box_version,
-            file_count_delta=1,
-            size_delta=file_upload.decrypted_size,
-        )
+        # Update the FileUploadBox with new size and file count
+        await self._update_box_stats(box_id=box_id, version=box_version)
         log.info("DB data updated for upload completion of file %s", file_id)
 
     async def remove_file_upload(self, *, box_id: UUID4, file_id: UUID4) -> None:
@@ -776,6 +773,7 @@ class UploadController(UploadControllerPort):
         - `BoxVersionError` if the box version changed before stats could be updated.
         - `UnknownStorageAliasError` if the storage alias is not known.
         - `UploadAbortError` if there's an error instructing S3 to abort the upload.
+        - `BoxStatsCalcError` if there's a problem calculating box size and file count.
         """
         # Make sure box exists and is unlocked (unless overridden)
         box = await self._get_unlocked_box(box_id=box_id)
@@ -934,31 +932,11 @@ class UploadController(UploadControllerPort):
                     await self._upload_activity_dao.delete(file_upload.id)
                 await self._file_upload_dao.delete(file_upload.id)
 
-    async def _compute_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
-        """Compute the file count and total decrypted size for a FileUploadBox,
-        counting only files that are finished uploading.
-
-        Returns a tuple of (file_count, total_size).
-        """
-        file_count = 0
-        total_size = 0
-        async for file_upload in self._file_upload_dao.find_all(
-            mapping={
-                "box_id": box_id,
-                "state": {
-                    "$in": ["inbox", "interrogated", "awaiting_archival", "archived"]
-                },
-            }
-        ):
-            file_count += 1
-            total_size += file_upload.decrypted_size
-        return file_count, total_size
-
     async def _update_box_stats(self, *, box_id: UUID4, version: int) -> None:
         """Update FileUploadBox stats (file count & size) in an idempotent manner,
         counting only files that are finished uploading.
 
-        Re-fetches the box to get the latest state, verifies the version is still
+        Re-fetches the box to get the latest state and verifies the version is still
         current before applying any changes.
 
         This helps mitigate potential state inconsistency arising from a hard crash.
@@ -966,10 +944,11 @@ class UploadController(UploadControllerPort):
         Raises:
         - `BoxNotFoundError` if the box no longer exists.
         - `BoxVersionError` if the box version has changed since it was fetched.
+        - `BoxStatsCalcError` if there's a problem calculating box size and file count.
         """
         box = await self._get_box_at_version(box_id=box_id, version=version)
 
-        file_count, total_size = await self._compute_box_stats(box_id=box_id)
+        file_count, total_size = await self._calc_box_stats(box_id=box_id)
 
         # Since every update triggers an event, only update if data differs
         if file_count != box.file_count or total_size != box.size:
@@ -978,27 +957,22 @@ class UploadController(UploadControllerPort):
             box.size = total_size
             await self._file_upload_box_dao.update(box)
 
-    async def _apply_box_stat_delta(
-        self, *, box_id: UUID4, version: int, file_count_delta: int, size_delta: int
-    ) -> None:
-        """Apply a delta to the FileUploadBox stats (file count & size).
-
-        Unlike `_update_box_stats`, this does not rescan the box's FileUploads, so it
-        stays O(1) regardless of box size. It must only be called from paths where the
-        triggering state transition is guaranteed to occur at most once per file (e.g.
-        the guarded 'init' -> 'inbox' transition on upload completion). Any drift left
-        behind by a crash or a concurrent box update is corrected by the full recompute
-        performed on file removal and box locking.
+    async def _calc_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
+        """Compute a box's (file_count, total_decrypted_size) via the aggregator,
+        translating any datastore error into a `BoxStatsCalcError`.
 
         Raises:
-        - `BoxNotFoundError` if the box no longer exists.
-        - `BoxVersionError` if the box version has changed since it was fetched.
+        - `BoxStatsCalcError` if there's a problem calculating box size and file count.
         """
-        box = await self._get_box_at_version(box_id=box_id, version=version)
-        box.version += 1
-        box.file_count += file_count_delta
-        box.size += size_delta
-        await self._file_upload_box_dao.update(box)
+        try:
+            return await self._box_stats_aggregator.compute_box_stats(box_id=box_id)
+        except Exception as err:
+            log.error(
+                "Box stats computation failed with the following error: %s",
+                err,
+                extra={"box_id": box_id},
+            )
+            raise self.BoxStatsCalcError(box_id=box_id) from err
 
     async def create_file_upload_box(
         self, *, storage_alias: str, max_size: int
@@ -1062,6 +1036,7 @@ class UploadController(UploadControllerPort):
         - `BoxVersionError` if the supplied version doesn't match the current version.
         - `IncompleteUploadsError` if force is False and the box has incomplete FileUploads.
         - `UploadAbortError` if force is True and aborting an in-progress upload fails.
+        - `BoxStatsCalcError` if there's a problem calculating box size and file count.
         """
         box = await self._get_box_at_version(box_id=box_id, version=version)
 
@@ -1101,11 +1076,8 @@ class UploadController(UploadControllerPort):
                 log.info(error, extra={"box_id": box_id, "file_ids": str(file_ids)})
                 raise error
 
-        # Recompute stats from scratch while locking: the completion path only applies
-        #  deltas, so this is the backstop that corrects any drift (e.g. from crashes,
-        #  concurrent box updates, or interrogation failures) before the box contents
-        #  are finalized.
-        file_count, total_size = await self._compute_box_stats(box_id=box_id)
+        # Recompute stats
+        file_count, total_size = await self._calc_box_stats(box_id=box_id)
 
         box.version += 1
         box.state = "locked"

--- a/services/ucs/src/ucs/inject.py
+++ b/services/ucs/src/ucs/inject.py
@@ -21,7 +21,7 @@ from contextlib import asynccontextmanager, nullcontext
 from fastapi import FastAPI
 from ghga_service_commons.utils.multinode_storage import S3ObjectStorages
 from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
-from hexkit.providers.mongodb import MongoDbDaoFactory
+from hexkit.providers.mongodb import ConfiguredMongoClient, MongoDbDaoFactory
 from hexkit.providers.mongokafka.provider import MongoKafkaDaoPublisherFactory
 
 from ucs.adapters.inbound.event_sub import EventSubTranslator
@@ -30,9 +30,11 @@ from ucs.adapters.inbound.fastapi_.configure import get_configured_app
 from ucs.adapters.inbound.fastapi_.http_authorization import (
     JWTAuthContextProviderBundle,
 )
+from ucs.adapters.outbound.box_stats import MongoDbBoxStatsAggregator
 from ucs.adapters.outbound.dao import UploadDaoPublisherFactory, get_upload_activity_dao
 from ucs.adapters.outbound.s3 import S3Client
 from ucs.config import Config
+from ucs.constants import FILE_UPLOADS_COLLECTION
 from ucs.core.controller import UploadController
 from ucs.ports.inbound.controller import UploadControllerPort
 
@@ -62,6 +64,7 @@ async def prepare_core(
     async with (
         MongoKafkaDaoPublisherFactory.construct(config=config) as dao_pub_factory,
         MongoDbDaoFactory.construct(config=config) as dao_factory,
+        ConfiguredMongoClient(config=config) as mongo_client,
     ):
         upload_dao_factory = UploadDaoPublisherFactory(
             config=config, dao_publisher_factory=dao_pub_factory
@@ -69,12 +72,18 @@ async def prepare_core(
         file_upload_box_dao = await upload_dao_factory.get_file_upload_box_dao()
         file_upload_dao = await upload_dao_factory.get_file_upload_dao()
         upload_activity_dao = await get_upload_activity_dao(dao_factory=dao_factory)
+        box_stats_aggregator = MongoDbBoxStatsAggregator(
+            client=mongo_client,
+            db_name=config.db_name,
+            collection_name=FILE_UPLOADS_COLLECTION,
+        )
 
         controller = UploadController(
             config=config,
             file_upload_box_dao=file_upload_box_dao,
             file_upload_dao=file_upload_dao,
             upload_activity_dao=upload_activity_dao,
+            box_stats_aggregator=box_stats_aggregator,
             s3_client=s3_client,
         )
         yield controller

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -148,6 +148,13 @@ class UploadControllerPort(ABC):
             )
             super().__init__(msg)
 
+    class BoxStatsCalcError(UploadError):
+        """Raised when the statistics for a FileUploadBox cannot be calculated."""
+
+        def __init__(self, *, box_id: UUID4):
+            msg = f"Failed to calculate statistics for FileUploadBox {box_id}."
+            super().__init__(msg)
+
     class BoxMaxSizeTooLowError(UploadError):
         """Raised when the requested max_size is less than the box's current committed size."""
 

--- a/services/ucs/src/ucs/ports/outbound/dao.py
+++ b/services/ucs/src/ucs/ports/outbound/dao.py
@@ -20,11 +20,13 @@ from abc import ABC, abstractmethod
 
 from hexkit.protocols.dao import Dao, ResourceAlreadyExistsError, ResourceNotFoundError
 from hexkit.protocols.daopub import DaoPublisher
+from pydantic import UUID4
 
 from ucs.core import models
 from ucs.core.models import FileUploadBox, UploadActivity
 
 __all__ = [
+    "BoxStatsAggregatorPort",
     "FileUploadBoxDao",
     "FileUploadDao",
     "ResourceAlreadyExistsError",
@@ -36,6 +38,21 @@ __all__ = [
 FileUploadBoxDao = DaoPublisher[FileUploadBox]
 FileUploadDao = DaoPublisher[models.FileUpload]
 UploadActivityDao = Dao[UploadActivity]
+
+
+class BoxStatsAggregatorPort(ABC):
+    """Port for computing FileUploadBox statistics directly from the datastore.
+
+    Implementations compute the stats server-side to avoid loading and deserializing
+    full FileUpload documents.
+    """
+
+    @abstractmethod
+    async def compute_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
+        """Return a `(file_count, total_decrypted_size)` tuple aggregated over the
+        FileUploads in the given box that count toward its stats (i.e. files that have
+        finished uploading and are not cancelled or failed).
+        """
 
 
 class UploadDaoPublisherFactoryPort(ABC):

--- a/services/ucs/tests_ucs/fixtures/joint.py
+++ b/services/ucs/tests_ucs/fixtures/joint.py
@@ -46,12 +46,35 @@ from tests_ucs.fixtures.in_mem_obj_storage import InMemS3ObjectStorages
 from tests_ucs.fixtures.utils import TEST_MAX_BOX_SIZE
 from ucs.adapters.outbound.s3 import S3Client
 from ucs.config import Config
+from ucs.constants import COUNTED_UPLOAD_STATES
 from ucs.core import models
 from ucs.core.controller import UploadController
 from ucs.core.models import FileUpload, FileUploadBox, UploadActivity
 from ucs.inject import prepare_core, prepare_event_subscriber, prepare_rest_app
 from ucs.ports.inbound.controller import UploadControllerPort
+from ucs.ports.outbound.dao import BoxStatsAggregatorPort, FileUploadDao
 from ucs.ports.outbound.storage import S3ClientPort
+
+
+class InMemBoxStatsAggregator(BoxStatsAggregatorPort):
+    """In-memory box stats aggregator for unit tests.
+
+    Mirrors the MongoDB aggregation by scanning the in-memory FileUpload DAO, so the
+    controller's stat logic can be exercised without a real database.
+    """
+
+    def __init__(self, *, file_upload_dao: FileUploadDao):
+        self._file_upload_dao = file_upload_dao
+
+    async def compute_box_stats(self, *, box_id: UUID4) -> tuple[int, int]:
+        file_count = 0
+        total_size = 0
+        async for file_upload in self._file_upload_dao.find_all(
+            mapping={"box_id": box_id, "state": {"$in": list(COUNTED_UPLOAD_STATES)}}
+        ):
+            file_count += 1
+            total_size += file_upload.decrypted_size
+        return file_count, total_size
 
 
 @dataclass
@@ -181,11 +204,14 @@ def rig(config: ConfigFixture, patch_s3_calls) -> JointRig:
 
     storage.get_object_size = mock_get_object_size
 
+    box_stats_aggregator = InMemBoxStatsAggregator(file_upload_dao=file_upload_dao)
+
     controller = UploadController(
         config=(_config),
         file_upload_box_dao=(file_upload_box_dao),
         file_upload_dao=(file_upload_dao),
         upload_activity_dao=upload_activity_dao,
+        box_stats_aggregator=box_stats_aggregator,
         s3_client=s3_client,
     )
 

--- a/services/ucs/tests_ucs/integration/test_box_stats.py
+++ b/services/ucs/tests_ucs/integration/test_box_stats.py
@@ -1,0 +1,91 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the MongoDbBoxStatsAggregator"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from hexkit.correlation import set_correlation_id
+
+from tests_ucs.fixtures import utils
+from tests_ucs.fixtures.joint import JointFixture
+from ucs.constants import COUNTED_UPLOAD_STATES
+from ucs.core.controller import UploadController
+
+pytestmark = pytest.mark.asyncio()
+
+NOT_COUNTED_UPLOAD_STATES = ("init", "failed", "cancelled")
+
+
+async def test_box_stats_aggregation(joint_fixture: JointFixture):
+    """Test MongoDbBoxStatsAggregator.compute_box_stats against a real MongoDB instance.
+
+    The FileUpload documents are written through the DAO so that the docs in the DB
+    more reliably have the correct structure, e.g. __metadata__, field encoding, etc.
+    """
+    controller = joint_fixture.upload_controller
+    assert isinstance(controller, UploadController)
+    box_stats_aggregator = controller._box_stats_aggregator
+    file_upload_dao = controller._file_upload_dao
+
+    box_id = uuid4()
+    other_box_id = uuid4()
+
+    # Try calculating stats box without any FileUploads
+    assert await box_stats_aggregator.compute_box_stats(box_id=box_id) == (0, 0)
+
+    # Insert one FileUpload per state, each with a distinct decrypted_size
+    counted_sizes_by_file_id: dict[UUID, int] = {}
+    not_counted_size_total = 0
+    async with set_correlation_id(uuid4()):
+        for index, state in enumerate(
+            COUNTED_UPLOAD_STATES + NOT_COUNTED_UPLOAD_STATES
+        ):
+            file_upload = utils.make_file_upload(state=state)
+            file_upload.box_id = box_id
+            file_upload.alias = f"file_{state}"
+            file_upload.decrypted_size = 100 * (index + 1)
+            await file_upload_dao.insert(file_upload)
+            if state in COUNTED_UPLOAD_STATES:
+                counted_sizes_by_file_id[file_upload.id] = file_upload.decrypted_size
+            else:
+                not_counted_size_total += file_upload.decrypted_size
+
+        # Also insert a 'counted' FileUpload into a different box
+        other_box_file_upload = utils.make_file_upload(state="inbox")
+        other_box_file_upload.box_id = other_box_id
+        await file_upload_dao.insert(other_box_file_upload)
+
+    # Only the counted states of the requested box may contribute to the stats
+    assert not_counted_size_total > 0
+    file_count, total_size = await box_stats_aggregator.compute_box_stats(box_id=box_id)
+    assert file_count == len(COUNTED_UPLOAD_STATES)
+    assert total_size == sum(counted_sizes_by_file_id.values())
+
+    # Make sure calc only considers files owned by the given box
+    file_count, total_size = await box_stats_aggregator.compute_box_stats(
+        box_id=other_box_id
+    )
+    assert file_count == 1
+    assert total_size == other_box_file_upload.decrypted_size
+
+    # Make sure 'deleted' outbox docs are not counted somehow
+    deleted_file_id, _ = counted_sizes_by_file_id.popitem()
+    async with set_correlation_id(uuid4()):
+        await file_upload_dao.delete(deleted_file_id)
+    file_count, total_size = await box_stats_aggregator.compute_box_stats(box_id=box_id)
+    assert file_count == len(COUNTED_UPLOAD_STATES) - 1
+    assert total_size == sum(counted_sizes_by_file_id.values())

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -15,6 +15,7 @@
 
 """Tests that check the REST API's behavior and auth handling"""
 
+import logging
 from dataclasses import dataclass
 from unittest.mock import AsyncMock
 from uuid import UUID
@@ -572,9 +573,19 @@ async def test_create_box_endpoint_error_handling(
                 box_id=TEST_BOX_ID, file_ids=[(TEST_FILE_ID, "test_file")]
             ),
         ),
+        (
+            UploadControllerPort.BoxStatsCalcError(box_id=TEST_BOX_ID),
+            http_exceptions.HttpInternalError(),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
-    ids=["BoxNotFound", "BoxVersionOutdated", "IncompleteUploads", "InternalError"],
+    ids=[
+        "BoxNotFound",
+        "BoxVersionOutdated",
+        "IncompleteUploads",
+        "BoxStatsCalcError",
+        "InternalError",
+    ],
 )
 async def test_update_box_endpoint_error_handling(
     config: ConfigFixture,
@@ -882,6 +893,10 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
             ),
             http_exceptions.HttpFileUploadStateError(file_id=TEST_FILE_ID),
         ),
+        (
+            UploadControllerPort.BoxStatsCalcError(box_id=TEST_BOX_ID),
+            http_exceptions.HttpInternalError(),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
     ids=[
@@ -891,6 +906,7 @@ async def test_get_file_part_upload_url_endpoint_error_handling(
         "UploadCompletionError",
         "UploadSizeMismatchError",
         "FileUploadStateError",
+        "BoxStatsCalcError",
         "InternalError",
     ],
 )
@@ -922,6 +938,42 @@ async def test_complete_file_upload_endpoint_error_translation(
     assert response.json()["description"] == str(http_error)
 
 
+async def test_box_stats_calc_error_not_re_logged_by_api(
+    config: ConfigFixture, app_fixture: AppFixture, caplog
+):
+    """BoxStatsCalcError is already logged by the controller, so the API layer must
+    translate it to a 500 without emitting another error log of its own.
+    """
+    routes_logger = "ucs.adapters.inbound.fastapi_.routes"
+    wps_jwk = config.wps_jwk
+    body: dict = {
+        "decrypted_sha256": "unencrypted_checksum",
+        "encrypted_md5": "encrypted_checksum",
+        "encrypted_parts_md5": ["abc123"],
+        "encrypted_parts_sha256": ["def456"],
+    }
+    rest_client = app_fixture.rest_client
+    core_mock = app_fixture.core_mock
+    core_mock.complete_file_upload.side_effect = UploadControllerPort.BoxStatsCalcError(
+        box_id=TEST_BOX_ID
+    )
+    token_header = utils.close_file_token_header(
+        box_id=TEST_BOX_ID, file_id=TEST_FILE_ID, jwk=wps_jwk
+    )
+    with caplog.at_level(logging.ERROR, logger=routes_logger):
+        response = await rest_client.patch(
+            f"/boxes/{TEST_BOX_ID}/uploads/{TEST_FILE_ID}",
+            json=body,
+            headers=token_header,
+        )
+    assert response.json()["description"] == str(http_exceptions.HttpInternalError())
+    assert not [
+        record
+        for record in caplog.records
+        if record.name == routes_logger and record.levelno >= logging.ERROR
+    ]
+
+
 @pytest.mark.parametrize(
     "core_error, http_error",
     [
@@ -949,6 +1001,10 @@ async def test_complete_file_upload_endpoint_error_translation(
             ),
             http_exceptions.HttpUploadAbortError(),
         ),
+        (
+            UploadControllerPort.BoxStatsCalcError(box_id=TEST_BOX_ID),
+            http_exceptions.HttpInternalError(),
+        ),
         (RuntimeError("Random error"), http_exceptions.HttpInternalError()),
     ],
     ids=[
@@ -957,6 +1013,7 @@ async def test_complete_file_upload_endpoint_error_translation(
         "UnknownStorageAlias",
         "FileUploadNotFound",
         "UploadAbortError",
+        "BoxStatsCalcError",
         "InternalError",
     ],
 )

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -312,14 +312,20 @@ async def test_lock_file_upload_box(rig: JointRig):
     assert file_upload_box_dao.latest.state == "locked"
 
 
-async def test_lock_recomputes_box_stats(rig: JointRig):
-    """Test that locking a box recomputes its stats from the FileUploads,
-    correcting any drift left behind by the delta-based completion path.
+async def test_completion_recomputes_box_stats_from_truth(rig: JointRig):
+    """Test that completing an upload derives box stats from the current FileUpload
+    states, correcting any prior drift rather than blindly incrementing.
     """
     file_upload_box_dao = rig.file_upload_box_dao
     box_id = await rig.create_default_box()
 
-    # Complete one file upload so the box has real stats (version 0 -> 1)
+    # Simulate out-of-sync size/file count on the box (version 0 -> 1)
+    drifted_box = await file_upload_box_dao.get_by_id(box_id)
+    drifted_box.file_count = 5
+    drifted_box.size = 12345
+    await file_upload_box_dao.update(drifted_box)
+
+    # Complete one file upload so the box has real stats again
     file_id, _ = await rig.controller.initiate_file_upload(
         box_id=box_id,
         alias="test_file",
@@ -339,13 +345,38 @@ async def test_lock_recomputes_box_stats(rig: JointRig):
     assert file_upload_box_dao.latest.file_count == 1
     assert file_upload_box_dao.latest.size == DECRYPTED_SIZE
 
-    # Manufacture stat drift, as if a crash or concurrent update had lost a delta
+
+async def test_lock_recomputes_box_stats(rig: JointRig):
+    """Test that locking a box unconditionally recomputes its stats from the current
+    FileUploads, correcting any prior drift in the same write that locks the box.
+    """
+    file_upload_box_dao = rig.file_upload_box_dao
+    box_id = await rig.create_default_box()
+
+    # Complete one upload so the box has a real, counted file (version 0 -> 1)
+    file_id, _ = await rig.controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+    object_id = rig.file_upload_dao.latest.object_id
+    await rig.controller.complete_file_upload(
+        box_id=box_id,
+        file_id=file_id,
+        unencrypted_checksum="unencrypted_checksum",
+        encrypted_checksum=f"etag_for_{object_id}",
+        encrypted_parts_md5=["abc123"],
+        encrypted_parts_sha256=["def456"],
+    )
+
+    # Manufacture stat drift, then lock and confirm the lock write corrected it
     drifted_box = await file_upload_box_dao.get_by_id(box_id)
     drifted_box.file_count = 5
     drifted_box.size = 12345
     await file_upload_box_dao.update(drifted_box)
 
-    # Lock the box and verify the stats were corrected in the same update
     await rig.controller.lock_file_upload_box(box_id=box_id, version=1)
     assert file_upload_box_dao.latest.state == "locked"
     assert file_upload_box_dao.latest.file_count == 1

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -312,6 +312,46 @@ async def test_lock_file_upload_box(rig: JointRig):
     assert file_upload_box_dao.latest.state == "locked"
 
 
+async def test_lock_recomputes_box_stats(rig: JointRig):
+    """Test that locking a box recomputes its stats from the FileUploads,
+    correcting any drift left behind by the delta-based completion path.
+    """
+    file_upload_box_dao = rig.file_upload_box_dao
+    box_id = await rig.create_default_box()
+
+    # Complete one file upload so the box has real stats (version 0 -> 1)
+    file_id, _ = await rig.controller.initiate_file_upload(
+        box_id=box_id,
+        alias="test_file",
+        decrypted_size=DECRYPTED_SIZE,
+        encrypted_size=ENCRYPTED_SIZE,
+        part_size=PART_SIZE,
+    )
+    object_id = rig.file_upload_dao.latest.object_id
+    await rig.controller.complete_file_upload(
+        box_id=box_id,
+        file_id=file_id,
+        unencrypted_checksum="unencrypted_checksum",
+        encrypted_checksum=f"etag_for_{object_id}",
+        encrypted_parts_md5=["abc123"],
+        encrypted_parts_sha256=["def456"],
+    )
+    assert file_upload_box_dao.latest.file_count == 1
+    assert file_upload_box_dao.latest.size == DECRYPTED_SIZE
+
+    # Manufacture stat drift, as if a crash or concurrent update had lost a delta
+    drifted_box = await file_upload_box_dao.get_by_id(box_id)
+    drifted_box.file_count = 5
+    drifted_box.size = 12345
+    await file_upload_box_dao.update(drifted_box)
+
+    # Lock the box and verify the stats were corrected in the same update
+    await rig.controller.lock_file_upload_box(box_id=box_id, version=1)
+    assert file_upload_box_dao.latest.state == "locked"
+    assert file_upload_box_dao.latest.file_count == 1
+    assert file_upload_box_dao.latest.size == DECRYPTED_SIZE
+
+
 async def test_unlock_file_upload_box(rig: JointRig):
     """Test unlocking a locked FileUploadBox"""
     file_upload_box_dao = rig.file_upload_box_dao


### PR DESCRIPTION
The FileUpload DAO was a really inefficient tool to recalculate current FileUploadBox size, so there is now an aggregator class that uses a Pymongo client directly. Error handling is minimal: the core class just catches whatever error, logs it, and re-raises it as `BoxStatsCalcError`. On the API side this is returned as a 500 without the extra logging that other random errors trigger.