### PR TITLE
UCS: Optional checksums (GSI-2492)

### DIFF
--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -1063,6 +1063,19 @@ paths:
             order. If 'alias' is not referenced, it is appended as an ascending tiebreaker
             to guarantee a stable order.
           title: Sort
+      - description: If True, include the part checksum lists (encrypted_parts_md5
+          and encrypted_parts_sha256) in the returned FileUploads. They are omitted
+          by default as they can be very large.
+        in: query
+        name: with_checksums
+        required: false
+        schema:
+          default: false
+          description: If True, include the part checksum lists (encrypted_parts_md5
+            and encrypted_parts_sha256) in the returned FileUploads. They are omitted
+            by default as they can be very large.
+          title: With Checksums
+          type: boolean
       responses:
         '200':
           content:

--- a/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
+++ b/services/ucs/src/ucs/adapters/inbound/fastapi_/routes.py
@@ -342,6 +342,14 @@ async def get_box_uploads(  # noqa: PLR0913
             + " tiebreaker to guarantee a stable order."
         ),
     ] = None,
+    with_checksums: Annotated[
+        bool,
+        Query(
+            description="If True, include the part checksum lists"
+            + " (encrypted_parts_md5 and encrypted_parts_sha256) in the returned"
+            + " FileUploads. They are omitted by default as they can be very large."
+        ),
+    ] = False,
 ) -> rest_models.BoxUploadsPage:
     """Retrieve a paginated list of FileUploads for a FileUploadBox.
 
@@ -356,6 +364,7 @@ async def get_box_uploads(  # noqa: PLR0913
             skip=skip,
             limit=limit,
             sort=sort.split(",") if sort else ["alias"],
+            with_checksums=with_checksums,
         )
     except UploadControllerPort.BoxNotFoundError as error:
         raise http_exceptions.HttpBoxNotFoundError(box_id=box_id) from error

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1161,6 +1161,7 @@ class UploadController(UploadControllerPort):
         skip: int = 0,
         limit: int | None = None,
         sort: list[str] | None = None,
+        with_checksums: bool = False,
     ) -> tuple[list[FileUpload], int]:
         """Return a page of FileUploads for a FileUploadBox.
 
@@ -1170,6 +1171,9 @@ class UploadController(UploadControllerPort):
         sorted by alias in ascending order. If `sort` does not reference the alias
         field, alias (ascending) is appended as a tiebreaker so the resulting
         order is stable.
+
+        The flag `with_checksums` determines whether the part checksum lists
+        (`encrypted_parts_md5` and `encrypted_parts_sha256`) are populated.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.
@@ -1197,7 +1201,16 @@ class UploadController(UploadControllerPort):
         except ValueError as err:
             raise self.PaginationError() from err
 
-        file_uploads = [x async for x in find_result]
+        if with_checksums:
+            # TODO: Use `.to_list()` once newer hexkit is pulled in
+            file_uploads = [x async for x in find_result]
+        else:
+            file_uploads = [
+                x.model_copy(
+                    update={"encrypted_parts_md5": None, "encrypted_parts_sha256": None}
+                )
+                async for x in find_result
+            ]
         total_count = await find_result.total_count()
         return file_uploads, total_count
 

--- a/services/ucs/src/ucs/ports/inbound/controller.py
+++ b/services/ucs/src/ucs/ports/inbound/controller.py
@@ -465,6 +465,7 @@ class UploadControllerPort(ABC):
         skip: int = 0,
         limit: int | None = None,
         sort: list[str] | None = None,
