### PR TITLE
UCS: Sort Paginated FileUploads (GSI-2496)

### DIFF
--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -1047,8 +1047,9 @@ paths:
           type: integer
       - description: A comma-separated list of FileUpload field names defining the
           sort order, where field names prefixed with '-' indicate descending order
-          (e.g. 'alias,-decrypted_size'). Defaults to sorting by alias in ascending
-          order.
+          (e.g. 'state,-decrypted_size'). Defaults to sorting by alias in ascending
+          order. If 'alias' is not referenced, it is appended as an ascending tiebreaker
+          to guarantee a stable order.
         in: query
         name: sort
         required: false
@@ -1058,8 +1059,9 @@ paths:
           - type: 'null'
           description: A comma-separated list of FileUpload field names defining the
             sort order, where field names prefixed with '-' indicate descending order
-            (e.g. 'alias,-decrypted_size'). Defaults to sorting by alias in ascending
-            order.
+            (e.g. 'state,-decrypted_size'). Defaults to sorting by alias in ascending
+            order. If 'alias' is not referenced, it is appended as an ascending tiebreaker
+            to guarantee a stable order.
           title: Sort
       responses:
         '200':

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -1040,11 +1040,27 @@ paths:
         name: limit
         required: false
         schema:
-          default: 50
-          maximum: 100
+          default: 10
+          maximum: 1000
           minimum: 0
           title: Limit
           type: integer
+      - description: A comma-separated list of FileUpload field names defining the
+          sort order, where field names prefixed with '-' indicate descending order
+          (e.g. 'alias,-decrypted_size'). Defaults to sorting by alias in ascending
+          order.
+        in: query
+        name: sort
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: A comma-separated list of FileUpload field names defining the
+            sort order, where field names prefixed with '-' indicate descending order
+            (e.g. 'alias,-decrypted_size'). Defaults to sorting by alias in ascending
+            order.
+          title: Sort
       responses:
         '200':
           content:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -15,13 +15,44 @@
 
 """REST API-specific data models (not used by core package)"""
 
-from typing import Literal, TypeVar
+from typing import Annotated, Literal, TypeVar
 
 from ghga_event_schemas.pydantic_ import UploadBoxState
-from pydantic import UUID4, BaseModel, ConfigDict, Field, PositiveInt, model_validator
+from pydantic import (
+    UUID4,
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    model_validator,
+)
 
 from ucs.constants import MAX_PART_SIZE, MIN_PART_SIZE
 from ucs.core.models import FileUpload
+
+
+def _ensure_valid_sort_fields(sort: str) -> str:
+    """Ensure each comma-separated sort spec references a FileUpload field.
+
+    A "-" prefix on a spec (denoting descending order) is ignored for validation.
+    An empty string is allowed and means no sort was specified.
+    """
+    if not sort:
+        return sort
+    invalid_fields = [
+        field_name
+        for field_name in (spec.removeprefix("-") for spec in sort.split(","))
+        if field_name not in FileUpload.model_fields
+    ]
+    if invalid_fields:
+        raise ValueError(
+            f"sort references nonexistent FileUpload fields: {', '.join(invalid_fields)}"
+        )
+    return sort
+
+
+SortString = Annotated[str, AfterValidator(_ensure_valid_sort_fields)]
 
 
 class BoxCreationRequest(BaseModel):

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -336,8 +336,10 @@ async def get_box_uploads(  # noqa: PLR0913
         Query(
             description="A comma-separated list of FileUpload field names defining"
             + " the sort order, where field names prefixed with '-' indicate"
-            + " descending order (e.g. 'alias,-decrypted_size')."
+            + " descending order (e.g. 'state,-decrypted_size')."
             + " Defaults to sorting by alias in ascending order."
+            + " If 'alias' is not referenced, it is appended as an ascending"
+            + " tiebreaker to guarantee a stable order."
         ),
     ] = None,
 ) -> rest_models.BoxUploadsPage:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -322,7 +322,7 @@ async def update_box(  # noqa: C901, PLR0912
     },
 )
 @TRACER.start_as_current_span("routes.get_box_uploads")
