### PR TITLE
More gracefully handle cleanup errors

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "16.1.0"
+version = "16.1.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fsb"
-version = "16.1.0"
+version = "16.1.1"
 description = "File Services Backend - monorepo housing file services"
 dependencies = [
     "typer >= 0.25",

--- a/services/dcs/README.md
+++ b/services/dcs/README.md
@@ -43,13 +43,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:10.2.0
+docker pull ghga/download-controller-service:10.2.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:10.2.0 .
+docker build -t ghga/download-controller-service:10.2.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -57,7 +57,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:10.2.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:10.2.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/dcs/openapi.yaml
+++ b/services/dcs/openapi.yaml
@@ -211,7 +211,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 10.2.0
+  version: 10.2.1
 openapi: 3.1.0
 paths:
   /health:

--- a/services/dcs/pyproject.toml
+++ b/services/dcs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dcs"
-version = "10.2.0"
+version = "10.2.1"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 readme = "README.md"
 authors = [

--- a/services/dcs/src/dcs/core/bucket_cleanup.py
+++ b/services/dcs/src/dcs/core/bucket_cleanup.py
@@ -28,7 +28,7 @@ from hexkit.utils import now_utc_ms_prec
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-from dcs.core.errors import StorageAliasNotConfiguredError
+from dcs.core.errors import StorageAliasNotConfiguredError, StorageUnavailableError
 from dcs.ports.inbound.bucket_cleanup import BucketCleanerPort
 from dcs.ports.outbound.dao import DrsObjectDaoPort
 
@@ -108,10 +108,18 @@ class DownloadBucketCleaner(BucketCleanerPort):
         )
 
         # filter to get all files in download bucket that should be removed
-        object_ids = [
-            uuid.UUID(x)
-            for x in await object_storage.list_all_object_ids(bucket_id=bucket_id)
-        ]
+        try:
+            raw_object_ids = await object_storage.list_all_object_ids(
+                bucket_id=bucket_id
+            )
+        except Exception as error:
+            # If the first call to S3 fails, assume there's a persistent issue and skip the bucket
+            log.warning(
+                StorageUnavailableError(alias=storage_alias, reason=str(error)),
+                exc_info=True,
+            )
+            return
+        object_ids = [uuid.UUID(x) for x in raw_object_ids]
         log.debug(
             f"Retrieved list of deletion candidates for storage '{storage_alias}'"
         )
@@ -152,3 +160,11 @@ class DownloadBucketCleaner(BucketCleanerPort):
                         reason=str(error),
                     )
                     log.error(cleanup_error)
+                except Exception as error:
+                    # Assume connection errors here are transient and just log them
+                    cleanup_error = self.CleanupError(
+                        object_id=object_id,
+                        storage_alias=storage_alias,
+                        reason=str(error),
+                    )
+                    log.warning(cleanup_error, exc_info=True)

--- a/services/dcs/src/dcs/core/errors.py
+++ b/services/dcs/src/dcs/core/errors.py
@@ -25,3 +25,14 @@ class StorageAliasNotConfiguredError(RuntimeError):
             + "Check íf your multi node configuration contains a corresponding entry."
         )
         super().__init__(message)
+
+
+class StorageUnavailableError(RuntimeError):
+    """Raised when the object storage for a given alias could not be reached."""
+
+    def __init__(self, *, alias: str, reason: str):
+        message = (
+            f"Could not reach the object storage for alias {alias}: {reason}\n"
+            + "Skipping download bucket cleanup for this storage."
+        )
+        super().__init__(message)

--- a/services/dcs/src/dcs/core/errors.py
+++ b/services/dcs/src/dcs/core/errors.py
@@ -22,7 +22,7 @@ class StorageAliasNotConfiguredError(RuntimeError):
     def __init__(self, *, alias: str):
         message = (
             f"Could not find a storage configuration for alias {alias}.\n"
-            + "Check íf your multi node configuration contains a corresponding entry."
+            + "Check if your multi node configuration contains a corresponding entry."
         )
         super().__init__(message)
 

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -504,18 +504,21 @@ async def test_bucket_cleanup_continues_with_remaining_aliases(
         cleanup_fixture.config.object_storages[unreachable_alias],
     )
 