+        with_checksums: bool = False,
     ) -> tuple[list[FileUpload], int]:
         """Return a page of FileUploads for a FileUploadBox.
 
@@ -474,6 +475,9 @@ class UploadControllerPort(ABC):
         sorted by alias in ascending order. If `sort` does not reference the alias
         field, alias (ascending) is appended as a tiebreaker so the resulting
         order is stable.
+
+        The flag `with_checksums` determines whether the part checksum lists
+        (`encrypted_parts_md5` and `encrypted_parts_sha256`) are populated.
 
         Raises:
         - `PaginationError` if skip and/or limit are invalid.

--- a/services/ucs/tests_ucs/unit/test_api.py
+++ b/services/ucs/tests_ucs/unit/test_api.py
@@ -215,7 +215,7 @@ async def test_get_box_uploads_response_format(
     assert body["items"][0]["alias"] == "test0.bam"
     assert body["items"][1]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"]
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"], with_checksums=False
     )
 
     # Test with skip and limit parameters explicitly set
@@ -229,7 +229,7 @@ async def test_get_box_uploads_response_format(
     assert len(body["items"]) == 1
     assert body["items"][0]["alias"] == "test1.vcf"
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=3, limit=1, sort=["alias"]
+        box_id=TEST_BOX_ID, skip=3, limit=1, sort=["alias"], with_checksums=False
     )
 
     # Test that the comma-separated sort parameter is forwarded as a list
@@ -239,7 +239,11 @@ async def test_get_box_uploads_response_format(
     )
     assert response.status_code == 200
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["-alias", "state"]
+        box_id=TEST_BOX_ID,
+        skip=0,
+        limit=10,
+        sort=["-alias", "state"],
+        with_checksums=False,
     )
 
     # An empty sort parameter is treated the same as omitting it
@@ -247,7 +251,17 @@ async def test_get_box_uploads_response_format(
     response = await rest_client.get(url, params={"sort": ""}, headers=token_header)
     assert response.status_code == 200
     core_mock.get_box_file_info.assert_awaited_with(
-        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"]
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"], with_checksums=False
+    )
+
+    # The with_checksums query parameter is forwarded to the controller
+    core_mock.get_box_file_info.return_value = ([file_upload_a, file_upload_b], 5)
+    response = await rest_client.get(
+        url, params={"with_checksums": True}, headers=token_header
+    )
+    assert response.status_code == 200
+    core_mock.get_box_file_info.assert_awaited_with(
+        box_id=TEST_BOX_ID, skip=0, limit=10, sort=["alias"], with_checksums=True
     )
 
     # skip beyond all results  controller returns empty page but preserves total_count

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -415,6 +415,18 @@ async def test_get_box_uploads(rig: JointRig):
     assert [r.alias for r in file_uploads] == ["file0", "file1", "file2"]
     assert all(r.id in file_ids for r in file_uploads)
 
+    # The part checksum lists should be stripped by default
+    assert all(r.encrypted_parts_md5 is None for r in file_uploads)
+    assert all(r.encrypted_parts_sha256 is None for r in file_uploads)
+
+    # The part checksum lists should be included when with_checksums is True,
+    #  and stripping them must not have modified the stored data
+    file_uploads, _ = await controller.get_box_file_info(
+        box_id=box_id, with_checksums=True
+    )
+    assert all(r.encrypted_parts_md5 == ["abc123"] for r in file_uploads)
+    assert all(r.encrypted_parts_sha256 == ["def456"] for r in file_uploads)
+
     # Get the file uploads sorted by alias in descending order
     file_uploads, total_count = await controller.get_box_file_info(
         box_id=box_id, sort=["-alias"]


### PR DESCRIPTION
This adds a `with_checksums` parameter to the `GET /boxes/{box_id}/uploads` endpoint. By default it is set to `False`, which is a breaking change. Since UCS version `15.0.0` is already on deck and unreleased, this is fine. The point of this change is to reduce the amount of data transferred to the frontend (the checksum lists can constitute a non-trivial amount of data, especially at higher part counts and file counts). This does _not_, however, prevent the data from being pulled back from MongoDB because of the limitations imposed by our DAO solution (mostly just a technical footnote).

There is a corresponding PR for the RS [here](https://github.com/ghga-de/ghga-registry-service/pull/22).