-async def get_box_uploads(
+async def get_box_uploads(  # noqa: PLR0913
     box_id: UUID4,
     work_order: Annotated[
         rest_models.ViewFileBoxWorkOrder,
@@ -330,7 +330,16 @@ async def get_box_uploads(
     ],
     upload_controller: dummies.UploadControllerDummy,
     skip: Annotated[int, Query(ge=0)] = 0,
-    limit: Annotated[int, Query(ge=0, le=100)] = 50,
+    limit: Annotated[int, Query(ge=0, le=1000)] = 10,
+    sort: Annotated[
+        rest_models.SortString | None,
+        Query(
+            description="A comma-separated list of FileUpload field names defining"
+            + " the sort order, where field names prefixed with '-' indicate"
+            + " descending order (e.g. 'alias,-decrypted_size')."
+            + " Defaults to sorting by alias in ascending order."
+        ),
+    ] = None,
 ) -> rest_models.BoxUploadsPage:
     """Retrieve a paginated list of FileUploads for a FileUploadBox.
 
@@ -341,7 +350,10 @@ async def get_box_uploads(
 
     try:
         file_uploads, total_count = await upload_controller.get_box_file_info(
-            box_id=box_id, skip=skip, limit=limit
+            box_id=box_id,
+            skip=skip,
+            limit=limit,
+            sort=sort.split(",") if sort else ["alias"],
         )
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1167,7 +1167,9 @@ class UploadController(UploadControllerPort):
         The `sort` parameter is a list of FileUpload field names defining the sort
         order, where a "-" prefix indicates descending order. Field names are
         assumed to be validated by the caller. If `sort` is None, results are
-        sorted by alias in ascending order.
+        sorted by alias in ascending order. If `sort` does not reference the alias
+        field, alias (ascending) is appended as a tiebreaker so the resulting
+        order is stable.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.
@@ -1175,6 +1177,8 @@ class UploadController(UploadControllerPort):
         """
         if sort is None:
             sort = ["alias"]
+        elif all(spec.removeprefix("-") != "alias" for spec in sort):
+            sort = [*sort, "alias"]
 
         try:
             _ = await self._file_upload_box_dao.get_by_id(box_id)

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1155,14 +1155,27 @@ class UploadController(UploadControllerPort):
         log.info("Archived box with ID %s", box_id)
 
     async def get_box_file_info(
-        self, *, box_id: UUID4, skip: int = 0, limit: int | None = None
+        self,
+        *,
+        box_id: UUID4,
+        skip: int = 0,
+        limit: int | None = None,
+        sort: list[str] | None = None,
     ) -> tuple[list[FileUpload], int]:
-        """Return a page of FileUploads for a FileUploadBox, sorted by alias.
+        """Return a page of FileUploads for a FileUploadBox.
+
+        The `sort` parameter is a list of FileUpload field names defining the sort
+        order, where a "-" prefix indicates descending order. Field names are
+        assumed to be validated by the caller. If `sort` is None, results are
+        sorted by alias in ascending order.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.
         - `BoxNotFoundError` if the FileUploadBox isn't found in the DB.
         """
+        if sort is None:
+            sort = ["alias"]
+
         try:
             _ = await self._file_upload_box_dao.get_by_id(box_id)
         except ResourceNotFoundError as err:
@@ -1175,7 +1188,7 @@ class UploadController(UploadControllerPort):
                 mapping={"box_id": box_id},
                 skip=skip,
                 limit=limit,
-                sort=["alias"],
+                sort=sort,
             )
         except ValueError as err:
             raise self.PaginationError() from err

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -459,9 +459,19 @@ class UploadControllerPort(ABC):
 
     @abstractmethod
     async def get_box_file_info(
-        self, *, box_id: UUID4, skip: int = 0, limit: int | None = None
+        self,
+        *,
+        box_id: UUID4,
+        skip: int = 0,
+        limit: int | None = None,
+        sort: list[str] | None = None,
     ) -> tuple[list[FileUpload], int]:
-        """Return a page of FileUploads for a FileUploadBox, sorted by alias.
+        """Return a page of FileUploads for a FileUploadBox.
+
+        The `sort` parameter is a list of FileUpload field names defining the sort
+        order, where a "-" prefix indicates descending order. Field names are
+        assumed to be validated by the caller. If `sort` is None, results are
+        sorted by alias in ascending order.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -471,7 +471,9 @@ class UploadControllerPort(ABC):
         The `sort` parameter is a list of FileUpload field names defining the sort
         order, where a "-" prefix indicates descending order. Field names are
         assumed to be validated by the caller. If `sort` is None, results are
-        sorted by alias in ascending order.
+        sorted by alias in ascending order. If `sort` does not reference the alias
+        field, alias (ascending) is appended as a tiebreaker so the resulting
+        order is stable.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -205,7 +205,7 @@ async def test_get_box_uploads_response_format(
     file_upload_b.alias = "test1.vcf"
     file_upload_b.box_id = TEST_BOX_ID
 
-    # Test with default parameters (no skip/limit in query string)
+    # Test with default parameters (no skip/limit/sort in query string)
     core_mock.get_box_file_info.return_value = ([file_upload_a, file_upload_b], 5)
     response = await rest_client.get(url, headers=token_header)
     assert response.status_code == 200
@@ -215,7 +215,7 @@ async def test_get_box_uploads_response_format(
     assert body["items"][0]["alias"] == "test0.bam"
     assert body["items"][1]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=50
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=None
     )
 
     # Test with skip and limit parameters explicitly set
@@ -228,7 +228,27 @@ async def test_get_box_uploads_response_format(
     assert body["total_count"] == 5
     assert len(body["items"]) == 1
     assert body["items"][0]["alias"] == "test1.vcf"
-    core_mock.get_box_file_info.assert_awaited_with(box_id=TEST_BOX_ID, skip=3, limit=1)
+    core_mock.get_box_file_info.assert_awaited_with(
+        box_id=TEST_BOX_ID, skip=3, limit=1, sort=None
+    )
+
+    # Test that the comma-separated sort parameter is forwarded as a list
+    core_mock.get_box_file_info.return_value = ([file_upload_b, file_upload_a], 5)
+    response = await rest_client.get(
+        url, params={"sort": "-alias,state"}, headers=token_header
+    )
+    assert response.status_code == 200
+    core_mock.get_box_file_info.assert_awaited_with(
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["-alias", "state"]
+    )
+
+    # An empty sort parameter is treated the same as omitting it
+    core_mock.get_box_file_info.return_value = ([file_upload_a, file_upload_b], 5)
+    response = await rest_client.get(url, params={"sort": ""}, headers=token_header)
+    assert response.status_code == 200
+    core_mock.get_box_file_info.assert_awaited_with(
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=None
+    )
 
     # skip beyond all results  controller returns empty page but preserves total_count
     core_mock.get_box_file_info.return_value = ([], 5)
@@ -254,12 +274,25 @@ async def test_get_box_uploads_invalid_params(
     response = await rest_client.get(url, params={"skip": -1}, headers=token_header)
     assert response.status_code == 422
 
-    # limit must be <= 100
-    response = await rest_client.get(url, params={"limit": 101}, headers=token_header)
+    # limit must be <= 1000
+    response = await rest_client.get(url, params={"limit": 1001}, headers=token_header)
     assert response.status_code == 422
 
     # limit must also be >=0
     response = await rest_client.get(url, params={"limit": -1}, headers=token_header)
+    assert response.status_code == 422
+
+    # sort specs must reference FileUpload fields (modulo a leading '-')
+    response = await rest_client.get(
+        url, params={"sort": "alias,-bogus,fake"}, headers=token_header
+    )
+    assert response.status_code == 422
+    assert "bogus, fake" in response.text
+
+    # bracketed values are not valid syntax
+    response = await rest_client.get(
+        url, params={"sort": "[alias,state]"}, headers=token_header
+    )
     assert response.status_code == 422
 
 

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -215,7 +215,7 @@ async def test_get_box_uploads_response_format(
     assert body["items"][0]["alias"] == "test0.bam"
     assert body["items"][1]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=10, sort=None
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"]
     )
 
     # Test with skip and limit parameters explicitly set
@@ -229,7 +229,7 @@ async def test_get_box_uploads_response_format(
     assert len(body["items"]) == 1
     assert body["items"][0]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=3, limit=1, sort=None
+        box_id=TEST_BOX_ID, skip=3, limit=1, sort=["alias"]
     )
 
     # Test that the comma-separated sort parameter is forwarded as a list
@@ -247,7 +247,7 @@ async def test_get_box_uploads_response_format(
     response = await rest_client.get(url, params={"sort": ""}, headers=token_header)
     assert response.status_code == 200
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=10, sort=None
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"]
     )
 
     # skip beyond all results  controller returns empty page but preserves total_count

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -19,6 +19,7 @@ import logging
 from asyncio import sleep
 from contextlib import nullcontext
 from datetime import timedelta
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -420,6 +421,22 @@ async def test_get_box_uploads(rig: JointRig):
     )
     assert total_count == 3
     assert [r.alias for r in file_uploads] == ["file2", "file1", "file0"]
+
+    # When the sort spec doesn't reference alias, it should be appended. If it is
+    #  included, then it shouldn't be appended.
+    with patch.object(
+        rig.file_upload_dao, "find_all", wraps=rig.file_upload_dao.find_all
+    ) as find_all_spy:
+        await controller.get_box_file_info(box_id=box_id, sort=["-state"])
+        assert find_all_spy.call_args.kwargs["sort"] == ["-state", "alias"]
+        await controller.get_box_file_info(
+            box_id=box_id, sort=["-state", "-alias", "decrypted_size"]
+        )
+        assert find_all_spy.call_args.kwargs["sort"] == [
+            "-state",
+            "-alias",
+            "decrypted_size",
+        ]
 
     # Verify the other box returns only its own files
     other_uploads, other_total = await controller.get_box_file_info(box_id=other_box_id)

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -407,12 +407,19 @@ async def test_get_box_uploads(rig: JointRig):
     # Create a third, empty box
     empty_box_id = await rig.create_default_box()
 
-    # Get the file uploads for the first box - should be sorted by alias
+    # Get the file uploads for the first box - should be sorted by alias by default
     file_uploads, total_count = await controller.get_box_file_info(box_id=box_id)
     assert len(file_uploads) == 3
     assert total_count == 3
     assert [r.alias for r in file_uploads] == ["file0", "file1", "file2"]
     assert all(r.id in file_ids for r in file_uploads)
+
+    # Get the file uploads sorted by alias in descending order
+    file_uploads, total_count = await controller.get_box_file_info(
+        box_id=box_id, sort=["-alias"]
+    )
+    assert total_count == 3
+    assert [r.alias for r in file_uploads] == ["file2", "file1", "file0"]
 
     # Verify the other box returns only its own files
     other_uploads, other_total = await controller.get_box_file_info(box_id=other_box_id)


### PR DESCRIPTION
This is a follow-up PR for the recent pagination implementation. We add a `sort` parameter that expects a list of field names as a comma-delimited string. A validator checks each specified field name against the list of valid fields from the model. If not specified, then the default is to sort by `alias` ascending.