-    object_storages = cleanup_fixture.bucket_cleaner._object_storages
-    real_for_alias = object_storages.for_alias
     connection_error = SimulatedConnectionError(
         'Could not connect to the endpoint URL: "https://localhost:1"'
     )
+    real_list = S3ObjectStorage.list_all_object_ids
+    listed_buckets = 0
 
-    def failing_for_alias(alias: str):
-        if alias == unreachable_alias:
+    async def failing_first_list(self, *, bucket_id: str):
+        """Fail the listing for the first alias only, then behave normally."""
+        nonlocal listed_buckets
+        listed_buckets += 1
+        if listed_buckets == 1:
             raise connection_error
-        return real_for_alias(alias)
+        return await real_list(self, bucket_id=bucket_id)
 
-    monkeypatch.setattr(object_storages, "for_alias", failing_for_alias)
+    monkeypatch.setattr(S3ObjectStorage, "list_all_object_ids", failing_first_list)
 
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="dcs.core.bucket_cleanup"):
@@ -529,6 +532,9 @@ async def test_bucket_cleanup_continues_with_remaining_aliases(
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 1
     assert expected_warning in warnings[0].getMessage()
+
+    # The second alias was reached despite the first one being skipped
+    assert listed_buckets == 2
 
     expired_object = await cleanup_fixture.mongodb_dao.get_by_id(
         cleanup_fixture.expired_file_id

--- a/services/dcs/tests_dcs/test_typical_journey.py
+++ b/services/dcs/tests_dcs/test_typical_journey.py
@@ -25,12 +25,13 @@ import pytest
 from fastapi import status
 from ghga_event_schemas.pydantic_ import FileDownloadServed, NonStagedFileRequested
 from hexkit.providers.akafka.testutils import ExpectedEvent
+from hexkit.providers.s3 import S3ObjectStorage
 from hexkit.providers.s3.testutils import FileObject, temp_file_object
 from hexkit.utils import now_utc_ms_prec
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from dcs.core import models
-from dcs.core.errors import StorageAliasNotConfiguredError
+from dcs.core.errors import StorageAliasNotConfiguredError, StorageUnavailableError
 from tests_dcs.fixtures.joint import CleanupFixture, PopulatedFixture
 from tests_dcs.fixtures.mock_api.app import router
 from tests_dcs.fixtures.utils import generate_work_order_token
@@ -362,4 +363,177 @@ async def test_bucket_cleanup_dangling_objects(cleanup_fixture: CleanupFixture, 
     assert await s3.storage.does_object_exist(
         bucket_id=bucket_id,
         object_id=str(cached_object_id),
+    )
+
+
+class SimulatedConnectionError(Exception):
+    """Stand-in for the connection failures the S3 client raises.
+
+    Those derive from `Exception` rather than from `ObjectStorageProtocolError`, so
+    they pass straight through hexkit's error translation - which is precisely the
+    case the cleanup job has to survive.
+    """
+
+
+CONNECTION_ERRORS = [
+    SimulatedConnectionError(
+        'Could not connect to the endpoint URL: "https://localhost:1"'
+    ),
+    SimulatedConnectionError(
+        "SSL validation failed for https://localhost:1 certificate verify failed"
+    ),
+]
+CONNECTION_ERROR_IDS = ["endpoint_unreachable", "invalid_ssl"]
+
+
+@pytest.mark.parametrize(
+    "connection_error", CONNECTION_ERRORS, ids=CONNECTION_ERROR_IDS
+)
+async def test_bucket_cleanup_skips_unreachable_storage(
+    cleanup_fixture: CleanupFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+    connection_error: Exception,
+):
+    """Test that a failed connection while listing the bucket contents skips the
+    storage alias with a warning instead of crashing the cleanup job.
+    """
+
+    async def failing_list(*args, **kwargs):
+        raise connection_error
+
+    monkeypatch.setattr(S3ObjectStorage, "list_all_object_ids", failing_list)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dcs.core.bucket_cleanup"):
+        await cleanup_fixture.bucket_cleaner.cleanup_download_buckets(
+            object_storages_config=cleanup_fixture.config
+        )
+
+    expected_warning = str(
+        StorageUnavailableError(
+            alias=cleanup_fixture.endpoint_aliases.valid_node,
+            reason=str(connection_error),
+        )
+    )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert expected_warning in warnings[0].getMessage()
+
+    # Nothing was removed, since the bucket contents were never listed
+    expired_object = await cleanup_fixture.mongodb_dao.get_by_id(
+        cleanup_fixture.expired_file_id
+    )
+    assert await cleanup_fixture.s3.storage.does_object_exist(
+        bucket_id=cleanup_fixture.bucket_id,
+        object_id=str(expired_object.object_id),
+    )
+
+
+@pytest.mark.parametrize(
+    "connection_error", CONNECTION_ERRORS, ids=CONNECTION_ERROR_IDS
+)
+async def test_bucket_cleanup_continues_after_deletion_failure(
+    cleanup_fixture: CleanupFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+    connection_error: Exception,
+):
+    """Test that a failed connection while deleting an object is logged as a warning
+    and does not stop the remaining deletion candidates from being attempted.
+
+    The bucket was reachable a moment earlier, so the failure is treated as potentially
+    transient rather than as a reason to abandon the storage alias.
+    """
+    # Backdate the second object as well, so there are two deletion candidates
+    cached_object = await cleanup_fixture.mongodb_dao.get_by_id(
+        cleanup_fixture.cached_file_id
+    )
+    cached_object.last_accessed = now_utc_ms_prec() - timedelta(
+        days=cleanup_fixture.config.download_bucket_cache_timeout + 1
+    )
+    await cleanup_fixture.mongodb_dao.update(cached_object)
+
+    call_count = 0
+
+    async def failing_delete(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise connection_error
+
+    monkeypatch.setattr(S3ObjectStorage, "delete_object", failing_delete)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dcs.core.bucket_cleanup"):
+        await cleanup_fixture.bucket_cleaner.cleanup_download_buckets(
+            object_storages_config=cleanup_fixture.config
+        )
+
+    # Both candidates were attempted despite the first failure
+    assert call_count == 2
+
+    expired_object = await cleanup_fixture.mongodb_dao.get_by_id(
+        cleanup_fixture.expired_file_id
+    )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    for object_id in (cached_object.object_id, expired_object.object_id):
+        expected_warning = str(
+            cleanup_fixture.bucket_cleaner.CleanupError(
+                object_id=object_id,
+                storage_alias=cleanup_fixture.endpoint_aliases.valid_node,
+                reason=str(connection_error),
+            )
+        )
+        assert any(expected_warning in record.getMessage() for record in warnings)
+
+
+async def test_bucket_cleanup_continues_with_remaining_aliases(
+    cleanup_fixture: CleanupFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+):
+    """Test that skipping an unreachable storage alias does not stop the cleanup job
+    from processing the remaining configured aliases.
+    """
+    unreachable_alias = cleanup_fixture.endpoint_aliases.valid_node
+    second_alias = f"{unreachable_alias}_2"
+    monkeypatch.setitem(
+        cleanup_fixture.config.object_storages,
+        second_alias,
+        cleanup_fixture.config.object_storages[unreachable_alias],
+    )
+
+    object_storages = cleanup_fixture.bucket_cleaner._object_storages
+    real_for_alias = object_storages.for_alias
+    connection_error = SimulatedConnectionError(
+        'Could not connect to the endpoint URL: "https://localhost:1"'
+    )
+
+    def failing_for_alias(alias: str):
+        if alias == unreachable_alias:
+            raise connection_error
+        return real_for_alias(alias)
+
+    monkeypatch.setattr(object_storages, "for_alias", failing_for_alias)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dcs.core.bucket_cleanup"):
+        await cleanup_fixture.bucket_cleaner.cleanup_download_buckets(
+            object_storages_config=cleanup_fixture.config
+        )
+
+    expected_warning = str(
+        StorageUnavailableError(alias=unreachable_alias, reason=str(connection_error))
+    )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert expected_warning in warnings[0].getMessage()
+
+    expired_object = await cleanup_fixture.mongodb_dao.get_by_id(
+        cleanup_fixture.expired_file_id
+    )
+    assert not await cleanup_fixture.s3.storage.does_object_exist(
+        bucket_id=cleanup_fixture.bucket_id,
+        object_id=str(expired_object.object_id),
     )

--- a/services/ucs/README.md
+++ b/services/ucs/README.md
@@ -15,13 +15,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:15.1.0
+docker pull ghga/upload-controller-service:15.1.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:15.1.0 .
+docker build -t ghga/upload-controller-service:15.1.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -29,7 +29,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:15.1.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:15.1.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/services/ucs/openapi.yaml
+++ b/services/ucs/openapi.yaml
@@ -818,7 +818,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 15.1.0
+  version: 15.1.1
 openapi: 3.1.0
 paths:
   /boxes:

--- a/services/ucs/pyproject.toml
+++ b/services/ucs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ucs"
-version = "15.1.0"
+version = "15.1.1"
 description = "Upload Controller Service - manages uploads to an S3 inbox bucket."
 readme = "README.md"
 authors = [

--- a/services/ucs/src/ucs/adapters/outbound/s3.py
+++ b/services/ucs/src/ucs/adapters/outbound/s3.py
@@ -456,21 +456,21 @@ class S3Client(S3ClientPort):
         Raises:
             `UnknownStorageAliasError` if the storage alias is not known.
             `BucketNotFoundError` if the configured bucket does not exist in S3.
+            `S3OperationError` if S3 returns any other unexpected error.
         """
         bucket_id, object_storage = self._get_bucket_and_storage(storage_alias)
         extra: dict[str, Any] = {"storage_alias": storage_alias, "bucket_id": bucket_id}
-        try:
+        with handle_bucket_and_general_s3_errors(
+            op_name="list_all_object_ids", bucket_id=bucket_id, extra=extra
+        ):
             object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
-        except ObjectStorageProtocol.BucketNotFoundError as err:
-            error = S3ClientPort.BucketNotFoundError(bucket_id=bucket_id)
-            log.error(error, extra=extra)
-            raise error from err
 
         orphaned_object_ids = set(object_ids) - known_object_ids
 
         # Return early if no orphaned objects
         if not orphaned_object_ids:
             log.info("Did not detect any orphaned objects in the bucket %s.", bucket_id)
+            return
 
         # Deleting an already-gone object succeeds silently, so it counts as deleted.
         deleted_ids = []

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1455,12 +1455,15 @@ class UploadController(UploadControllerPort):
     async def _cancel_stale_file_upload(
         self, *, upload: FileUpload, storage_alias: str
     ) -> None:
-        """Abort the S3 multipart upload and mark the FileUpload as 'cancelled'."""
+        """Abort the S3 multipart upload and mark the FileUpload as 'cancelled'.
+
+        S3 errors are logged instead of raised so cleanup can continue with the
+        remaining stale uploads. Anything left behind is picked up by the next round.
+        """
         try:
             await self._remove_incomplete_file_upload(file_upload=upload)
         except Exception:
-            # If there's a problem aborting the stale upload, log it but otherwise go on
-            log.error(
+            log.warning(
                 "Failed to abort S3 upload for stale file %s in alias '%s'.",
                 upload.id,
                 storage_alias,
@@ -1482,7 +1485,11 @@ class UploadController(UploadControllerPort):
         storage_alias: str,
         orphaned_s3_uploads: dict[str, str],
     ) -> None:
-        """Abort S3 multipart uploads that have no corresponding FileUpload record."""
+        """Abort S3 multipart uploads that have no corresponding FileUpload record.
+
+        Errors are logged instead of raised so cleanup can continue with the remaining
+        orphaned uploads. Anything left behind is picked up by the next cleanup round.
+        """
         for s3_upload_id, object_id in orphaned_s3_uploads.items():
             try:
                 await self._s3_client.abort_multipart_upload(
@@ -1491,11 +1498,12 @@ class UploadController(UploadControllerPort):
                     s3_upload_id=s3_upload_id,
                 )
             except Exception:
-                log.exception(
+                log.warning(
                     "Failed to abort orphaned S3 upload %s (object %s) for alias '%s'.",
                     s3_upload_id,
                     object_id,
                     storage_alias,
+                    exc_info=True,
                 )
 
     async def _cleanup_stale_uploads_for_alias(

--- a/services/ucs/src/ucs/core/controller.py
+++ b/services/ucs/src/ucs/core/controller.py
@@ -1539,14 +1539,19 @@ class UploadController(UploadControllerPort):
             )
         except S3ClientPort.UnknownStorageAliasError:
             log.error(
-                "Unknown storage alias '%s' during stale upload cleanup.", storage_alias
+                "Unknown storage alias '%s' during stale upload cleanup. Skipping it.",
+                storage_alias,
             )
-            raise
+            return
         except Exception:
-            log.error(
-                "Failed to list S3 multipart uploads for alias '%s'.", storage_alias
+            # Assume S3 connection issues are persistent here and skip the alias
+            log.warning(
+                "Skipping stale upload cleanup for alias '%s': failed to list S3"
+                + " multipart uploads.",
+                storage_alias,
+                exc_info=True,
             )
-            raise
+            return
 
         # Find truly orphaned S3 uploads (object_id not matching any known init FileUpload)
         orphaned_s3_uploads = {
@@ -1568,6 +1573,14 @@ class UploadController(UploadControllerPort):
         # Get a set of all object_ids from init_and_inbox_uploads. Cast to str because
         #  S3Client does a set diff on the string object IDs returned by S3
         known_object_ids = {str(x.object_id) for x in init_and_inbox_uploads}
-        await self._s3_client.cleanup_orphaned_objects(
-            storage_alias=storage_alias, known_object_ids=known_object_ids
-        )
+        try:
+            await self._s3_client.cleanup_orphaned_objects(
+                storage_alias=storage_alias, known_object_ids=known_object_ids
+            )
+        except Exception:
+            # Treat all unhandled exceptions as potentially transient here and just log
+            log.warning(
+                "Could not clean up orphaned objects for alias '%s'.",
+                storage_alias,
+                exc_info=True,
+            )

--- a/services/ucs/tests_ucs/unit/test_controller.py
+++ b/services/ucs/tests_ucs/unit/test_controller.py
@@ -2095,6 +2095,165 @@ async def test_orphaned_abort_failure_does_not_stop_cleanup(
     assert call_count == 2
 
 
+class SimulatedConnectionError(Exception):
+    """Stand-in for the connection failures the S3 client raises.
+
+    Those derive from `Exception` rather than from `ObjectStorageProtocolError`, so
+    they pass straight through hexkit's error translation - which is precisely the
+    case the cleanup job has to survive.
+    """
+
+
+@pytest.mark.parametrize(
+    "connection_error",
+    [
+        SimulatedConnectionError(
+            'Could not connect to the endpoint URL: "https://localhost:1"'
+        ),
+        SimulatedConnectionError(
+            "SSL validation failed for https://localhost:1 certificate verify failed"
+        ),
+    ],
+    ids=["endpoint_unreachable", "invalid_ssl"],
+)
+async def test_cleanup_skips_alias_when_s3_connection_fails(
+    rig: JointRig,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    connection_error: Exception,
+):
+    """Test that a failed connection on the first S3 call skips the storage alias with
+    a warning instead of crashing the cleanup job.
+    """
+
+    async def failing_list(**kwargs):
+        raise connection_error
+
+    orphan_cleanup_calls = 0
+
+    async def counting_orphan_cleanup(**kwargs):
+        nonlocal orphan_cleanup_calls
+        orphan_cleanup_calls += 1
+
+    monkeypatch.setattr(rig.s3_client, "list_all_multipart_uploads", failing_list)
+    monkeypatch.setattr(
+        rig.s3_client, "cleanup_orphaned_objects", counting_orphan_cleanup
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="ucs.core.controller"):
+        await rig.controller.cleanup_stale_uploads()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "Skipping stale upload cleanup for alias 'test'" in warnings[0].getMessage()
+
+    # The alias was abandoned before any further S3 work was attempted
+    assert orphan_cleanup_calls == 0
+
+
+async def test_cleanup_continues_with_remaining_aliases(
+    rig: JointRig, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that skipping an unreachable storage alias does not stop the cleanup job
+    from processing the remaining configured aliases.
+    """
+    monkeypatch.setitem(
+        rig.config.object_storages, "test2", rig.config.object_storages["test"]
+    )
+
+    async def failing_for_first_alias(*, storage_alias: str):
+        if storage_alias == "test":
+            raise SimulatedConnectionError(
+                'Could not connect to the endpoint URL: "https://localhost:1"'
+            )
+        return {}
+
+    cleaned_aliases: list[str] = []
+
+    async def record_orphan_cleanup(*, storage_alias: str, known_object_ids: set[str]):
+        cleaned_aliases.append(storage_alias)
+
+    monkeypatch.setattr(
+        rig.s3_client, "list_all_multipart_uploads", failing_for_first_alias
+    )
+    monkeypatch.setattr(
+        rig.s3_client, "cleanup_orphaned_objects", record_orphan_cleanup
+    )
+
+    await rig.controller.cleanup_stale_uploads()
+
+    assert cleaned_aliases == ["test2"]
+
+
+async def test_cleanup_skips_unknown_storage_alias(
+    rig: JointRig, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Test that a storage alias unknown to the S3 client is skipped rather than
+    aborting cleanup for the remaining aliases.
+    """
+    monkeypatch.setitem(
+        rig.config.object_storages, "test2", rig.config.object_storages["test"]
+    )
+
+    async def failing_for_first_alias(*, storage_alias: str):
+        if storage_alias == "test":
+            raise rig.s3_client.UnknownStorageAliasError(storage_alias=storage_alias)
+        return {}
+
+    cleaned_aliases: list[str] = []
+
+    async def record_orphan_cleanup(*, storage_alias: str, known_object_ids: set[str]):
+        cleaned_aliases.append(storage_alias)
+
+    monkeypatch.setattr(
+        rig.s3_client, "list_all_multipart_uploads", failing_for_first_alias
+    )
+    monkeypatch.setattr(
+        rig.s3_client, "cleanup_orphaned_objects", record_orphan_cleanup
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="ucs.core.controller"):
+        await rig.controller.cleanup_stale_uploads()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert "Unknown storage alias 'test'" in errors[0].getMessage()
+    assert cleaned_aliases == ["test2"]
+
+
+async def test_cleanup_tolerates_orphaned_object_cleanup_failure(
+    rig: JointRig, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Test that a connection failure while removing orphaned objects is logged as a
+    warning instead of crashing the cleanup job.
+
+    This happens after the alias has already been reached successfully, so it is
+    treated as potentially transient rather than as a reason to skip the alias.
+    """
+
+    async def failing_orphan_cleanup(**kwargs):
+        raise SimulatedConnectionError(
+            "SSL validation failed for https://localhost:1 certificate verify failed"
+        )
+
+    monkeypatch.setattr(
+        rig.s3_client, "cleanup_orphaned_objects", failing_orphan_cleanup
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="ucs.core.controller"):
+        await rig.controller.cleanup_stale_uploads()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert (
+        "Could not clean up orphaned objects for alias 'test'"
+        in warnings[0].getMessage()
+    )
+
+
 async def test_refresh_activity_warns_and_recreates_when_missing(rig: JointRig):
     """Test that _refresh_upload_activity logs a warning and recreates the entry
     when the activity record is unexpectedly absent during a part URL request.


### PR DESCRIPTION
This PR changes the cleanup behavior for both the DCS and UCS to the following:

- Previously unhandled exceptions around S3 calls should no longer crash the cleanup job
- For the firsts S3 operation, the exception is assumed to be persistent and just logs and skips the alias
- Any additional S3 operations just log and skip the current object, if applicable 